### PR TITLE
docs: emphasize README intro and reposition as engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 <h1 align="center">DiceFrame</h1>
 
-[English](README_EN.md) | 中文
+<p align="center"><a href="README_EN.md">English</a> | 中文</p>
 
 ![DiceFrame WebUI preview](docs/assets/diceframe-readme-hero.png)
 
-DiceFrame 是一个可以自己部署的 AI 跑团桌面，支持 DND/COC/自定义规则，多人 WebUI。
+DiceFrame 是一个可以自己部署的 **ai跑团引擎**，支持 **DND/COC/自定义规则**，**多人 WebUI**。
 
 它把 Web 桌面、角色卡、世界书、骰子、状态变动、剧情日志和群聊 Bot 接到同一个游戏状态里。玩家用自然语言说“我想做什么”，系统负责把这句话交给 GM 模型、处理骰子与状态变化，并把结果同步给网页或群聊里的其他玩家。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,11 +4,11 @@
 
 <h1 align="center">DiceFrame</h1>
 
-English | [中文](README.md)
+<p align="center">English | <a href="README.md">中文</a></p>
 
 ![DiceFrame Web UI preview](docs/assets/diceframe-readme-hero.png)
 
-DiceFrame is a self-hostable AI tabletop RPG platform supporting DND/COC/custom rules, with multiplayer WebUI.
+DiceFrame is a self-hostable **AI tabletop RPG engine** supporting **DND/COC/custom rules**, with **multiplayer WebUI**.
 
 It brings the Web UI, character sheets, lorebooks, dice checks, state changes, campaign logs, and optional chat-bot play into one shared game state. Players describe what they want to do in natural language; DiceFrame passes those actions to a GM model, handles dice and state tags, then syncs the result back to the browser.
 


### PR DESCRIPTION
## 改动

开场两段的呈现与定位微调（README.md / README_EN.md）。

- 一句话 pitch 加粗关键词，便于扫读。
- 语言切换行 `[English](README_EN.md) | 中文` 居中，与 logo/标题对齐。
- 产品定位从“AI 跑团桌面 / AI tabletop RPG platform”改为“ai跑团引擎 / AI tabletop RPG engine”。

## 原因

- 开场 pitch 关键词不突出，扫读时差异化卖点不显眼。
- 语言切换行左对齐与居中的 logo/标题不协调。
- 统一以“引擎”定位产品。

## 影响

仅公开 README 文案与排版，不改代码、版本号或行为。

## 验证

- `git diff --check` 干净。
- 公开边界与秘密扫描通过（仅 README.md / README_EN.md）。
