### PR TITLE
fix: restore new update action after prior completion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v1.7.0
+# DiceFrame v1.7.1
 
 ## 中文
 
@@ -23,8 +23,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.7.0-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.7.0-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.7.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.7.1-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -50,6 +50,6 @@ This release makes DiceFrame safer to share through port forwarding and complete
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.7.0-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.7.0-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.7.1-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.7.1-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/frontend-v2/src/composables/useUpdater.ts
+++ b/frontend-v2/src/composables/useUpdater.ts
@@ -14,6 +14,17 @@ const DOWNLOAD_STATES = new Set<UpdateStatusResponse['state']>(['downloading', '
 const RELOAD_DELAY_SECONDS = 5
 const isDownloading = computed(() => DOWNLOAD_STATES.has(updateStatus.value?.state || 'idle'))
 const isUpdateBusy = computed(() => ACTIVE_STATES.has(updateStatus.value?.state || 'idle'))
+
+export function updateStateForVersion(
+  status: Pick<UpdateStatusResponse, 'state' | 'version'> | null,
+  targetVersion?: string,
+): UpdateStatusResponse['state'] {
+  const normalize = (value?: string) => String(value || '').trim().replace(/^v/i, '')
+  const statusVersion = normalize(status?.version)
+  const target = normalize(targetVersion)
+  return statusVersion && target && statusVersion === target ? status?.state || 'idle' : 'idle'
+}
+
 const downloadPercent = computed(() => {
   const s = updateStatus.value
   if (!s || !s.total_bytes) return 0

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -11,7 +11,7 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
 import { useUpdateCheck } from '@/composables/useUpdateCheck'
-import { useUpdater } from '@/composables/useUpdater'
+import { updateStateForVersion, useUpdater } from '@/composables/useUpdater'
 import { useLocale } from '@/composables/useLocale'
 import { api, errorMessage } from '@/api/client'
 import type { MessageKey } from '@/i18n'
@@ -34,7 +34,7 @@ const route = useRoute()
 const toast = useToast()
 const { confirm } = useConfirm()
 const { updateInfo, updateChecking, checkForUpdates } = useUpdateCheck()
-const { updateStatus, reloadCountdown, isDownloading, isUpdateBusy, downloadPercent, startDownload, applyUpdate, refreshStatus } = useUpdater()
+const { updateStatus, reloadCountdown, downloadPercent, startDownload, applyUpdate, refreshStatus } = useUpdater()
 const { t } = useLocale()
 
 const section = ref<SectionId>('api')
@@ -93,6 +93,21 @@ const requiredUpdateKind = computed<UpdatePackageKind | null>(() => {
   const mode = updateStatus.value?.self_update.mode
   return mode === 'source' || mode === 'portable' ? mode : null
 })
+const latestUpdateVersion = computed(() => (
+  updateInfo.value?.latest?.version || updateInfo.value?.latest?.tag_name || ''
+))
+const displayedUpdateState = computed(() => updateStateForVersion(
+  updateStatus.value,
+  latestUpdateVersion.value,
+))
+const isDisplayedUpdateDownloading = computed(() => (
+  displayedUpdateState.value === 'downloading' || displayedUpdateState.value === 'verifying'
+))
+const isDisplayedUpdateBusy = computed(() => (
+  isDisplayedUpdateDownloading.value
+  || displayedUpdateState.value === 'applying'
+  || displayedUpdateState.value === 'restarting'
+))
 const updateTagType = computed<StatusTone>(() => {
   if (!updateInfo.value) return 'default'
   if (!updateInfo.value.ok) return 'error'
@@ -643,7 +658,7 @@ function redownloadUpdatePackage() {
                     : (updateStatus.self_update.hint || t('updateSelfUpdateUnsupported')) }}
                 </div>
                 <template v-else>
-                  <div v-if="updateStatus.state === 'staged'" class="update-staged">
+                  <div v-if="displayedUpdateState === 'staged'" class="update-staged">
                     <NTag type="success" size="small" round>{{ t('updateStaged') }}</NTag>
                     <span class="muted">{{ t('updateStagedHint') }}</span>
                     <div class="actions-row">
@@ -651,31 +666,31 @@ function redownloadUpdatePackage() {
                       <NButton v-if="requiredUpdateKind" @click="redownloadUpdatePackage">{{ t('redownloadUpdate') }}</NButton>
                     </div>
                   </div>
-                  <div v-else-if="updateStatus.state === 'failed'" class="error-text">
+                  <div v-else-if="displayedUpdateState === 'failed'" class="error-text">
                     {{ updateStatus.path ? t('updateApplyFailed') : t('updateDownloadFailed') }}: {{ updateStatus.error }}
                   </div>
-                  <div v-else-if="updateStatus.state === 'applying'" class="muted">
+                  <div v-else-if="displayedUpdateState === 'applying'" class="muted">
                     {{ t('updateApplying') }}
                   </div>
-                  <div v-else-if="updateStatus.state === 'restarting'" class="muted">
+                  <div v-else-if="displayedUpdateState === 'restarting'" class="muted">
                     {{ t('updateRestarting') }}
                   </div>
-                  <div v-else-if="updateStatus.state === 'done'" class="update-staged">
+                  <div v-else-if="displayedUpdateState === 'done'" class="update-staged">
                     <NTag type="success" size="small" round>{{ t('updateApplied') }}</NTag>
                     <span v-if="reloadCountdown !== null" class="muted">{{ t('updateReloadCountdown', { seconds: reloadCountdown }) }}</span>
                     <span v-else-if="updateStatus.restart_needed" class="muted">{{ t('updateRestartNeeded') }}</span>
                   </div>
-                  <div v-else-if="updateStatus.state === 'rolled-back'" class="error-text">
+                  <div v-else-if="displayedUpdateState === 'rolled-back'" class="error-text">
                     {{ t('updateRolledBack') }}: {{ updateStatus.error }}
                   </div>
-                  <div v-else-if="isDownloading" class="update-progress">
+                  <div v-else-if="isDisplayedUpdateDownloading" class="update-progress">
                     <div class="update-progress-head">
                       <span>{{ t('updateDownloading') }}</span>
                       <span class="muted">{{ updateStatus.mirror_used || '-' }}</span>
                     </div>
                     <NProgress :percentage="downloadPercent" />
                   </div>
-                  <div v-if="!isUpdateBusy && !['staged', 'done'].includes(updateStatus.state)" class="actions-row">
+                  <div v-if="!isDisplayedUpdateBusy && !['staged', 'done'].includes(displayedUpdateState)" class="actions-row">
                     <NButton v-if="requiredUpdateKind" @click="downloadUpdatePackage(requiredUpdateKind)">
                       {{ requiredUpdateKind === 'portable' ? t('downloadUpdatePortable') : t('downloadUpdateSource') }}
                     </NButton>

--- a/frontend-v2/tests/useUpdater.test.ts
+++ b/frontend-v2/tests/useUpdater.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useUpdater } from '../src/composables/useUpdater'
+import { updateStateForVersion, useUpdater } from '../src/composables/useUpdater'
 
 const mocks = vi.hoisted(() => ({
   api: vi.fn(),
@@ -43,5 +43,11 @@ describe('useUpdater', () => {
     expect(updater.reloadCountdown.value).toBe(4)
     vi.clearAllTimers()
     vi.useRealTimers()
+  })
+
+  it('does not treat a previous completed version as the newly available update', () => {
+    expect(updateStateForVersion({ state: 'done', version: '1.6.3' }, 'v1.7.0')).toBe('idle')
+    expect(updateStateForVersion({ state: 'done', version: 'v1.7.0' }, '1.7.0')).toBe('done')
+    expect(updateStateForVersion(null, '1.7.0')).toBe('idle')
   })
 })

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"


### PR DESCRIPTION
## Summary

- ignore persisted updater terminal states when they belong to an older release
- show the correct download action when a newer version is detected
- preserve genuine staged, applying, restart, completion, rollback, and failure states for the currently detected release
- add a regression test for the stale `done` state
- prepare version 1.7.1 while retaining the v1.7.0 release notes

## Why

The updater persists its last result in `data/_updater/state.json`. After a successful update, a later version check could combine the newly available release with the previous release's `done` state. Settings then displayed “Update complete” and hid the download button.

## Impact

When a new release is available, only updater state carrying that same version is shown. Old completed, staged, or failed state no longer blocks the new download action. Source installs that have genuinely applied the current release still retain their restart guidance.

## Validation

- `python -m pytest -q` — 526 passed
- frontend typecheck — passed
- frontend Vitest — 20 passed
- frontend production build — passed
- desktop Playwright smoke tests — 5 passed
- API contract and text encoding audits — passed
- release builder tests — 2 passed
- v1.7.1 source ZIP content and secret scans — passed
