### PR TITLE
fix: clean up resources after deleting games

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,55 +1,37 @@
-# DiceFrame v1.7.4
+# DiceFrame v1.7.5
 
 ## 中文
 
-这个版本让 DiceFrame 更适合通过端口映射邀请朋友游玩，并补齐了群聊 Bot 的中英文体验和插件扩展能力。
-
-### 新功能
-
-- **公网访问保护**：加入轻量请求限流和更清楚的操作频繁提示，降低大量连续请求对游戏的影响。
-- **最近登录记录**：设置页可以查看最近的登录时间、来源 IP 和结果，记录会自动限制数量。
-- **中英文群聊 Bot**：Bot 会跟随对局语言显示帮助、状态、前情、地图、支付和错误提示，英文对局可以直接使用英文命令。
-- **群聊展示扩展**：插件可以增加 Bot 命令，或把状态、地图等回复替换为自定义文字、图片和卡片；扩展失败时会自动使用内置展示。
+这个版本主要修复删除游戏后遗留临时世界模板和群聊 Bot 绑定的问题。
 
 ### 优化与修复
 
-- 减少私下部署的 DiceFrame 页面被搜索引擎收录。
-- 补充常用安全响应头，并改进登录与接口访问保护。
-- 修复未设置固定密码时，部分情况下页面却显示已经设置密码的问题。
-- “忘记密码”说明现在会明确指出重置文件应放在 `data` 目录。
-- 改善日间主题的文字、状态标签和高亮内容对比度。
-- 调整游玩页顶部栏高度和排版，避免内容上下溢出，并移除与场景卡片重复的信息。
-- 更新 Bot Bridge、QQ / NapCat 和插件开发文档。
+- 删除游戏时，会一并清理该游戏生成且未被其他存档使用的临时世界模板。
+- 启动时会清理旧版本遗留的孤立临时模板，同时保留用户主动创建和保存的模板。
+- QQ / NapCat Bot 连续确认绑定的游戏已经不存在后，会自动解除群绑定，不再每隔数秒重复报错。
+- 调整启动顺序，避免程序恢复存档前错误地把有效 Bot 绑定判定为失效。
+- MaiBot Bridge 同步支持识别已删除的游戏并解除失效绑定。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.7.4-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.7.4-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.7.5-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.7.5-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release makes DiceFrame safer to share through port forwarding and completes the bilingual chat Bot experience and extension support.
-
-### New Features
-
-- **Public access protection**: Lightweight request throttling and clearer rate-limit messages reduce the impact of repeated requests on active games.
-- **Recent login history**: Settings now shows recent login times, source IPs, and results while automatically limiting retained entries.
-- **Bilingual chat Bot**: Help, status, recap, map, payment, and error messages follow the game language, with native English commands for English games.
-- **Chat presentation extensions**: Plugins can add Bot commands or replace status, map, and other replies with custom text, images, or cards. DiceFrame falls back to its built-in presentation if an extension fails.
+This release fixes temporary world templates and chat Bot bindings being left behind after a game is deleted.
 
 ### Improvements and Fixes
 
-- Reduced search-engine indexing of privately hosted DiceFrame pages.
-- Added common security response headers and improved login and API access protection.
-- Fixed cases where DiceFrame reported that a fixed password was configured when none had been set.
-- Password recovery guidance now clearly identifies the `data` directory.
-- Improved text, status tag, and highlighted-content contrast in the light theme.
-- Refined the play-page header to prevent vertical clipping and removed information duplicated by the scene card.
-- Updated Bot Bridge, QQ / NapCat, and plugin development documentation.
+- Deleting a game now also removes its generated temporary world template when no other save uses it.
+- Startup cleanup removes orphaned temporary templates from older versions while preserving templates created or saved by users.
+- QQ / NapCat automatically unbinds a group after repeatedly confirming that its bound game no longer exists, stopping recurring sync errors.
+- Save recovery now finishes before Bot plugins start, preventing valid bindings from being treated as stale.
+- MaiBot Bridge now also recognizes deleted games and clears stale bindings.
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.7.4-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.7.4-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.7.5-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.7.5-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/src/bots/bridge_core/client.py
+++ b/src/bots/bridge_core/client.py
@@ -170,12 +170,22 @@ class DiceFrameClient:
                 data = await response.json(content_type=None)
             except Exception as exc:
                 text = await response.text()
-                raise DiceFrameHTTPError(f"DiceFrame 返回了非 JSON 响应：HTTP {response.status} {text[:120]}") from exc
+                raise DiceFrameHTTPError(
+                    f"DiceFrame 返回了非 JSON 响应：HTTP {response.status} {text[:120]}",
+                    status=response.status,
+                ) from exc
             if response.status >= 400:
                 error = data.get("error") or data.get("message") or f"HTTP {response.status}"
-                raise DiceFrameHTTPError(str(error))
+                raise DiceFrameHTTPError(
+                    str(error),
+                    status=response.status,
+                    code=str(data.get("code") or ""),
+                )
             if isinstance(data, dict) and data.get("ok") is False:
-                raise DiceFrameHTTPError(str(data.get("error") or data.get("narration") or "DiceFrame 请求失败"))
+                raise DiceFrameHTTPError(
+                    str(data.get("error") or data.get("narration") or "DiceFrame 请求失败"),
+                    code=str(data.get("code") or ""),
+                )
             return data if isinstance(data, dict) else {"data": data}
 
 

--- a/src/bots/bridge_core/errors.py
+++ b/src/bots/bridge_core/errors.py
@@ -9,3 +9,8 @@ class DiceFrameBridgeError(RuntimeError):
 
 class DiceFrameHTTPError(DiceFrameBridgeError):
     """Raised when the DiceFrame HTTP API returns an error payload."""
+
+    def __init__(self, message: str, *, status: int | None = None, code: str = "") -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = str(code or "")

--- a/src/bots/qq/adapter.py
+++ b/src/bots/qq/adapter.py
@@ -142,6 +142,7 @@ class QQTRPGAdapter(QQDeliveryMixin, QQWebSyncMixin, QQCharacterFlowMixin, QQGam
         self.character_wizards: dict[str, dict[str, Any]] = {}
         self._web_sync_last_round: dict[str, int] = {}
         self._web_sync_seen_actions: dict[str, set[str]] = {}
+        self._web_sync_failures: dict[str, int] = {}
         self._group_action_inflight: dict[str, bool] = {}
 
     async def handle_payload(self, payload: dict[str, Any]) -> None:

--- a/src/bots/qq/web_sync.py
+++ b/src/bots/qq/web_sync.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from src.bots.bridge_core.errors import DiceFrameHTTPError
 from src.bots.bridge_core.language import bridge_is_english
+
+_STALE_BINDING_FAILURE_LIMIT = 3
 
 
 class QQWebSyncMixin:
@@ -15,9 +18,37 @@ class QQWebSyncMixin:
                 continue
             try:
                 detail = await self.api.game_detail(game_key, gm_uid)
+            except DiceFrameHTTPError as exc:
+                stale_binding = (
+                    exc.code in {"GAME_NOT_FOUND", "BOT_ACTOR_INVALID"}
+                    or exc.status == 404
+                    or (exc.status == 403 and str(exc) == "Bot 代表玩家无效")
+                )
+                if stale_binding:
+                    failures = self._web_sync_failures.get(group_id, 0) + 1
+                    self._web_sync_failures[group_id] = failures
+                    if failures >= _STALE_BINDING_FAILURE_LIMIT:
+                        await self.store.unbind_group(group_id)
+                        self._web_sync_failures.pop(group_id, None)
+                        self._web_sync_last_round.pop(game_key, None)
+                        self._web_sync_seen_actions.pop(game_key, None)
+                        self.logger.warning(
+                            "Web 同步绑定已失效并自动解除: group=%s game=%s code=%s status=%s",
+                            group_id, game_key, exc.code or "-", exc.status or "-",
+                        )
+                        continue
+                    self.logger.warning(
+                        "Web 同步绑定校验失败（%d/%d）: group=%s game=%s code=%s status=%s",
+                        failures, _STALE_BINDING_FAILURE_LIMIT,
+                        group_id, game_key, exc.code or "-", exc.status or "-",
+                    )
+                    continue
+                self.logger.warning("Web 同步轮询 game_detail 失败: %s", game_key, exc_info=True)
+                continue
             except Exception:
                 self.logger.warning("Web 同步轮询 game_detail 失败: %s", game_key, exc_info=True)
                 continue
+            self._web_sync_failures.pop(group_id, None)
             if not isinstance(detail, dict):
                 continue
             recap = detail.get("recap") or {}

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.7.4"
+__version__ = "1.7.5"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -236,6 +236,9 @@ class WebAPI:
     def game_detail(self, game_key: str) -> dict[str, Any] | None:
         return games.game_detail(self, game_key)
 
+    def delete_game(self, game_key: str) -> dict[str, Any]:
+        return games.delete_game(self, game_key)
+
     async def get_bot_bind_token(self, game_key: str, rotate: bool = False) -> dict[str, Any]:
         return await bot_access.get_bind_token(self, game_key, rotate)
 
@@ -421,6 +424,9 @@ class WebAPI:
 
     def list_world_templates(self) -> dict[str, Any]:
         return worlds.list_world_templates(self)
+
+    def cleanup_orphan_game_templates(self, world_id: str = "") -> int:
+        return worlds.cleanup_orphan_game_templates(self, world_id)
 
     # ---- 创建游戏 ----
 

--- a/src/webui/routes/games.py
+++ b/src/webui/routes/games.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import json
 import secrets
-import shutil
 from urllib.parse import quote
 
 from aiohttp import web
@@ -34,19 +33,6 @@ def _read_saved_gm_uid(registry, gk: tuple) -> str:
         except Exception:
             logger.warning("读取存档 GM 身份失败: %s", path, exc_info=True)
     return ""
-
-
-def _remove_save_dir(registry, gk: tuple) -> tuple[bool, str]:
-    save_dir = registry._save_path(gk).parent
-    if not save_dir.exists():
-        return False, "存档目录不存在"
-    try:
-        shutil.rmtree(save_dir)
-    except Exception as exc:
-        logger.warning("删除存档目录失败: %s", save_dir, exc_info=True)
-        return False, f"删除存档目录失败: {exc}"
-    registry.remove(gk)
-    return True, ""
 
 
 def _can_delete_save(request: web.Request, session_uid: str, gm_uid: str) -> bool:
@@ -785,11 +771,11 @@ async def api_batch_delete_games(request: web.Request) -> web.Response:
         if not _can_delete_save(request, session_uid, gm_uid):
             failed.append({"key": raw, "error": "非 GM 不可删除"})
             continue
-        ok, error = _remove_save_dir(registry, gk)
-        if ok:
+        result = api.delete_game(raw)
+        if result.get("ok"):
             deleted.append(raw)
         else:
-            failed.append({"key": raw, "error": error})
+            failed.append({"key": raw, "error": str(result.get("error") or "删除失败")})
     return web.json_response({"ok": True, "deleted": deleted, "failed": failed})
 
 
@@ -812,11 +798,12 @@ async def api_delete_game(request: web.Request) -> web.Response:
         return web.json_response({"error": "存档缺少 GM 身份，拒绝删除"}, status=403)
     if not _can_delete_save(request, session_uid, gm_uid):
         return web.json_response({"error": "仅 GM 可删除游戏"}, status=403)
-    ok, error = _remove_save_dir(registry, gk)
-    if not ok:
+    result = api.delete_game(request.match_info["game_key"])
+    if not result.get("ok"):
+        error = str(result.get("error") or "删除失败")
         status = 404 if error == "存档目录不存在" else 500
         return web.json_response({"error": error}, status=status)
-    return web.json_response({"ok": True})
+    return web.json_response(result)
 
 
 def register_games(app: web.Application) -> None:

--- a/src/webui/services/games.py
+++ b/src/webui/services/games.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import time
 import uuid
 from datetime import datetime, timezone
@@ -106,6 +107,41 @@ def game_detail(api: "WebAPI", game_key: str) -> dict[str, Any] | None:
         "multiplayer": inst.multiplayer_status(),
         "plot_tracker": inst.plot_tracker.to_dict() if inst.plot_tracker else None,
         "recap": _public_recap(inst),
+    }
+
+
+def _saved_world_id(api: "WebAPI", game_key: tuple[str, ...]) -> str:
+    save_path = api._reg._save_path(game_key)
+    for path in (save_path, save_path.with_name("state.backup.json")):
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            logger.warning("读取待删除存档的世界 ID 失败: %s", path, exc_info=True)
+            continue
+        return str(data.get("world_id") or "")
+    return ""
+
+
+def delete_game(api: "WebAPI", game_key: str) -> dict[str, Any]:
+    """Delete one save and release its game-scoped template when no save uses it."""
+    parsed_key = api._parse_key(game_key)
+    instance = api._reg.get(parsed_key)
+    save_dir = api._reg._save_path(parsed_key).parent
+    if not instance and not save_dir.exists():
+        return {"ok": False, "error": "存档目录不存在"}
+    world_id = str(getattr(instance, "world_id", "") or "") or _saved_world_id(api, parsed_key)
+    try:
+        shutil.rmtree(save_dir)
+    except Exception as exc:
+        logger.warning("删除存档目录失败: %s", save_dir, exc_info=True)
+        return {"ok": False, "error": f"删除存档目录失败: {exc}"}
+    api._reg.remove(parsed_key)
+    removed_templates = api.cleanup_orphan_game_templates(world_id) if world_id else 0
+    return {
+        "ok": True,
+        "world_template_removed": bool(removed_templates),
     }
 
 
@@ -617,6 +653,9 @@ async def create_game(api: "WebAPI", world_id: str, game_name: str = "",
                     "default_rule": resolved_rule,
                     "starter_lorebook": [],
                 }
+                if create_lorebook and not custom_world:
+                    min_template["_diceframe_managed"] = "game"
+                    min_template["_diceframe_owner_game"] = _GAME_KEY_SEP.join(game_key)
                 if cats:
                     min_template["item_categories"] = cats
                 api._worlds_dir.mkdir(parents=True, exist_ok=True)

--- a/src/webui/services/worlds.py
+++ b/src/webui/services/worlds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,13 @@ logger = logging.getLogger("trpg")
 _LOREBOOK_ENTRY_TYPES = {"npc", "location", "item", "event", "puzzle", "faction", "other"}
 _LOREBOOK_TIERS = {"core", "background", "archived"}
 _MAX_GENERATED_LOREBOOK_CONTENT = 2000
+_LEGACY_GAME_TEMPLATE_ID = re.compile(r"^.+_(?:copy|blank)_\d+$")
+_LEGACY_GAME_TEMPLATE_SUFFIXES = (
+    "（复制世界书）",
+    "（空白世界书）",
+    " (Copied Lorebook)",
+    " (Blank Lorebook)",
+)
 
 
 def list_worlds(api: "WebAPI") -> dict[str, Any]:
@@ -202,6 +210,48 @@ def list_world_templates(api: "WebAPI") -> dict[str, Any]:
             templates.append(item)
             seen.add(str(item.get("world_id") or ""))
     return {"templates": templates, "total": len(templates)}
+
+
+def _is_game_scoped_template(data: dict[str, Any], world_id: str) -> bool:
+    if data.get("_diceframe_managed") == "game":
+        return True
+    world_name = str(data.get("world_name") or "")
+    return bool(
+        data.get("custom") is True
+        and _LEGACY_GAME_TEMPLATE_ID.fullmatch(world_id)
+        and world_name.endswith(_LEGACY_GAME_TEMPLATE_SUFFIXES)
+    )
+
+
+def cleanup_orphan_game_templates(api: "WebAPI", world_id: str = "") -> int:
+    """Remove generated copy/blank templates after their last game is gone."""
+    worlds_dir = api._worlds_dir
+    if not worlds_dir or not worlds_dir.is_dir():
+        return 0
+    referenced = {
+        str(getattr(instance, "world_id", "") or "")
+        for instance in api._reg.list_all()
+    }
+    removed = 0
+    candidates = sorted(worlds_dir.glob("*.json"))
+    if world_id:
+        candidates = [path for path in candidates if path.stem == world_id]
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            template_world_id = str(data.get("world_id") or path.stem)
+            if world_id and template_world_id != world_id:
+                continue
+            if template_world_id in referenced or not _is_game_scoped_template(data, template_world_id):
+                continue
+            path.unlink()
+            removed += 1
+            logger.info("已清理孤立的对局临时世界模板: %s", path.name)
+        except (OSError, ValueError, json.JSONDecodeError):
+            logger.warning("清理对局临时世界模板失败: %s", path, exc_info=True)
+    return removed
 
 
 def _world_template_summary(data: dict[str, Any], fallback_id: str) -> dict[str, Any]:

--- a/tests/test_qq_bot.py
+++ b/tests/test_qq_bot.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from src.bots.bridge_core.errors import DiceFrameHTTPError
 from src.bots.qq.adapter import QQTRPGAdapter
 from src.bots.qq.card_renderer import BRAND_FOOTER
 from src.bots.qq.main import _watch_parent_process
@@ -1221,6 +1222,48 @@ async def test_web_sync_forwards_new_round_actions_and_narration(tmp_path):
     assert len(sender.messages) == 2
     assert sender.messages[0] == ("100", "艾琳：我攻击守卫")
     assert "剑光一闪" in sender.messages[1][1]
+
+
+@pytest.mark.asyncio
+async def test_web_sync_unbinds_deleted_game_after_repeated_not_found(tmp_path):
+    class MissingGameAPI(FakeAPI):
+        async def game_detail(self, game_key, actor):
+            raise DiceFrameHTTPError(
+                "游戏不存在",
+                status=404,
+                code="GAME_NOT_FOUND",
+            )
+
+    store = QQSessionStore(tmp_path / "sessions.json")
+    await store.bind_group("100", "web|deleted|bot", "42", "gm-1")
+    adapter = QQTRPGAdapter(MissingGameAPI(), store, FakeSender(), qq_config())
+
+    await adapter._poll_web_notifications()
+    await adapter._poll_web_notifications()
+    assert store.group("100") is not None
+
+    await adapter._poll_web_notifications()
+
+    assert store.group("100") is None
+    persisted = json.loads((tmp_path / "sessions.json").read_text(encoding="utf-8"))
+    assert persisted["groups"] == {}
+    assert persisted["players"] == {}
+
+
+@pytest.mark.asyncio
+async def test_web_sync_keeps_binding_for_unrelated_forbidden_error(tmp_path):
+    class ClosedGameAPI(FakeAPI):
+        async def game_detail(self, game_key, actor):
+            raise DiceFrameHTTPError("本局玩家入口已关闭", status=403)
+
+    store = QQSessionStore(tmp_path / "sessions.json")
+    await store.bind_group("100", "web|closed|bot", "42", "gm-1")
+    adapter = QQTRPGAdapter(ClosedGameAPI(), store, FakeSender(), qq_config())
+
+    for _ in range(4):
+        await adapter._poll_web_notifications()
+
+    assert store.group("100") is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_bot_auth.py
+++ b/tests/test_web_server_bot_auth.py
@@ -72,12 +72,13 @@ async def _identity(request: web.Request) -> web.Response:
 class FakeAPI:
     def __init__(self) -> None:
         self._players = {"actor-1"}
+        self.exists = True
 
     def bot_actor_allowed(self, game_key: str, user_id: str) -> bool:
         return user_id in self._players
 
     def game_detail(self, game_key: str) -> dict:
-        return {"player_access_open": True, "gm_uid": "actor-1"}
+        return {"player_access_open": True, "gm_uid": "actor-1"} if self.exists else None
 
 
 class FakePluginHost:
@@ -171,6 +172,21 @@ async def test_bot_game_action_with_valid_actor_allowed(bot_enabled):
             json={},
         )
         assert r.status == 200
+
+
+@pytest.mark.asyncio
+async def test_bot_deleted_game_returns_machine_readable_not_found(bot_enabled):
+    api = FakeAPI()
+    api.exists = False
+    app = _make_app(api)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/api/games/web%7Cx%7Cy/action",
+            headers={"X-Bot-Token": "tok", "X-Bot-Actor": "actor-1"},
+            json={},
+        )
+        assert response.status == 404
+        assert (await response.json())["code"] == "GAME_NOT_FOUND"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webui_create_flow.py
+++ b/tests/test_webui_create_flow.py
@@ -1053,7 +1053,14 @@ async def test_blank_lorebook_from_template_keeps_starter_lorebook_empty(web_api
     assert result["ok"] is True
     template_data = json.loads((worlds_dir / "template_world_blank_case.json").read_text(encoding="utf-8"))
     assert template_data["starter_lorebook"] == []
+    assert template_data["_diceframe_managed"] == "game"
+    assert template_data["_diceframe_owner_game"] == result["game_key"]
     assert lorebook.list_entries("template_world_blank_case") == []
+
+    deleted = api.delete_game(result["game_key"])
+
+    assert deleted == {"ok": True, "world_template_removed": True}
+    assert not (worlds_dir / "template_world_blank_case.json").exists()
 
 
 @pytest.mark.asyncio
@@ -1084,6 +1091,43 @@ async def test_copy_lorebook_copies_selected_source_entries(web_api):
     entries = lorebook.list_entries("template_world_copy_case")
     assert [entry["name"] for entry in entries] == ["抄录者"]
     assert entries[0]["world_id"] == "template_world_copy_case"
+
+
+def test_cleanup_orphan_legacy_copy_template_preserves_referenced_copy(web_api):
+    api, _lorebook, registry, _fake_llm, worlds_dir = web_api
+    world_id = "template_world_copy_1785176322339"
+    path = worlds_dir / f"{world_id}.json"
+    path.write_text(json.dumps({
+        "world_id": world_id,
+        "world_name": "贝克兰德（复制世界书）",
+        "custom": True,
+    }, ensure_ascii=False), encoding="utf-8")
+    instance = SimpleNamespace(
+        game_key=("web", "copy-user", "web_bot"),
+        world_id=world_id,
+    )
+    registry.register(instance)
+
+    assert api.cleanup_orphan_game_templates() == 0
+    assert path.exists()
+
+    registry.remove(instance.game_key)
+    assert api.cleanup_orphan_game_templates() == 1
+    assert not path.exists()
+
+
+def test_cleanup_does_not_remove_user_template_that_only_looks_like_copy(web_api):
+    api, _lorebook, _registry, _fake_llm, worlds_dir = web_api
+    world_id = "my_world_copy_1785176322339"
+    path = worlds_dir / f"{world_id}.json"
+    path.write_text(json.dumps({
+        "world_id": world_id,
+        "world_name": "我主动保存的世界",
+        "custom": True,
+    }, ensure_ascii=False), encoding="utf-8")
+
+    assert api.cleanup_orphan_game_templates() == 0
+    assert path.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_webui_route_permissions.py
+++ b/tests/test_webui_route_permissions.py
@@ -37,6 +37,16 @@ class FakeAPI:
         self.calls.append(("switch", game_key, world_id))
         return {"ok": True, "world_id": world_id}
 
+    def delete_game(self, game_key: str) -> dict:
+        key = self._parse_key(game_key)
+        save_dir = self.registry._save_path(key).parent
+        if not save_dir.exists():
+            return {"ok": False, "error": "存档目录不存在"}
+        import shutil
+        shutil.rmtree(save_dir)
+        self.registry.remove(key)
+        return {"ok": True}
+
     def get_log(self, game_key: str, page: int, per_page: int) -> dict:
         self.calls.append(("log", game_key, page, per_page))
         return {"log": [], "total": 0, "page": page, "total_pages": 1}

--- a/web_server.py
+++ b/web_server.py
@@ -508,10 +508,13 @@ async def on_startup(app: web.Application) -> None:
     app["plugin_host"] = plugin_host
     app["api"] = _make_api(subsystems, plugin_host)
     app["updater"] = updater_svc.UpdaterService(DATA_DIR, ROOT, plugin_host.mirrors if plugin_host else None)
-    await plugin_host.start_enabled()
     recovered = await subsystems.registry.recover_all()
     if recovered:
         logger.info("恢复了 %d 个存档", len(recovered))
+    removed_templates = app["api"].cleanup_orphan_game_templates()
+    if removed_templates:
+        logger.info("已清理 %d 个孤立的对局临时世界模板", removed_templates)
+    await plugin_host.start_enabled()
     app["_embedding_backfill_task"] = asyncio.create_task(_embed_pending_memories(app))
     app["_save_task"] = asyncio.create_task(_periodic_save(app))
 
@@ -568,10 +571,18 @@ async def auth_middleware(request: web.Request, handler):
             if request.path in _BOT_PUBLIC_ENDPOINTS:
                 return await handler(request)
             return web.json_response({"ok": False, "error": "Bot 代表玩家无效"}, status=403)
+        detail = api.game_detail(game_key) if api else None
+        if not detail:
+            return web.json_response(
+                {"ok": False, "error": "游戏不存在", "code": "GAME_NOT_FOUND"},
+                status=404,
+            )
         actor = str(request.headers.get("X-Bot-Actor") or "").strip()
         if not actor or not api or not api.bot_actor_allowed(game_key, actor):
-            return web.json_response({"ok": False, "error": "Bot 代表玩家无效"}, status=403)
-        detail = api.game_detail(game_key) or {}
+            return web.json_response(
+                {"ok": False, "error": "Bot 代表玩家无效", "code": "BOT_ACTOR_INVALID"},
+                status=403,
+            )
         if detail.get("player_access_open") is False and actor != detail.get("gm_uid"):
             return web.json_response({"ok": False, "error": "本局玩家入口已关闭"}, status=403)
         request["user_id"] = actor


### PR DESCRIPTION
## Summary
- remove game-scoped temporary world templates after their final save is deleted
- clean up orphaned templates left by older releases without touching user-created templates
- stop recurring QQ / NapCat sync errors by clearing bindings only after repeated stale-game failures
- expose stable Bot API error codes and recover saves before starting Bot plugins
- bump DiceFrame to 1.7.5 and add bilingual release notes

Closes #28
Closes #29

## Validation
- `python -m pytest -q` (537 passed)
- related regression suite (165 passed)
- API contract and text audits passed
- frontend typecheck, unit tests (26 passed), and production build passed
- release source package inspected: no runtime/private/docs content