### PR TITLE
release: DiceFrame v1.7.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v1.7.3
+# DiceFrame v1.7.4
 
 ## 中文
 
@@ -23,8 +23,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.7.3-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.7.3-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.7.4-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.7.4-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -50,6 +50,6 @@ This release makes DiceFrame safer to share through port forwarding and complete
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.7.3-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.7.3-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.7.4-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.7.4-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/frontend-v2/src/features/admin/LogsView.vue
+++ b/frontend-v2/src/features/admin/LogsView.vue
@@ -168,7 +168,6 @@ const hasSystem = computed(() => statusChips.value.length || recentHealth.value.
       <button type="button" :class="{ active: tab === 'proclog' }" @click="tab = 'proclog'">{{ t('processingLog') }}</button>
     </div>
     <div class="log-toolbar">
-      <span>{{ t('logPageLoadHint') }}</span>
       <label>{{ t('perPage') }}
         <select :value="pageSize" @change="setPageSize(($event.target as HTMLSelectElement).value)">
           <option :value="10">{{ t('roundsCount', { count: 10 }) }}</option>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -896,7 +896,6 @@ export const en = {
   gmWhispers: 'GM Whispers',
   dialogueLog: 'Dialogue Log',
   processingLog: 'Processing Log',
-  logPageLoadHint: 'Only the current page is loaded by default so long campaigns do not overwhelm the page.',
   perPage: 'Per page',
   roundsCount: '{count} rounds',
   branchesCount: '{count} branches',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -897,7 +897,6 @@ export const zhCN = {
   gmWhispers: 'GM 悄悄话',
   dialogueLog: '对话日志',
   processingLog: '处理日志',
-  logPageLoadHint: '默认只加载当前页，避免长团日志一次性撑爆页面。',
   perPage: '每页',
   roundsCount: '{count} 轮',
   branchesCount: '{count} 分支',

--- a/src/commands/game_handler.py
+++ b/src/commands/game_handler.py
@@ -47,7 +47,7 @@ class GameHandler:
         prompts_dir: Path | None = None,
         rules_dir: Path | None = None,
         worlds_dir: Path | None = None,
-        narrative_max_tokens: int = 1536,
+        narrative_max_tokens: int = 2048,
         summary_max_tokens: int = 400,
         brief_max_tokens: int = 300,
         analysis_max_tokens: int = 512,

--- a/src/commands/round_llm.py
+++ b/src/commands/round_llm.py
@@ -11,7 +11,7 @@ from src.commands.tag_parser import parse_tag_state
 from src.engine.game_instance import GameInstance
 from src.engine.health import record_health_event
 from src.engine.language import is_english
-from src.llm.client import LENGTH_RETRY_FACTOR, LENGTH_RETRY_MAX_MULT, OutputTruncatedError
+from src.llm.client import OutputTruncatedError, length_retry_budgets
 from src.llm.parser import (
     find_protocol_suffix_start,
     normalize_tag_protocol,
@@ -188,6 +188,48 @@ async def append_multistep_analysis(
         return context
 
 
+async def _call_stream_with_length_retry(
+    llm_client: Any,
+    instance: GameInstance,
+    gm_prompt: str,
+    context: str,
+    narrative_max_tokens: int,
+    on_delta,
+    on_reset,
+):
+    """流式调用被截断时，按 1×、2×、4× 的预算独立重试。"""
+    budgets = length_retry_budgets(narrative_max_tokens)
+    for budget_index, current_max_tokens in enumerate(budgets):
+        filt = _NarrationDeltaFilter(on_delta)
+        try:
+            response = await llm_client.call_stream(
+                system_prompt=gm_prompt,
+                user_message=context,
+                temperature=0.7,
+                max_tokens=current_max_tokens,
+                on_delta=filt.feed,
+            )
+            await filt.flush()
+            return response
+        except OutputTruncatedError:
+            if budget_index + 1 >= len(budgets):
+                logger.warning(
+                    "流式输出截断且已达放大上限 (max_tokens=%d, round=%d)",
+                    current_max_tokens,
+                    instance.round_number,
+                )
+                raise
+            bumped = budgets[budget_index + 1]
+            logger.info(
+                "流式输出被截断，提高 max_tokens 重试: %d -> %d (round=%d)",
+                current_max_tokens,
+                bumped,
+                instance.round_number,
+            )
+            if on_reset:
+                await on_reset()
+
+
 async def call_llm_with_tag_retry(
     llm_client: Any,
     instance: GameInstance,
@@ -205,15 +247,14 @@ async def call_llm_with_tag_retry(
 
     传入 on_delta 时走流式调用（call_stream），逐段叙事经 _NarrationDeltaFilter 过滤掉
     --- 之后的结构化标签后推给前端；骰子矛盾或截断重试前调 on_reset 让前端清空已显示
-    的流式文本。未传 on_delta 时退化为原有非流式 call()，bot 等场景不受影响。
+    的流式文本。流式与非流式截断均按 1×、2×、4× 预算重试，且不占用骰子矛盾重试次数。
     """
     response = None
     data: dict = {}
     stream = on_delta is not None
-    current_max_tokens = narrative_max_tokens
-    for retry in range(2):
+    for dice_retry in range(2):
         retry_context = context
-        if retry > 0:
+        if dice_retry > 0:
             if is_english(getattr(instance, "language", "")):
                 retry_context = context + "\n\nPrevious response contradicted the required dice/check result. Rewrite the narration and strictly follow the check outcome."
             else:
@@ -221,36 +262,15 @@ async def call_llm_with_tag_retry(
             if on_reset:
                 await on_reset()
         if stream:
-            filt = _NarrationDeltaFilter(on_delta)
-            try:
-                response = await llm_client.call_stream(
-                    system_prompt=gm_prompt,
-                    user_message=retry_context,
-                    temperature=0.7,
-                    max_tokens=current_max_tokens,
-                    on_delta=filt.feed,
-                )
-                await filt.flush()
-            except OutputTruncatedError:
-                bumped = min(
-                    current_max_tokens * LENGTH_RETRY_FACTOR,
-                    narrative_max_tokens * LENGTH_RETRY_MAX_MULT,
-                )
-                if bumped > current_max_tokens:
-                    logger.info(
-                        "流式输出被截断，提高 max_tokens 重试: %d -> %d (round=%d)",
-                        current_max_tokens, bumped, instance.round_number,
-                    )
-                    current_max_tokens = bumped
-                    continue
-                logger.warning("流式输出截断且已达放大上限，降级为非流式调用 (round=%d)", instance.round_number)
-                stream = False
-                response = await llm_client.call(
-                    system_prompt=gm_prompt,
-                    user_message=retry_context,
-                    temperature=0.7,
-                    max_tokens=current_max_tokens,
-                )
+            response = await _call_stream_with_length_retry(
+                llm_client,
+                instance,
+                gm_prompt,
+                retry_context,
+                narrative_max_tokens,
+                on_delta,
+                on_reset,
+            )
         else:
             response = await llm_client.call(
                 system_prompt=gm_prompt,
@@ -290,7 +310,11 @@ async def call_llm_with_tag_retry(
         narration = response.narration or response.content
         if not dice_block or validate_dice_constraint(dice_block, narration):
             break
-        logger.warning("骰子约束矛盾，重试 (%d/1, round=%d)", retry + 1, instance.round_number)
+        logger.warning(
+            "骰子约束矛盾，重试 (%d/1, round=%d)",
+            dice_retry + 1,
+            instance.round_number,
+        )
     else:
         logger.error("骰子约束连续2次矛盾，接受最后输出 (round=%d)", instance.round_number)
 

--- a/src/common_factory.py
+++ b/src/common_factory.py
@@ -42,7 +42,7 @@ def create_trpg_subsystems(
     embedding_max_input: int = 0,
     proxy_url: str = "",
     auto_recover: bool = False,
-    narrative_max_tokens: int = 1536,
+    narrative_max_tokens: int = 2048,
     character_gen_max_tokens: int = 2048,
     summary_max_tokens: int = 400,
     brief_max_tokens: int = 300,

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -17,6 +17,21 @@ LENGTH_RETRY_FACTOR = 2    # finish_reason=length 时重试放大 max_tokens 的
 LENGTH_RETRY_MAX_MULT = 4  # 最大放大到原始 max_tokens 的多少倍
 
 
+def length_retry_budgets(base_max_tokens: int) -> tuple[int, ...]:
+    """返回输出截断时共用的 token 预算序列。"""
+    if base_max_tokens <= 0:
+        raise ValueError("base_max_tokens 必须大于 0")
+
+    budgets = [base_max_tokens]
+    limit = base_max_tokens * LENGTH_RETRY_MAX_MULT
+    while len(budgets) < MAX_RETRIES:
+        bumped = min(budgets[-1] * LENGTH_RETRY_FACTOR, limit)
+        if bumped <= budgets[-1]:
+            break
+        budgets.append(bumped)
+    return tuple(budgets)
+
+
 # 按 HTTP 状态码的退避策略
 _RETRY_BACKOFF: dict[int, float] = {
     429: 5.0,     # Rate Limit → 较长等待
@@ -29,10 +44,10 @@ _RETRYABLE_STATUSES = frozenset(_RETRY_BACKOFF) | {408}  # 408 Timeout 也可重
 
 
 class OutputTruncatedError(ValueError):
-    """模型输出被 max_tokens 截断且未返回正文（finish_reason=length / stop_reason=max_tokens）。
+    """模型输出被 max_tokens 截断（finish_reason=length / stop_reason=max_tokens）。
 
-    继承 ValueError 以保持"空正文即报错"的原有语义；call() 据此在重试时
-    自动提高 max_tokens，而不是用相同预算对推理模型原地重试。
+    即使已经返回部分正文也不能当作完整结果；call() 据此在重试时自动提高
+    max_tokens，而不是保存缺少结尾或结构化状态的半截回复。
     """
 
     def __init__(self, finish_reason: str = "length"):
@@ -124,7 +139,8 @@ class LLMClient:
 
         last_error = None
         last_backoff = BASE_DELAY
-        current_max_tokens = max_tokens
+        retry_budgets = length_retry_budgets(max_tokens)
+        current_max_tokens = retry_budgets[0]
         for attempt_num in range(1, MAX_RETRIES + 1):
             for provider in ordered:
                 try:
@@ -170,10 +186,9 @@ class LLMClient:
                     continue
             if attempt_num < MAX_RETRIES:
                 if isinstance(last_error, OutputTruncatedError):
-                    bumped = min(
-                        current_max_tokens * LENGTH_RETRY_FACTOR,
-                        max_tokens * LENGTH_RETRY_MAX_MULT,
-                    )
+                    bumped = retry_budgets[
+                        min(attempt_num, len(retry_budgets) - 1)
+                    ]
                     if bumped > current_max_tokens:
                         logger.info(
                             "输出截断，下次重试提高 max_tokens: %d -> %d",
@@ -204,9 +219,9 @@ class LLMClient:
         内部累积完整正文后走同一个 _to_response 解析，保证流式/非流式结果同构。
 
         供应商在开始流式前失败（连接/HTTP 错误/超时）时按 fallback 顺序与退避重试，
-        行为与 call() 一致；流式过程中途失败则抛出，由调用方决定是否重试。空正文且
-        finish_reason=length 时抛 OutputTruncatedError，不在内部放大预算，由调用方
-        提高 max_tokens 后重新调用（与 call() 的截断处理对齐）。
+        行为与 call() 一致；流式过程中途失败则抛出，由调用方决定是否重试。
+        finish_reason=length 时即使已有部分正文也抛 OutputTruncatedError，不在内部
+        放大预算，由调用方提高 max_tokens 后重新调用（与 call() 的截断处理对齐）。
         """
         primary = self.providers[force_provider or self.default]
         ordered = [primary] + [
@@ -326,10 +341,10 @@ class LLMClient:
 
         choice = data["choices"][0]
         content = choice["message"].get("content") or ""
+        finish_reason = str(choice.get("finish_reason") or "unknown")
+        if finish_reason == "length":
+            raise OutputTruncatedError(finish_reason)
         if not content.strip():
-            finish_reason = str(choice.get("finish_reason") or "unknown")
-            if finish_reason == "length":
-                raise OutputTruncatedError(finish_reason)
             raise ValueError(
                 f"模型未返回最终正文 (finish_reason={finish_reason})"
             )
@@ -379,8 +394,12 @@ class LLMClient:
             data = await resp.json()
 
         content = _anthropic_text_content(data)
-        if not content.strip() and data.get("stop_reason") == "max_tokens":
+        if data.get("stop_reason") == "max_tokens":
             raise OutputTruncatedError("max_tokens")
+        if not content.strip():
+            raise ValueError(
+                f"模型未返回最终正文 (stop_reason={data.get('stop_reason') or 'unknown'})"
+            )
         usage = data.get("usage", {})
         total_tokens = int(usage.get("input_tokens", 0) or 0) + int(usage.get("output_tokens", 0) or 0)
         return self._to_response(content, total_tokens, provider.provider_name)
@@ -483,9 +502,9 @@ class LLMClient:
                     total_tokens = int(usage.get("total_tokens", 0) or 0)
 
         content = "".join(content_parts)
+        if finish_reason == "length":
+            raise OutputTruncatedError(finish_reason)
         if not content.strip():
-            if finish_reason == "length":
-                raise OutputTruncatedError(finish_reason)
             raise ValueError(f"模型未返回最终正文 (finish_reason={finish_reason})")
         return content, total_tokens, finish_reason
 
@@ -567,9 +586,9 @@ class LLMClient:
                     output_tokens = int(usage.get("output_tokens", 0) or 0)
 
         content = "".join(content_parts)
+        if stop_reason == "max_tokens":
+            raise OutputTruncatedError("max_tokens")
         if not content.strip():
-            if stop_reason == "max_tokens":
-                raise OutputTruncatedError("max_tokens")
             raise ValueError(f"模型未返回最终正文 (stop_reason={stop_reason})")
         total_tokens = input_tokens + output_tokens
         return content, total_tokens, stop_reason

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -5,7 +5,16 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.llm.client import LLMClient, ProviderConfig, OutputTruncatedError
+from src.llm.client import (
+    LLMClient,
+    OutputTruncatedError,
+    ProviderConfig,
+    length_retry_budgets,
+)
+
+
+def test_length_retry_budgets_are_shared_one_two_four_times():
+    assert length_retry_budgets(2048) == (2048, 4096, 8192)
 
 
 class _FakeResponse:
@@ -53,10 +62,27 @@ class _EmptyOpenAIResponse(_FakeResponse):
         }
 
 
+class _PartialOpenAIResponse(_FakeResponse):
+    async def json(self):
+        return {
+            "choices": [{
+                "message": {"content": "已经生成但没有结束的部分正文"},
+                "finish_reason": "length",
+            }],
+            "usage": {"total_tokens": 512},
+        }
+
+
 class _EmptyOpenAISession(_FakeSession):
     def post(self, url, **kwargs):
         self.calls.append({"url": url, **kwargs})
         return _EmptyOpenAIResponse()
+
+
+class _PartialOpenAISession(_FakeSession):
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return _PartialOpenAIResponse()
 
 
 @pytest.mark.asyncio
@@ -117,6 +143,32 @@ async def test_openai_provider_never_exposes_reasoning_as_final_content(monkeypa
             "compress the narration",
             "original narration",
             temperature=0.2,
+            max_tokens=512,
+        )
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_rejects_partial_content_when_finish_reason_is_length(monkeypatch):
+    session = _PartialOpenAISession()
+    provider = ProviderConfig(
+        provider_name="partial-model",
+        base_url="https://api.example.com",
+        api_key="test-key",
+        model_name="partial-test",
+    )
+    client = LLMClient(providers=[provider], default=provider.provider_name)
+
+    async def fake_get_session():
+        return session
+
+    monkeypatch.setattr(client, "_get_session", fake_get_session)
+
+    with pytest.raises(OutputTruncatedError, match=r"finish_reason=length"):
+        await client._call_openai_compatible(
+            provider,
+            "system",
+            "user",
+            temperature=0.7,
             max_tokens=512,
         )
 
@@ -314,6 +366,40 @@ async def test_call_stream_openai_length_truncation_raises(monkeypatch):
 
     with pytest.raises(OutputTruncatedError):
         await client.call_stream("system", "hello", max_tokens=512)
+
+
+@pytest.mark.asyncio
+async def test_call_stream_openai_partial_length_truncation_raises(monkeypatch):
+    session = _FakeStreamSession(
+        _openai_sse_lines([("部分正文", ""), ("", "length")])
+    )
+    provider = ProviderConfig(
+        provider_name="reasoning-model",
+        base_url="https://api.example.com",
+        api_key="k",
+        model_name="m",
+    )
+    client = LLMClient(providers=[provider], default="reasoning-model")
+
+    async def fake_get_session():
+        return session
+
+    monkeypatch.setattr(client, "_get_session", fake_get_session)
+
+    deltas: list[str] = []
+
+    async def on_delta(text: str) -> None:
+        deltas.append(text)
+
+    with pytest.raises(OutputTruncatedError):
+        await client.call_stream(
+            "system",
+            "hello",
+            max_tokens=512,
+            on_delta=on_delta,
+        )
+
+    assert deltas == ["部分正文"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_round_llm_streaming.py
+++ b/tests/test_round_llm_streaming.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.commands.round_llm import _NarrationDeltaFilter, call_llm_with_tag_retry
 from src.engine.game_instance import GameInstance
-from src.llm.client import LLMResponse
+from src.llm.client import LLMResponse, OutputTruncatedError
 
 
 def _make_response(content: str, provider: str = "stream-test") -> LLMResponse:
@@ -45,6 +45,31 @@ class StreamingLLM:
             await on_delta(content[:mid])
             await on_delta(content[mid:])
         return _make_response(content)
+
+
+class LengthRetryStreamingLLM:
+    """None 表示本次流式输出因 token 上限截断，其余值表示成功响应。"""
+
+    default = "stream-test"
+
+    def __init__(self, outcomes: list[str | None]) -> None:
+        self._outcomes = list(outcomes)
+        self._i = 0
+        self.max_tokens: list[int] = []
+
+    async def call_stream(self, system_prompt: str = "", user_message: str = "", *,
+                          temperature: float = 0.7, max_tokens: int = 1024,
+                          on_delta=None, **kwargs) -> LLMResponse:
+        self.max_tokens.append(max_tokens)
+        outcome = self._outcomes[min(self._i, len(self._outcomes) - 1)]
+        self._i += 1
+        if outcome is None:
+            if on_delta:
+                await on_delta("尚未完成的叙事。" * 20)
+            raise OutputTruncatedError("max_tokens")
+        if on_delta:
+            await on_delta(outcome)
+        return _make_response(outcome)
 
 
 @pytest.mark.asyncio
@@ -143,6 +168,77 @@ async def test_call_llm_with_tag_retry_streams_narration_only():
     assert resets == []
     assert llm.stream_calls == 1
     assert "青铜钥匙" in response.content
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_tag_retry_stream_length_budgets_reach_four_times():
+    llm = LengthRetryStreamingLLM([None, None, "最终叙事。"])
+    instance = GameInstance(game_key=("web", "stream", "bot"))
+    deltas: list[str] = []
+    resets: list[int] = []
+
+    async def on_delta(text: str) -> None:
+        deltas.append(text)
+
+    async def on_reset() -> None:
+        resets.append(1)
+        deltas.clear()
+
+    response, _data = await call_llm_with_tag_retry(
+        llm, instance, "GM", "ctx", "hp_based", "", 1024, "actions",
+        on_delta=on_delta, on_reset=on_reset,
+    )
+
+    assert llm.max_tokens == [1024, 2048, 4096]
+    assert len(resets) == 2
+    assert "".join(deltas) == "最终叙事。"
+    assert response.narration == "最终叙事。"
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_tag_retry_stream_length_stops_after_four_times():
+    llm = LengthRetryStreamingLLM([None])
+    instance = GameInstance(game_key=("web", "stream", "bot"))
+    resets: list[int] = []
+
+    async def on_delta(_text: str) -> None:
+        pass
+
+    async def on_reset() -> None:
+        resets.append(1)
+
+    with pytest.raises(OutputTruncatedError):
+        await call_llm_with_tag_retry(
+            llm, instance, "GM", "ctx", "hp_based", "", 1024, "actions",
+            on_delta=on_delta, on_reset=on_reset,
+        )
+
+    assert llm.max_tokens == [1024, 2048, 4096]
+    assert len(resets) == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_length_retry_does_not_consume_dice_rewrite():
+    bad = "你没能打开门。"
+    good = "你成功打开了门。"
+    llm = LengthRetryStreamingLLM([None, bad, good])
+    instance = GameInstance(game_key=("web", "stream", "bot"))
+    resets: list[int] = []
+
+    async def on_delta(_text: str) -> None:
+        pass
+
+    async def on_reset() -> None:
+        resets.append(1)
+
+    response, _data = await call_llm_with_tag_retry(
+        llm, instance, "GM", "ctx", "hp_based", "大成功", 1024, "actions",
+        on_delta=on_delta, on_reset=on_reset,
+    )
+
+    assert llm.max_tokens == [1024, 2048, 1024]
+    assert len(resets) == 2
+    assert response.narration == good
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_bot_auth.py
+++ b/tests/test_web_server_bot_auth.py
@@ -17,16 +17,24 @@ from src.webui.sse_ticket import SseTicketStore
 
 def test_generation_defaults_migration_raises_only_the_old_narrative_default():
     old_default = {"narrative_max_tokens": 1024}
+    previous_default = {
+        "narrative_max_tokens": 1536,
+        "generation_defaults_version": 2,
+    }
     custom = {"narrative_max_tokens": 1280}
 
     assert web_server._migrate_generation_defaults(old_default) is True
     assert old_default["narrative_max_tokens"] == web_server.DEFAULT_NARRATIVE_MAX_TOKENS
-    assert old_default["generation_defaults_version"] == 2
+    assert old_default["generation_defaults_version"] == 3
     assert web_server._migrate_generation_defaults(old_default) is False
+
+    assert web_server._migrate_generation_defaults(previous_default) is True
+    assert previous_default["narrative_max_tokens"] == web_server.DEFAULT_NARRATIVE_MAX_TOKENS
+    assert previous_default["generation_defaults_version"] == 3
 
     assert web_server._migrate_generation_defaults(custom) is True
     assert custom["narrative_max_tokens"] == 1280
-    assert custom["generation_defaults_version"] == 2
+    assert custom["generation_defaults_version"] == 3
 
 
 def test_invalid_config_is_quarantined_instead_of_silently_discarded(tmp_path):

--- a/web_server.py
+++ b/web_server.py
@@ -48,8 +48,8 @@ from src.webui.services import updater as updater_svc
 logger = logging.getLogger("trpg")
 logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
 
-DEFAULT_NARRATIVE_MAX_TOKENS = 1536
-GENERATION_DEFAULTS_VERSION = 2
+DEFAULT_NARRATIVE_MAX_TOKENS = 2048
+GENERATION_DEFAULTS_VERSION = 3
 
 DATA_DIR = Path(os.getenv("TRPG_DATA_DIR", str(Path(__file__).parent / "data")))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -104,7 +104,7 @@ def _migrate_generation_defaults(config: dict) -> bool:
         narrative_tokens = int(config.get("narrative_max_tokens", 1024) or 1024)
     except (TypeError, ValueError):
         narrative_tokens = 1024
-    if narrative_tokens == 1024:
+    if narrative_tokens in {1024, 1536}:
         config["narrative_max_tokens"] = DEFAULT_NARRATIVE_MAX_TOKENS
     config["generation_defaults_version"] = GENERATION_DEFAULTS_VERSION
     return True


### PR DESCRIPTION
## 改动

- 将默认叙事输出额度恢复为 2048，并迁移旧的 1024/1536 默认配置。
- 流式与非流式输出统一按 1×、2×、4× 预算处理截断。
- 检测并丢弃 API 明确标记为长度截断的半截正文。
- 将截断扩容与骰子约束重写的重试次数解耦。
- 移除日志页多余的分页加载说明。
- 更新 v1.7.4 版本号，发布说明正文沿用 v1.7.3。

## 原因与影响

之前流式路径无法真正执行到 4× 预算，截断还会占用骰子矛盾重写机会；部分供应商返回非空但被截断的正文时也可能被当作完整结果。现在网页与 Bot/Bridge 的恢复规则一致，状态标签和叙事不再接受明确的半截输出。

## 验证

- `python -m pytest -q`：532 passed
- `python scripts/audit_api_contracts.py`
- `python scripts/audit_text_i18n.py`
- 前端 typecheck：通过
- 前端 Vitest：26 passed
- 前端生产构建：通过
- v1.7.4 源码包与便携包本地构建、边界检查：通过

非阻断：既有 aiohttp 29 条测试警告；npm audit 报告 9 个 high。