### PR TITLE
fix: raise token defaults to 1024 and table-drive migration

### DIFF
--- a/src/commands/game_handler.py
+++ b/src/commands/game_handler.py
@@ -48,9 +48,9 @@ class GameHandler:
         rules_dir: Path | None = None,
         worlds_dir: Path | None = None,
         narrative_max_tokens: int = 2048,
-        summary_max_tokens: int = 400,
-        brief_max_tokens: int = 300,
-        analysis_max_tokens: int = 512,
+        summary_max_tokens: int = 1024,
+        brief_max_tokens: int = 1024,
+        analysis_max_tokens: int = 1024,
     ):
         self.registry = registry
         self._combat = CombatResolver()

--- a/src/common_factory.py
+++ b/src/common_factory.py
@@ -44,9 +44,9 @@ def create_trpg_subsystems(
     auto_recover: bool = False,
     narrative_max_tokens: int = 2048,
     character_gen_max_tokens: int = 2048,
-    summary_max_tokens: int = 400,
-    brief_max_tokens: int = 300,
-    analysis_max_tokens: int = 512,
+    summary_max_tokens: int = 1024,
+    brief_max_tokens: int = 1024,
+    analysis_max_tokens: int = 1024,
 ) -> TRPGSubsystems:
     save_dir = data_dir / "saves"
 

--- a/src/memory/summarizer.py
+++ b/src/memory/summarizer.py
@@ -115,7 +115,7 @@ def needs_summary(instance: GameInstance, interval: int = 10) -> bool:
 
 
 async def summarize(instance: GameInstance, llm_client, system_prompt: str,
-                    max_tokens: int = 400) -> None:
+                    max_tokens: int = 1024) -> None:
     """调用 LLM 生成摘要并更新 GameInstance。
 
     由每轮 LLM 调用后检查触发，不需要独立调度。

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -37,7 +37,7 @@ class WebAPI:
                  memory: MemoryStore, rules_dir: Path,
                  handler=None, llm_client=None, worlds_dir: Path | None = None,
                  character_gen_max_tokens: int = 2048,
-                 text_gen_max_tokens: int = 400, plugin_host=None):
+                 text_gen_max_tokens: int = 1024, plugin_host=None):
         self._reg = registry
         self._lore = lorebook
         self._mem = memory

--- a/tests/test_web_server_bot_auth.py
+++ b/tests/test_web_server_bot_auth.py
@@ -25,16 +25,60 @@ def test_generation_defaults_migration_raises_only_the_old_narrative_default():
 
     assert web_server._migrate_generation_defaults(old_default) is True
     assert old_default["narrative_max_tokens"] == web_server.DEFAULT_NARRATIVE_MAX_TOKENS
-    assert old_default["generation_defaults_version"] == 3
+    assert old_default["generation_defaults_version"] == 5
     assert web_server._migrate_generation_defaults(old_default) is False
 
     assert web_server._migrate_generation_defaults(previous_default) is True
     assert previous_default["narrative_max_tokens"] == web_server.DEFAULT_NARRATIVE_MAX_TOKENS
-    assert previous_default["generation_defaults_version"] == 3
+    assert previous_default["generation_defaults_version"] == 5
 
     assert web_server._migrate_generation_defaults(custom) is True
     assert custom["narrative_max_tokens"] == 1280
-    assert custom["generation_defaults_version"] == 3
+    assert custom["generation_defaults_version"] == 5
+
+
+def test_generation_defaults_migration_raises_old_analysis_default():
+    """v4: 旧默认 analysis_max_tokens=512 提升到 1024，自定义值保留。"""
+    old_analysis = {"analysis_max_tokens": 512, "generation_defaults_version": 3}
+    custom_analysis = {"analysis_max_tokens": 768, "generation_defaults_version": 3}
+
+    assert web_server._migrate_generation_defaults(old_analysis) is True
+    assert old_analysis["analysis_max_tokens"] == 1024
+    assert old_analysis["generation_defaults_version"] == 5
+    assert web_server._migrate_generation_defaults(old_analysis) is False
+
+    assert web_server._migrate_generation_defaults(custom_analysis) is True
+    assert custom_analysis["analysis_max_tokens"] == 768
+    assert custom_analysis["generation_defaults_version"] == 5
+
+
+def test_generation_defaults_migration_raises_old_summary_brief_textgen_defaults():
+    """v5: summary/brief/text_gen 旧默认提升到 1024，自定义值保留。"""
+    old_defaults = {
+        "summary_max_tokens": 400,
+        "brief_max_tokens": 300,
+        "text_gen_max_tokens": 400,
+        "generation_defaults_version": 4,
+    }
+    custom = {
+        "summary_max_tokens": 500,
+        "brief_max_tokens": 350,
+        "text_gen_max_tokens": 600,
+        "generation_defaults_version": 4,
+    }
+
+    assert web_server._migrate_generation_defaults(old_defaults) is True
+    assert old_defaults["summary_max_tokens"] == 1024
+    assert old_defaults["brief_max_tokens"] == 1024
+    assert old_defaults["text_gen_max_tokens"] == 1024
+    assert old_defaults["generation_defaults_version"] == 5
+    assert web_server._migrate_generation_defaults(old_defaults) is False
+
+    assert web_server._migrate_generation_defaults(custom) is True
+    assert custom["summary_max_tokens"] == 500
+    assert custom["brief_max_tokens"] == 350
+    assert custom["text_gen_max_tokens"] == 600
+    assert custom["generation_defaults_version"] == 5
 
 
 def test_invalid_config_is_quarantined_instead_of_silently_discarded(tmp_path):

--- a/web_server.py
+++ b/web_server.py
@@ -49,7 +49,7 @@ logger = logging.getLogger("trpg")
 logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
 
 DEFAULT_NARRATIVE_MAX_TOKENS = 2048
-GENERATION_DEFAULTS_VERSION = 3
+GENERATION_DEFAULTS_VERSION = 5
 
 DATA_DIR = Path(os.getenv("TRPG_DATA_DIR", str(Path(__file__).parent / "data")))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -91,6 +91,19 @@ def _load_json_object(path: Path, label: str) -> dict:
         return {}
 
 
+# 各 token 字段的迁移规则：(字段名, 旧默认值集合, 新默认值)。
+# 仅在配置值等于某个已知旧默认时提升，保留用户自定义值。
+# 默认值历史上单调递增，缺失字段按最小旧默认补全后同样提升。
+# character_gen_max_tokens 一直是 2048，无旧默认需提升，不在表中。
+_TOKEN_FIELD_MIGRATIONS: tuple[tuple[str, frozenset[int], int], ...] = (
+    ("narrative_max_tokens", frozenset({1024, 1536}), DEFAULT_NARRATIVE_MAX_TOKENS),
+    ("analysis_max_tokens", frozenset({512}), 1024),
+    ("summary_max_tokens", frozenset({400}), 1024),
+    ("brief_max_tokens", frozenset({300}), 1024),
+    ("text_gen_max_tokens", frozenset({400}), 1024),
+)
+
+
 def _migrate_generation_defaults(config: dict) -> bool:
     """一次性提升旧版默认生成额度，同时保留用户的自定义数值。"""
     try:
@@ -100,12 +113,15 @@ def _migrate_generation_defaults(config: dict) -> bool:
     if version >= GENERATION_DEFAULTS_VERSION:
         return False
 
-    try:
-        narrative_tokens = int(config.get("narrative_max_tokens", 1024) or 1024)
-    except (TypeError, ValueError):
-        narrative_tokens = 1024
-    if narrative_tokens in {1024, 1536}:
-        config["narrative_max_tokens"] = DEFAULT_NARRATIVE_MAX_TOKENS
+    for field, old_defaults, new_default in _TOKEN_FIELD_MIGRATIONS:
+        missing = min(old_defaults)
+        try:
+            current = int(config.get(field, missing) or missing)
+        except (TypeError, ValueError):
+            current = missing
+        if current in old_defaults:
+            config[field] = new_default
+
     config["generation_defaults_version"] = GENERATION_DEFAULTS_VERSION
     return True
 
@@ -162,13 +178,13 @@ NARRATIVE_MAX_TOKENS = int(os.getenv("TRPG_NARRATIVE_MAX_TOKENS")
 CHARACTER_GEN_MAX_TOKENS = int(os.getenv("TRPG_CHARACTER_GEN_MAX_TOKENS")
                                or saved.get("character_gen_max_tokens", 2048))
 SUMMARY_MAX_TOKENS = int(os.getenv("TRPG_SUMMARY_MAX_TOKENS")
-                         or saved.get("summary_max_tokens", 400))
+                         or saved.get("summary_max_tokens", 1024))
 BRIEF_MAX_TOKENS = int(os.getenv("TRPG_BRIEF_MAX_TOKENS")
-                       or saved.get("brief_max_tokens", 300))
+                       or saved.get("brief_max_tokens", 1024))
 ANALYSIS_MAX_TOKENS = int(os.getenv("TRPG_ANALYSIS_MAX_TOKENS")
-                          or saved.get("analysis_max_tokens", 512))
+                          or saved.get("analysis_max_tokens", 1024))
 TEXT_GEN_MAX_TOKENS = int(os.getenv("TRPG_TEXT_GEN_MAX_TOKENS")
-                          or saved.get("text_gen_max_tokens", 400))
+                          or saved.get("text_gen_max_tokens", 1024))
 _ENV_PROXY_URL = env_proxy_url()
 _CONFIG_PROXY_URL = secrets.get("proxy_url") or saved.get("proxy_url", "")
 PROXY_ENABLED = bool(saved.get("proxy_enabled", bool(_ENV_PROXY_URL)))
@@ -403,9 +419,9 @@ def _build_subsystems() -> TRPGSubsystems:
         proxy_url=effective_proxy_url(bool(STATE.get("proxy_enabled")), STATE.get("proxy_url", "")),
         narrative_max_tokens=int(STATE.get("narrative_max_tokens", DEFAULT_NARRATIVE_MAX_TOKENS)),
         character_gen_max_tokens=int(STATE.get("character_gen_max_tokens", 4096)),
-        summary_max_tokens=int(STATE.get("summary_max_tokens", 400)),
-        brief_max_tokens=int(STATE.get("brief_max_tokens", 300)),
-        analysis_max_tokens=int(STATE.get("analysis_max_tokens", 512)),
+        summary_max_tokens=int(STATE.get("summary_max_tokens", 1024)),
+        brief_max_tokens=int(STATE.get("brief_max_tokens", 1024)),
+        analysis_max_tokens=int(STATE.get("analysis_max_tokens", 1024)),
     )
 
 
@@ -416,7 +432,7 @@ def _make_api(subsystems: TRPGSubsystems, plugin_host=None) -> WebAPI:
         handler=subsystems.handler, llm_client=subsystems.llm_client,
         worlds_dir=WORLDS_DIR,
         character_gen_max_tokens=int(STATE.get("character_gen_max_tokens", 4096)),
-        text_gen_max_tokens=int(STATE.get("text_gen_max_tokens", 400)),
+        text_gen_max_tokens=int(STATE.get("text_gen_max_tokens", 1024)),
         plugin_host=plugin_host,
     )
 


### PR DESCRIPTION
## 改动

把所有低于 1024 的 token 默认值提升到 1024，并将配置迁移逻辑重构为表驱动。

## 原因

`analysis/summary/brief/text_gen` 的 max_tokens 默认值（512/400/300/400）在多 NPC 与长团场景下几乎每次触发 `finish_reason=length` 截断重试。现有重试机制（1×→2×→4× 预算）本意是兜底**偶发**超长输出，但这些字段系统性偏紧，导致重试变成常态——每次重试都先烧掉一次失败请求（额外 token + 往返延迟）再翻倍预算，反而拖慢生成、加剧"对局感觉久"。

## 影响

- 默认值：analysis/summary/brief/text_gen → 1024（narrative 2048、character_gen 2048 已达标，不动）
- 迁移逻辑：`_migrate_generation_defaults` 重构为表驱动规则 `(字段, 旧默认值集合, 新默认值)`，今后任意字段调默认值都能自动提升老配置
- 兼容性：仅当配置值等于某个已知旧默认时才提升；用户自定义值一律保留
- `generation_defaults_version` 4→5
- 1×→2×→4× 重试机制保留，作为真正超长输出的兜底

## 根因

重试机制设计的临界点是"让绝大多数回合首轮即够"。这些字段卡在临界点偏小一侧，使兜底逻辑被当常态调用。

## 验证

- `py_compile` 6 文件通过
- pytest 42 passed：`test_web_server_bot_auth.py`（迁移测试，含新增 summary/brief/text_gen 用例）、`test_llm_client.py`、`test_round_llm_compression.py`、`test_round_llm_streaming.py`、`test_round_summary_defer.py`
- `git diff --check` 通过
- 迁移模拟：当前 config（version=3）重启后 summary/brief/text_gen 400/300/400→1024、analysis 512→1024，version→5
