### PR TITLE
chore: prepare v1.6.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,51 +1,35 @@
-# DiceFrame Release Notes
-
-## Unreleased
-
-### 中文
-
-- Windows 便携版新增旁路安装、健康检查、观察期和失败自动回滚；源码发布包使用可恢复的事务式替换。
-- Docker、NAS 和 Git 开发目录只显示适合各自环境的更新提示，不在运行环境中直接覆盖程序。
-- 创建冒险时新增模型 API 配置引导，后端会在写入世界、角色和存档前检查配置。
-- 购买物品改为由付款玩家确认；余额足够并确认后才扣款和发放物品。
-- 修复部分模型输出把内部状态标签显示在叙事正文中的问题。
-
-### English
-
-- Added side-by-side portable updates with health checking, probation, and automatic rollback. Extracted source releases use recoverable transactional replacement.
-- Docker, NAS, and Git development installations now receive environment-specific update guidance without in-place replacement.
-- Added model-API guidance on Create and a backend preflight before writing world, character, or save data.
-- Item purchases now require confirmation from the paying player; funds and items move only after confirmation and a sufficient-balance check.
-- Fixed internal model state tags appearing in player-facing narration.
+# DiceFrame v1.6.0
 
 ## 中文
 
-### v1.6.0
+本版本完善了应用更新流程，并加入叙事逐字显示、购买确认和模型配置引导。
 
-本版本新增应用内更新检查与叙事逐字显示，升级与回合反馈都更顺手。
+### 新功能
 
-#### 新功能
+- **应用更新**：可以在设置页检查、下载并应用新版本。
+- **叙事逐字显示**：GM 叙述会逐步显示，无需等待整段生成完毕。
+- **模型配置引导**：创建冒险前如果还没有配置模型 API，页面会提示并直达设置页。
+- **购买确认**：购买物品前由付款玩家确认；余额足够并确认后才会扣款和发放物品，多人游戏同样适用。
 
-- **应用内更新**：在设置页"版本更新"中检查并下载新版本安装包。
-- **叙事逐字显示**：GM 叙述现在逐字呈现，无需等待整段生成完毕。
-- **叙事生成更流畅**：优化了长叙事的生成体验。
+### 优化与修复
 
-#### 修复
-
-- 修正部分情况下玩家看不到 GM 叙述内容的问题。
+- 优化长叙事的生成体验。
+- 修正部分情况下玩家看不到 GM 叙述的问题。
+- 修复模型内部状态标签偶尔显示在叙事正文中的问题。
 
 ## English
 
-### v1.6.0
+This release completes the application update flow and adds streaming narration, purchase confirmation, and model setup guidance.
 
-This release adds in-app update checks and token-by-token narration display.
+### New Features
 
-#### New Features
+- **Application updates**: Check, download, and apply new versions from Settings.
+- **Streaming narration**: GM narration appears progressively instead of waiting for the complete response.
+- **Model setup guidance**: Create shows a direct Settings link when the model API has not been configured.
+- **Purchase confirmation**: The paying player confirms before funds and items move, including in multiplayer games.
 
-- **In-app update**: Check and download new release packages from the "Version Update" panel in Settings.
-- **Streaming narration**: GM narration now appears token by token instead of waiting for the full paragraph.
-- **Smoother narration generation**: Improved the long-form narration experience.
+### Improvements and Fixes
 
-#### Fixes
-
-- Fixed an issue where players could not see GM narration in some cases.
+- Improved long-form narration generation.
+- Fixed cases where players could not see GM narration.
+- Fixed internal model state tags occasionally appearing in player-facing narration.


### PR DESCRIPTION
## What changed

- Finalize the bilingual v1.6.0 release notes.
- Combine the previously prepared narration and updater notes with the new purchase confirmation, model API guidance, and state-tag rendering fix.
- Remove internal update implementation details from the player-facing summary.

## Why

The application version on `main` is already 1.6.0, but the release notes still contain a separate `Unreleased` section and an older partial v1.6.0 draft. The tag workflow reads this file directly as the GitHub Release body, so it must be finalized before tagging.

## User impact

The GitHub Release page and in-app update log will show a concise, bilingual summary of v1.6.0.

## Validation

- Confirmed `src/version.py` is `1.6.0`.
- Confirmed no remote `v1.6.0` tag or GitHub Release exists.
- Confirmed Release and Docker workflows are triggered by `v*` tags.
- Built `DiceFrame-v1.6.0-windows.zip`.
- Audited the package for internal files, runtime data, local paths, and secret-like content.
- Checked the committed diff and noreply identity.
