### PR TITLE
fix: bridge join links use server public address + mobile play layout (v1.4.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,19 @@
-# DiceFrame v1.4.0
+# DiceFrame v1.4.1
 
 ## 中文
 
-本版本改善了分享页面的多语言体验，并为世界书增加分类浏览。
+本版本修复了机器人桥接的玩家入口链接和移动端游玩页布局问题。
 
-### 改进
+### 修复
 
-- 分享链接会根据浏览器语言自动选择中文或英文。
-- 角色创建页和玩家游玩页新增语言切换入口。
-- 世界书按 NPC、地点、阵营、物品、事件、谜题和其他类型分类展示。
-- 世界书分类支持数量统计和快速筛选。
-- 补充浏览器语言检测与响应式布局自动测试。
+- 机器人在群聊中给出的玩家入口链接现在优先使用 DiceFrame 服务端配置的公开地址，避免暴露内部地址；插件显式配置的公开地址仍具有最高优先级。
+- 修复移动端游玩页在内容较长时被截断、无法滚动的问题；时间线和操作区在小屏上可正常显示与滚动。
 
 ## English
 
-This release improves multilingual shared pages and adds categorized lorebook browsing.
+This release fixes bot bridge join links and the mobile play page layout.
 
-### Improvements
+### Fixes
 
-- Shared links now follow the browser language automatically.
-- Character creation and player views now include a language switch.
-- Lorebook entries are grouped by NPCs, locations, factions, items, events, puzzles, and other types.
-- Lorebook categories include counts and quick filtering.
-- Added browser-language and responsive-layout test coverage.
+- Join links returned by the bot in group chat now prefer the public address configured on the DiceFrame server, instead of leaking the internal address. An explicit plugin override still takes the highest priority.
+- Fixed the mobile play page clipping long content and blocking scrolling; the timeline and controls now display and scroll correctly on small screens.

--- a/frontend-v2/src/styles.css
+++ b/frontend-v2/src/styles.css
@@ -480,8 +480,8 @@ body.light .update-dialog-notes{background:rgba(255,247,223,.7);border-color:rgb
 }
 .scene-strip p{display:none}
 @media(max-width:800px){
-  .play-page{height:100dvh;min-height:0;display:flex;flex-direction:column;overflow:hidden}
-  .workspace .play-page{height:calc(100dvh - 44px)}
+  .play-page{min-height:100dvh;display:flex;flex-direction:column;overflow:visible}
+  .workspace .play-page{min-height:calc(100dvh - 44px)}
   .play-hud{flex:0 0 auto;grid-template-columns:minmax(0,1fr) auto;grid-template-areas:"title tools";align-items:center;min-height:52px;padding:5px 7px;gap:6px}
   .play-hud .play-hud-main{align-items:center;min-width:0}
   .play-eyebrow,.play-hud-stats{display:none}
@@ -490,9 +490,8 @@ body.light .update-dialog-notes{background:rgba(255,247,223,.7);border-color:rgb
   .play-toolbar{min-width:0;max-width:48vw;justify-content:flex-end;flex-wrap:nowrap;overflow-x:auto;scrollbar-width:none}
   .play-toolbar::-webkit-scrollbar{display:none}
   .play-toolbar button{flex:0 0 auto;min-height:30px;padding:0 7px;font-size:12px}
-  .play-layout,.play-layout.no-console,.play-layout.collapsed,.play-layout.collapsed.no-console{flex:1 1 auto;min-height:0;height:auto;overflow-y:auto}
-  .play-main{height:calc(100dvh - 52px);min-height:0;padding:6px;gap:5px;overflow:hidden}
-  .workspace .play-main{height:calc(100dvh - 96px)}
+  .play-layout,.play-layout.no-console,.play-layout.collapsed,.play-layout.collapsed.no-console{flex:none;min-height:0;height:auto;overflow:visible;grid-template-columns:1fr;grid-template-areas:"main" "sidebar" "controls"}
+  .play-main{height:auto;min-height:72vh;padding:6px;gap:5px;overflow:visible}
   .scene-strip{display:flex;align-items:center;padding:5px 7px;gap:7px;min-height:34px}
   .scene-title{flex:1 1 auto;min-width:0}
   .scene-label,.scene-strip p{display:none}
@@ -500,7 +499,7 @@ body.light .update-dialog-notes{background:rgba(255,247,223,.7);border-color:rgb
   .scene-chips{flex:0 1 auto;max-width:58%;justify-content:flex-end;flex-wrap:nowrap;overflow:hidden}
   .scene-chips span{flex:0 1 auto;min-width:0;max-width:112px;padding:2px 6px;font-size:11px}
   .scene-chips span:nth-child(n+3){display:none}
-  .timeline-wrap{flex:1 1 0;min-height:0}
+  .timeline-wrap{flex:1 1 0;min-height:320px}
   .composer{flex:0 0 auto;padding:6px}
   .composer-row{grid-template-columns:minmax(0,1fr) 72px;gap:6px}
   .composer-row button{width:auto;padding:0 6px}

--- a/src/bots/bridge_core/service.py
+++ b/src/bots/bridge_core/service.py
@@ -169,13 +169,13 @@ class DiceFrameBridgeService:
         _group, game_key, actor = self._require_actor_or_group_gm(message)
         detail = await self.client.detail(game_key, actor)
         world = str(detail.get("world_name") or game_key)
-        link = self._join_link(game_key)
+        link = await self._join_link(game_key)
         return f"DiceFrame《{world}》玩家入口：{link}" if link else f"DiceFrame《{world}》已绑定。"
 
     async def _character_guide(self, message: BridgeInput, *, ai: bool) -> str:
         _group, game_key, actor = self._require_actor_or_group_gm(message)
         data = await self.client.characters(game_key, actor)
-        link = self._join_link(game_key)
+        link = await self._join_link(game_key)
         lines = character_creation_lines(data, command_prefix=self.config.command_prefix)
         if ai:
             lines.insert(0, "AI 辅助车卡请在网页入口选择 AI 生成，或按群聊适配器的私聊向导继续。")
@@ -203,7 +203,7 @@ class DiceFrameBridgeService:
         player = next((item for item in data.get("players", []) if isinstance(item, dict) and str(item.get("user_id") or "") == actor), None)
         if not player:
             return "未找到当前角色。"
-        return self._format_status(player, group)
+        return await self._format_status(player, group)
 
     async def _recap(self, message: BridgeInput) -> str:
         _group, game_key, actor = self._require_actor_or_group_gm(message)
@@ -324,7 +324,7 @@ class DiceFrameBridgeService:
             and (actor == gm_uid or str(item.get("uid") or "") == actor)
         ]
 
-    def _format_status(self, player: dict[str, Any], group: dict[str, Any]) -> str:
+    async def _format_status(self, player: dict[str, Any], group: dict[str, Any]) -> str:
         name = str(player.get("character_name") or player.get("user_id") or "角色")
         sheet = player.get("character_sheet") if isinstance(player.get("character_sheet"), dict) else {}
         lines = [f"{name} 状态"]
@@ -343,7 +343,7 @@ class DiceFrameBridgeService:
         status = sheet.get("status")
         if status:
             lines.append(f"状态：{status}")
-        link = self._join_link(str(group.get("game_key") or ""), str(player.get("user_id") or ""))
+        link = await self._join_link(str(group.get("game_key") or ""), str(player.get("user_id") or ""))
         if link:
             lines.append(f"网页入口：{link}")
         return "\n".join(lines)
@@ -399,9 +399,13 @@ class DiceFrameBridgeService:
         allowed = {item.strip().lower() for item in self.config.advance_allowed_users if item.strip()}
         return user.lower() in allowed
 
-    def _join_link(self, game_key: str, user: str = "") -> str:
-        base = self.config.public_base_url or self.client.base_url
-        return build_join_link(base, game_key, user) if base and game_key else ""
+    async def _join_link(self, game_key: str, user: str = "") -> str:
+        if not game_key:
+            return ""
+        override = str(self.config.public_base_url or "").strip()
+        if override:
+            return build_join_link(override, game_key, user)
+        return await self.client.build_join_link(game_key, user)
 
     def _split_reply(self, reply: str) -> list[str]:
         max_chars = max(200, int(self.config.max_reply_chars or 1800))

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/tests/test_bridge_links.py
+++ b/tests/test_bridge_links.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from src.bots.bridge_core.client import DiceFrameClient, build_join_link
+from src.bots.bridge_core.service import BridgeServiceConfig, DiceFrameBridgeService
+from src.bots.bridge_core.store import JsonBridgeStore
+
+
+def test_build_join_link_uses_hash_router_and_keeps_reverse_proxy_path():
+    assert build_join_link("https://table.example/trpg", "web|game|bot") == (
+        "https://table.example/trpg/#/join?game=web%7Cgame%7Cbot&share=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_prefers_diceframe_public_address(monkeypatch):
+    client = DiceFrameClient("http://diceframe:18000", "token")
+
+    async def public_config():
+        return {"public_base_url": "https://table.example/trpg"}
+
+    monkeypatch.setattr(client, "public_config", public_config)
+    assert await client.build_join_link("web|game|bot") == (
+        "https://table.example/trpg/#/join?game=web%7Cgame%7Cbot&share=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_explicit_public_address_overrides_server_setting(tmp_path: Path):
+    class Client:
+        base_url = "http://diceframe:18000"
+
+        async def build_join_link(self, game_key: str, user: str = "") -> str:
+            return build_join_link("https://server-setting.example", game_key, user)
+
+    service = DiceFrameBridgeService(
+        Client(),  # type: ignore[arg-type]
+        JsonBridgeStore(tmp_path / "bridge.json"),
+        BridgeServiceConfig(public_base_url="https://plugin-override.example"),
+    )
+    assert await service._join_link("web|game|bot", "player-1") == (
+        "https://plugin-override.example/#/join?game=web%7Cgame%7Cbot&share=1&user=player-1"
+    )


### PR DESCRIPTION
## Summary
- bridge_core: `_join_link` / `_format_status` 改为 async；join link 优先用插件 `public_base_url` 覆盖，否则委托 `client.build_join_link`，使用服务端配置的公开地址。
- frontend: 修复移动端游玩页内容被截断、无法滚动；改用 min-height + overflow visible。
- bump 版本 1.4.0 -> 1.4.1，更新 Release Notes。

## Root cause / Reason
- 机器人在群聊给出的玩家入口链接原来用 `client.base_url`（内部地址，如 `http://diceframe:18000`），暴露内部地址且玩家无法从外网访问；服务端实际配置了公开地址（public_config）但 bridge 没去取。
- 移动端游玩页用固定 100dvh 高度 + overflow hidden，内容长时被截断。

## Impact
- 群聊 join link 改用服务端公开地址；插件显式 `public_base_url` 覆盖仍最高优先，行为不变（向后兼容）。
- 移动端游玩页可正常滚动，时间线/操作区不再被裁剪；桌面端布局不受影响。

## Verification
- 后端 pytest：426 passed（含新增 `tests/test_bridge_links.py` 3 个）
- 前端：vue-tsc typecheck 通过；Vitest 11 passed；vite build 通过
- `build_release.py --allow-dirty`：`DiceFrame-v1.4.1-windows.zip` 构建成功，validate_zip 通过（390 文件，无禁止路径/秘密）
- 公开边界：`.codex` / `.claude` / `AGENTS.md` / `CLAUDE.md` / `data` / `.env` 均未暂存
- 提交身份白名单通过

## Release plan
合并到 main 后打 `v1.4.1` tag，由 GitHub Actions 自动构建 Release（windows zip + portable zip）并发布 Docker（GHCR + Docker Hub 的 `:1.4.1` 与 `:latest`）。