### PR TITLE
release: v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 <p align="center"><a href="README_EN.md">English</a> | 中文</p>
 
-<p align="center"><a href="https://diceframe.com">官方网站</a></p>
-
 <p align="center">
   <a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a>
   <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a>
   <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a>
   <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a>
 </p>
+
+<p align="center"><a href="https://diceframe.com">官方网站</a></p>
 
 ![DiceFrame WebUI preview](docs/assets/diceframe-readme-hero.png)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,14 +6,14 @@
 
 <p align="center">English | <a href="README.md">中文</a></p>
 
-<p align="center"><a href="https://diceframe.com">Official Website</a></p>
-
 <p align="center">
   <a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a>
   <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a>
   <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a>
   <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a>
 </p>
+
+<p align="center"><a href="https://diceframe.com">Official Website</a></p>
 
 ![DiceFrame Web UI preview](docs/assets/diceframe-readme-hero.png)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
-# DiceFrame v1.6.1
+# DiceFrame v1.6.2
 
 ## 中文
+
+### 下载指南
+
+- **普通 Windows 用户**：下载 `DiceFrame-v1.6.2-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.6.2-windows.zip`。
+- `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 这个版本补齐了应用更新流程，也带来了更流畅的叙事显示、购买确认和模型配置引导。
 
@@ -13,13 +19,21 @@
 
 ### 优化与修复
 
+- 更新提示现在可直接前往设置页的版本更新区域。
 - 设置页只会提供适合当前安装方式的更新包，避免便携版和源码版混用。
 - 优化长篇叙事的生成和显示体验。
 - 修复部分情况下玩家看不到 GM 叙述的问题。
 - 修复模型内部状态标签偶尔出现在叙事正文中的问题。
 - 调整中英文用户手册的开头说明。
+- 调整 README 首页链接布局。
 
 ## English
+
+### Download Guide
+
+- **Most Windows users**: Download `DiceFrame-v1.6.2-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.6.2-windows.zip`.
+- `.sha256` files are used for update verification and do not need to be downloaded manually.
 
 This release completes the application update flow and adds smoother narration, purchase confirmation, and model setup guidance.
 
@@ -32,8 +46,10 @@ This release completes the application update flow and adds smoother narration, 
 
 ### Improvements and Fixes
 
+- Update notifications can now take users directly to the version update area in Settings.
 - Settings now offers only the update package that matches the current installation, preventing portable and source packages from being mixed.
 - Improved the generation and display of long-form narration.
 - Fixed cases where players could not see GM narration.
 - Fixed internal model state tags occasionally appearing in player-facing narration.
 - Refined the introduction in both user guides.
+- Adjusted the link layout at the top of the README.

--- a/frontend-v2/src/components/common/StartupUpdateCheck.vue
+++ b/frontend-v2/src/components/common/StartupUpdateCheck.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h, onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import type { DialogOptions } from 'naive-ui'
 import { errorMessage } from '@/api/client'
 import { useUpdateCheck } from '@/composables/useUpdateCheck'
@@ -8,6 +8,7 @@ import { getDialog } from '@/composables/useNaiveBridge'
 import { useLocale } from '@/composables/useLocale'
 
 const route = useRoute()
+const router = useRouter()
 const { checkForUpdates } = useUpdateCheck()
 const { t } = useLocale()
 // Show at most once per process; cross-version dedupe is handled below.
@@ -17,10 +18,6 @@ function shouldSkipCurrentRoute(): boolean {
   if (route.name === 'login' || route.name === 'join') return true
   if (route.name === 'play' && (route.query.user || route.query.share)) return true
   return false
-}
-
-function openReleaseUrl(url: string) {
-  if (url) window.open(url, '_blank', 'noopener')
 }
 
 // Show once per version so refreshes do not keep interrupting the user.
@@ -40,7 +37,7 @@ function markNotified(version: string) {
   }
 }
 
-function showUpdateDialog(version: string, body: string, url: string) {
+function showUpdateDialog(version: string, body: string) {
   const dialog = getDialog()
   const cfg: DialogOptions = {
     title: t('updateDialogTitle', { version }),
@@ -50,13 +47,16 @@ function showUpdateDialog(version: string, body: string, url: string) {
         ? h('pre', { class: 'update-dialog-notes' }, body)
         : null,
     ]),
-    positiveText: t('openReleasePage'),
+    positiveText: t('goToUpdateSettings'),
     negativeText: t('laterSay'),
     maskClosable: true,
     closeOnEsc: true,
     positiveButtonProps: { type: 'primary' },
     negativeButtonProps: { secondary: true },
-    onPositiveClick: () => openReleaseUrl(url),
+    onPositiveClick: () => router.push({
+      name: 'settings',
+      query: { section: 'about', focus: 'update' },
+    }),
   }
   dialog.info(cfg)
 }
@@ -73,7 +73,6 @@ async function checkOnce() {
       showUpdateDialog(
         version,
         String(result.latest.body || ''),
-        result.latest.html_url || result.release_url || result.releases_url || result.source_url || '',
       )
     }
   } catch (e: unknown) {

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch, type Component } from 'vue'
+import { computed, nextTick, onMounted, ref, watch, type Component } from 'vue'
+import { useRoute } from 'vue-router'
 import { NButton, NInput, NInputNumber, NSwitch, NTag, NIcon, NCollapse, NCollapseItem, NSpin, NProgress } from 'naive-ui'
 import {
   ServerOutline, CubeOutline, CloudDownloadOutline, ExtensionPuzzleOutline,
@@ -29,6 +30,7 @@ type SystemStatusItem = { label: string; value: string; detail: string; tone: St
 type SettingsSection = { id: SectionId; labelKey: MessageKey; icon: Component }
 
 const store = useSettingsStore()
+const route = useRoute()
 const toast = useToast()
 const { confirm } = useConfirm()
 const { updateInfo, updateChecking, checkForUpdates } = useUpdateCheck()
@@ -47,6 +49,23 @@ const sections: SettingsSection[] = [
   { id: 'advanced', labelKey: 'settingsSectionAdvanced', icon: OptionsOutline },
   { id: 'about', labelKey: 'settingsSectionAbout', icon: InformationCircleOutline },
 ]
+
+function queryValue(value: unknown): string {
+  return String(Array.isArray(value) ? (value[0] || '') : (value || ''))
+}
+
+function syncRouteTarget() {
+  const requestedSection = queryValue(route.query.section)
+  if (sections.some(item => item.id === requestedSection)) {
+    section.value = requestedSection as SectionId
+  }
+  if (queryValue(route.query.focus) === 'update') {
+    section.value = 'about'
+    void nextTick(() => {
+      document.getElementById('settings-update')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }
+}
 
 const testing = ref(false)
 const testResult = ref<TestResult | null>(null)
@@ -135,7 +154,12 @@ const systemStatusItems = computed<SystemStatusItem[]>(() => {
   ]
 })
 
-onMounted(() => { void store.load(); void refreshStatus() })
+onMounted(() => {
+  void store.load()
+  void refreshStatus()
+  syncRouteTarget()
+})
+watch(() => [route.query.section, route.query.focus], syncRouteTarget)
 watch(section, () => {
   const sc = document.querySelector('.n-layout-scroll-container') as HTMLElement | null
   sc?.scrollTo({ top: 0 })
@@ -568,7 +592,7 @@ function redownloadUpdatePackage() {
               <p>{{ t('issueFeedback') }}: <a href="https://github.com/diceframe/diceframe/issues" target="_blank" rel="noopener">{{ t('submitIssue') }}</a></p>
               <p>{{ t('qqGroup') }}: 1060613588</p>
             </section>
-            <section class="update-card" :aria-label="t('versionUpdate')">
+            <section id="settings-update" class="update-card" :aria-label="t('versionUpdate')">
               <div class="update-card-head">
                 <div>
                   <h4>{{ t('versionUpdate') }}</h4>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -660,6 +660,7 @@ export const en = {
   switchToDarkTheme: 'Switch to dark theme',
   updateDialogTitle: 'New version found {version}',
   updateDialogBody: 'DiceFrame {version} has been released. Upgrading before continuing is recommended.',
+  goToUpdateSettings: 'Update in Settings',
   laterSay: 'Later',
   newVersion: 'New version',
   chooseCharacterCard: 'Choose Character Card',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -660,6 +660,7 @@ export const zhCN = {
   switchToDarkTheme: '切换到深色主题',
   updateDialogTitle: '发现新版本 {version}',
   updateDialogBody: 'DiceFrame {version} 已发布，建议升级后再继续跑团。',
+  goToUpdateSettings: '前往设置更新',
   laterSay: '稍后说',
   newVersion: '新版本',
   chooseCharacterCard: '选择角色卡',

--- a/frontend-v2/tests/StartupUpdateCheck.test.ts
+++ b/frontend-v2/tests/StartupUpdateCheck.test.ts
@@ -1,0 +1,78 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { i18n } from '../src/i18n'
+import StartupUpdateCheck from '../src/components/common/StartupUpdateCheck.vue'
+
+const mocks = vi.hoisted(() => ({
+  checkForUpdates: vi.fn(),
+  info: vi.fn(),
+}))
+
+vi.mock('../src/composables/useUpdateCheck', () => ({
+  useUpdateCheck: () => ({
+    checkForUpdates: mocks.checkForUpdates,
+  }),
+}))
+
+vi.mock('../src/composables/useNaiveBridge', () => ({
+  getDialog: () => ({ info: mocks.info }),
+}))
+
+describe('StartupUpdateCheck', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => { store.set(key, String(value)) },
+      removeItem: (key: string) => { store.delete(key) },
+      clear: () => { store.clear() },
+    })
+    localStorage.clear()
+    mocks.checkForUpdates.mockReset()
+    mocks.info.mockReset()
+    i18n.global.locale.value = 'zh-CN'
+  })
+
+  it('opens the update area in Settings instead of the release page', async () => {
+    mocks.checkForUpdates.mockResolvedValue({
+      ok: true,
+      update_available: true,
+      latest: {
+        version: '1.6.2',
+        tag_name: 'v1.6.2',
+        body: '更新说明',
+        html_url: 'https://github.com/diceframe/diceframe/releases/tag/v1.6.2',
+      },
+    })
+    const emptyView = defineComponent({ template: '<div />' })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/overview', name: 'overview', component: emptyView },
+        { path: '/settings', name: 'settings', component: emptyView },
+      ],
+    })
+    await router.push({ name: 'overview' })
+    await router.isReady()
+
+    mount(StartupUpdateCheck, {
+      global: { plugins: [i18n, router] },
+    })
+    await flushPromises()
+
+    expect(mocks.info).toHaveBeenCalledOnce()
+    const dialog = mocks.info.mock.calls[0][0]
+    expect(dialog.positiveText).toBe('前往设置更新')
+
+    await dialog.onPositiveClick()
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('settings')
+    expect(router.currentRoute.value.query).toEqual({
+      section: 'about',
+      focus: 'update',
+    })
+  })
+})

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"


### PR DESCRIPTION
# DiceFrame v1.6.2

## 中文

### 下载指南

- **普通 Windows 用户**：下载 `DiceFrame-v1.6.2-windows-portable.zip`。
- **源码运行用户**：下载 `DiceFrame-v1.6.2-windows.zip`。
- `.sha256` 是更新校验文件，普通用户不需要手动下载。

这个版本补齐了应用更新流程，也带来了更流畅的叙事显示、购买确认和模型配置引导。

### 新功能

- **应用更新**：可以直接在设置页检查、下载并应用新版本。
- **叙事逐字显示**：GM 叙述会逐步显示，不用再等整段内容生成完。
- **模型配置引导**：创建冒险时如果还没有配置模型 API，页面会给出提示，并能直接前往设置页。
- **购买确认**：购买物品前会先交给付款玩家确认；余额足够并确认后，才会扣款和发放物品，多人游戏同样适用。

### 优化与修复

- 更新提示现在可直接前往设置页的版本更新区域。
- 设置页只会提供适合当前安装方式的更新包，避免便携版和源码版混用。
- 优化长篇叙事的生成和显示体验。
- 修复部分情况下玩家看不到 GM 叙述的问题。
- 修复模型内部状态标签偶尔出现在叙事正文中的问题。
- 调整中英文用户手册的开头说明。
- 调整 README 首页链接布局。

## English

### Download Guide

- **Most Windows users**: Download `DiceFrame-v1.6.2-windows-portable.zip`.
- **Source package users**: Download `DiceFrame-v1.6.2-windows.zip`.
- `.sha256` files are used for update verification and do not need to be downloaded manually.

This release completes the application update flow and adds smoother narration, purchase confirmation, and model setup guidance.

### New Features

- **Application updates**: Check, download, and apply new versions directly from Settings.
- **Streaming narration**: GM narration appears progressively instead of waiting for the complete response.
- **Model setup guidance**: When no model API is configured, the adventure creation page shows a prompt with a direct link to Settings.
- **Purchase confirmation**: The paying player confirms a purchase before funds are deducted and items are granted, including in multiplayer games.

### Improvements and Fixes

- Update notifications can now take users directly to the version update area in Settings.
- Settings now offers only the update package that matches the current installation, preventing portable and source packages from being mixed.
- Improved the generation and display of long-form narration.
- Fixed cases where players could not see GM narration.
- Fixed internal model state tags occasionally appearing in player-facing narration.
- Refined the introduction in both user guides.
- Adjusted the link layout at the top of the README.
