### PR TITLE
docs: keep GitHub badges on one row

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,7 @@
 
 <p align="center"><a href="README_EN.md">English</a> | 中文</p>
 
-<p align="center">
-  <a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a>
-  <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a>
-  <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a>
-  <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a>
-</p>
+<p align="center"><a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a> <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a> <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a> <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a></p>
 
 <p align="center"><a href="https://diceframe.com">官方网站</a></p>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,12 +6,7 @@
 
 <p align="center">English | <a href="README.md">中文</a></p>
 
-<p align="center">
-  <a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a>
-  <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a>
-  <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a>
-  <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a>
-</p>
+<p align="center"><a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a> <a href="https://github.com/diceframe/diceframe/forks"><img src="https://img.shields.io/github/forks/diceframe/diceframe?style=flat-square&logo=github&label=Forks" alt="GitHub Forks"></a> <a href="https://github.com/diceframe/diceframe/issues"><img src="https://img.shields.io/github/issues/diceframe/diceframe?style=flat-square&logo=github&label=Issues" alt="GitHub Issues"></a> <a href="https://github.com/diceframe/diceframe/pulls"><img src="https://img.shields.io/github/issues-pr/diceframe/diceframe?style=flat-square&logo=github&label=Pull%20Requests" alt="GitHub Pull Requests"></a></p>
 
 <p align="center"><a href="https://diceframe.com">Official Website</a></p>
 


### PR DESCRIPTION
## 改动\n\n- 将中文 README 的 Stars、Forks、Issues、Pull Requests 徽章写入同一条 HTML 行。\n- 英文 README 同步调整。\n- 官网链接继续单独显示在徽章下方。\n\n## 原因与影响\n\n避免 GitHub 将分行的徽章源码渲染为多条居中内容，保持四个入口横向排列。只影响 README 展示，不影响程序运行。\n\n## 验证\n\n- 中英文 README 各只有 1 条徽章行，每行包含 4 个徽章。\n- v1.7.3 发布包重新生成成功，并确认包内 README 保持同样结构。\n- Markdown diff check 与公开边界检查通过。