### PR TITLE
release: DiceFrame v1.7.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v1.7.2
+# DiceFrame v1.7.3
 
 ## 中文
 
@@ -23,8 +23,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.7.2-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.7.2-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.7.3-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.7.3-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -50,6 +50,6 @@ This release makes DiceFrame safer to share through port forwarding and complete
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.7.2-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.7.2-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.7.3-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.7.3-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/docs/USER_GUIDE_CN.md
+++ b/docs/USER_GUIDE_CN.md
@@ -63,6 +63,47 @@ GM 创建游戏后，可以复制邀请链接发给其他玩家。
 
 GM 可以在游戏页查看玩家状态。有人临时不在时，可以标记“暂离”；暂离玩家不会阻塞回合，剧情里默认跟随队伍，不主动做重大决定。回来后再恢复即可。
 
+## 外网联机
+
+如果玩家和 GM 不在同一个局域网，邀请链接还需要配合内网穿透、虚拟局域网或路由器端口映射工具使用。DiceFrame 不与下面提到的第三方服务存在合作关系，请根据价格、网络环境和隐私政策自行选择。
+
+第三方工具需要连接到 DiceFrame 的本地网页地址：
+
+```text
+Windows 便携版或源码运行：http://127.0.0.1:18000
+默认 Docker 部署：http://127.0.0.1:9876
+```
+
+如果你修改过 Web 端口，请填写实际能在本机浏览器中打开的地址。隧道程序和 DiceFrame 不在同一台设备或同一个 Docker 容器时，`127.0.0.1` 通常要改为 DiceFrame 所在设备的局域网地址、容器名或 Docker 网关地址。
+
+### SakuraFrp
+
+SakuraFrp 提供 Windows、macOS、Linux、OpenWrt 和 Docker 客户端，并有免费使用方案。具体安装、节点限制、域名和 HTTPS 配置以 [SakuraFrp Web 应用穿透指南](https://doc.natfrp.com/app/http.html) 为准。
+
+用 TCP 隧道连接 Windows 上的 DiceFrame 时，关键配置是：
+
+```text
+隧道类型：TCP
+本地 IP：127.0.0.1
+本地端口：18000
+```
+
+SakuraFrp 官方要求通过 TCP 隧道转发 HTTP 网页时选择非内地节点。分享前请确认最终地址能从手机流量或其他网络打开，并优先使用其 HTTPS、自动 HTTPS 或免费子域名能力。
+
+### Cloudflare Tunnel
+
+Cloudflare Tunnel 可在免费套餐中使用，通过主动建立的隧道把域名指向本地服务，不要求公网 IP，也不需要在路由器上开放入站端口。它更适合已经有域名、希望长期保留固定 HTTPS 地址的 GM。创建正式隧道后，把 Public Hostname 的服务地址指向 `http://127.0.0.1:18000`；Docker 默认部署则指向实际可访问的 `9876` 端口。具体步骤见 [Cloudflare Tunnel 官方文档](https://developers.cloudflare.com/tunnel/)。
+
+不要把无需账号、会生成随机 `trycloudflare.com` 地址的 Quick Tunnel 当作 DiceFrame 的正式联机方案。Cloudflare 官方说明 Quick Tunnel 不支持 Server-Sent Events，而 DiceFrame 用它实时同步剧情和游戏状态。
+
+### 对外分享前
+
+- 先在“设置 → 访问密码”设置一个不容易猜到的密码。
+- 优先分享 HTTPS 地址，避免通过明文 HTTP 传输访问密码和游戏内容。
+- 只映射 DiceFrame 的网页端口，不要同时暴露 NAS 管理页、数据库或 `data/` 目录。
+- 游戏结束后可以关闭隧道；第三方服务的账号、实名、流量和费用由该服务商负责。
+- DiceFrame 有基础访问限流，但不能替代专业的抗 DDoS 服务。
+
 ## 掷骰流程
 
 有些行动会直接叙事，有些行动需要检定。

--- a/frontend-v2/src/api/client.ts
+++ b/frontend-v2/src/api/client.ts
@@ -9,6 +9,7 @@ export function isNotFoundError(error: unknown): boolean {
 }
 
 function isPlayerShareLocation(): boolean {
+  if (location.hash.startsWith('#/join')) return true
   const q = new URLSearchParams(location.hash.split('?')[1] || '')
   return q.has('user') || q.get('share') === '1' || q.get('share') === 'true' || q.get('share') === 'yes'
 }
@@ -100,6 +101,20 @@ export async function validateAccessToken(value: string): Promise<void> {
 
 export function setAccessToken(value: string) { localStorage.setItem(tokenKey, value) }
 export function hasAccessToken(): boolean { return !!localStorage.getItem(tokenKey) }
+
+export type OwnerAccessStatus = 'allowed' | 'login-required' | 'unavailable'
+
+export async function checkOwnerAccess(): Promise<OwnerAccessStatus> {
+  try {
+    // Do not use apiUrl(): a player share query must never grant access to owner pages.
+    const response = await fetch('/api/me', { headers: authHeaders(undefined, false) })
+    if (response.status === 401) return 'login-required'
+    return response.ok ? 'allowed' : 'unavailable'
+  } catch {
+    // A temporary network failure should not trap local users on the login page.
+    return 'unavailable'
+  }
+}
 
 export async function gameEventSource(gameKey: string): Promise<EventSource> {
   const result = await api<{ ticket: string }>(`/games/${encodeURIComponent(gameKey)}/sse-ticket`, { method: 'POST' })

--- a/frontend-v2/src/components/common/StartupUpdateCheck.vue
+++ b/frontend-v2/src/components/common/StartupUpdateCheck.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { h, onMounted, watch } from 'vue'
+import { h, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { DialogOptions } from 'naive-ui'
+import type { DialogOptions, DialogReactive } from 'naive-ui'
 import { errorMessage } from '@/api/client'
 import { useUpdateCheck } from '@/composables/useUpdateCheck'
 import { getDialog } from '@/composables/useNaiveBridge'
@@ -13,6 +13,7 @@ const { checkForUpdates } = useUpdateCheck()
 const { t } = useLocale()
 // Show at most once per process; cross-version dedupe is handled below.
 let notified = false
+let activeDialog: DialogReactive | null = null
 
 function shouldSkipCurrentRoute(): boolean {
   if (route.name === 'login' || route.name === 'join') return true
@@ -58,11 +59,15 @@ function showUpdateDialog(version: string, body: string) {
       query: { section: 'about', focus: 'update' },
     }),
   }
-  dialog.info(cfg)
+  activeDialog = dialog.info(cfg)
 }
 
 async function checkOnce() {
-  if (shouldSkipCurrentRoute()) return
+  if (shouldSkipCurrentRoute()) {
+    activeDialog?.destroy()
+    activeDialog = null
+    return
+  }
   try {
     const result = await checkForUpdates()
     if (!notified && result?.ok && result.update_available && result.latest) {
@@ -83,6 +88,7 @@ async function checkOnce() {
 
 onMounted(checkOnce)
 watch(() => [route.name, route.query.user, route.query.share], checkOnce)
+onBeforeUnmount(() => activeDialog?.destroy())
 </script>
 
 <template></template>

--- a/frontend-v2/src/router/index.ts
+++ b/frontend-v2/src/router/index.ts
@@ -1,4 +1,12 @@
-﻿import { createRouter, createWebHashHistory, type RouteRecordRaw } from 'vue-router'
+import {
+  createRouter,
+  createWebHashHistory,
+  type LocationQuery,
+  type RouteLocationNormalized,
+  type RouteRecordName,
+  type RouteRecordRaw,
+} from 'vue-router'
+import { checkOwnerAccess, type OwnerAccessStatus } from '@/api/client'
 
 const routes: RouteRecordRaw[] = [
   { path: '/', redirect: { name: 'overview' } },
@@ -19,5 +27,30 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes,
 })
+
+type PublicRoute = {
+  name: RouteRecordName | null | undefined
+  query: LocationQuery
+}
+
+export function isPublicRoute(route: PublicRoute): boolean {
+  if (route.name === 'login' || route.name === 'join') return true
+  return route.name === 'play' && Boolean(route.query.user || route.query.share)
+}
+
+export async function requireOwnerAccess(
+  to: RouteLocationNormalized,
+  probe: () => Promise<OwnerAccessStatus> = checkOwnerAccess,
+) {
+  if (isPublicRoute(to)) return true
+  const status = await probe()
+  if (status !== 'login-required') return true
+  return {
+    name: 'login',
+    query: { redirect: `${location.pathname}#${to.fullPath}` },
+  }
+}
+
+router.beforeEach((to) => requireOwnerAccess(to))
 
 export default router

--- a/frontend-v2/tests/StartupUpdateCheck.test.ts
+++ b/frontend-v2/tests/StartupUpdateCheck.test.ts
@@ -8,6 +8,7 @@ import StartupUpdateCheck from '../src/components/common/StartupUpdateCheck.vue'
 const mocks = vi.hoisted(() => ({
   checkForUpdates: vi.fn(),
   info: vi.fn(),
+  destroy: vi.fn(),
 }))
 
 vi.mock('../src/composables/useUpdateCheck', () => ({
@@ -32,6 +33,8 @@ describe('StartupUpdateCheck', () => {
     localStorage.clear()
     mocks.checkForUpdates.mockReset()
     mocks.info.mockReset()
+    mocks.destroy.mockReset()
+    mocks.info.mockReturnValue({ destroy: mocks.destroy })
     i18n.global.locale.value = 'zh-CN'
   })
 
@@ -74,5 +77,39 @@ describe('StartupUpdateCheck', () => {
       section: 'about',
       focus: 'update',
     })
+  })
+
+  it('closes an existing update dialog after entering the login page', async () => {
+    mocks.checkForUpdates.mockResolvedValue({
+      ok: true,
+      update_available: true,
+      latest: {
+        version: '9.9.9',
+        tag_name: 'v9.9.9',
+        body: '更新说明',
+      },
+    })
+    const emptyView = defineComponent({ template: '<div />' })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/overview', name: 'overview', component: emptyView },
+        { path: '/login', name: 'login', component: emptyView },
+      ],
+    })
+    await router.push({ name: 'overview' })
+    await router.isReady()
+
+    mount(StartupUpdateCheck, {
+      global: { plugins: [i18n, router] },
+    })
+    await flushPromises()
+
+    expect(mocks.info).toHaveBeenCalledOnce()
+    await router.push({ name: 'login' })
+    await flushPromises()
+
+    expect(mocks.destroy).toHaveBeenCalledOnce()
+    expect(mocks.checkForUpdates).toHaveBeenCalledOnce()
   })
 })

--- a/frontend-v2/tests/routerAccess.test.ts
+++ b/frontend-v2/tests/routerAccess.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RouteLocationNormalized } from 'vue-router'
+import { isPublicRoute, requireOwnerAccess } from '../src/router'
+
+function route(
+  name: string,
+  fullPath: string,
+  query: Record<string, string> = {},
+): RouteLocationNormalized {
+  return { name, fullPath, query } as unknown as RouteLocationNormalized
+}
+
+describe('owner route access', () => {
+  it('redirects unauthenticated owner routes to login and preserves the destination', async () => {
+    const result = await requireOwnerAccess(
+      route('settings', '/settings?section=about'),
+      vi.fn().mockResolvedValue('login-required'),
+    )
+
+    expect(result).toEqual({
+      name: 'login',
+      query: { redirect: '/#/settings?section=about' },
+    })
+  })
+
+  it('allows owner routes when no password is configured or the owner is authenticated', async () => {
+    await expect(requireOwnerAccess(
+      route('settings', '/settings'),
+      vi.fn().mockResolvedValue('allowed'),
+    )).resolves.toBe(true)
+  })
+
+  it('keeps login, join, and player share routes public without probing owner access', async () => {
+    const probe = vi.fn()
+    const routes = [
+      route('login', '/login'),
+      route('join', '/join?game=demo', { game: 'demo' }),
+      route('play', '/play?game=demo&user=player', { game: 'demo', user: 'player' }),
+      route('play', '/play?game=demo&share=1', { game: 'demo', share: '1' }),
+    ]
+
+    for (const target of routes) {
+      expect(isPublicRoute(target)).toBe(true)
+      await expect(requireOwnerAccess(target, probe)).resolves.toBe(true)
+    }
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('does not mistake the owner play page for a public player link', () => {
+    expect(isPublicRoute(route('play', '/play?game=demo', { game: 'demo' }))).toBe(false)
+  })
+})

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"


### PR DESCRIPTION
## 改动\n\n- 为设置等管理页面加入登录守卫，未认证访问会返回登录页并保留原目标。\n- 登录、加入和玩家分享页面继续公开访问；登录页会关闭已经显示的更新弹窗。\n- 中文用户手册补充 SakuraFrp 与 Cloudflare Tunnel 外网联机说明。\n- 版本更新至 v1.7.3，沿用 v1.7.2 的玩家更新日志正文。\n\n## 原因与影响\n\n更新提示此前可以把未登录用户直接带到设置界面。后端写操作仍受保护，但管理界面本身不应在未认证状态下展示。修复后管理页在前端入口统一验证，玩家分享流程不受影响。\n\n## 验证\n\n- pytest：526 passed\n- 前端 typecheck：通过\n- Vitest：26 passed\n- 前端生产构建：通过\n- 独立端口浏览器验收：设置页登录重定向、更新弹窗清理、玩家分享页和加入页均通过\n- API 契约与文案审计：通过\n- v1.7.3 源码包生成及公开边界检查：通过