### PR TITLE
release: prepare DiceFrame v1.7.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,37 +1,29 @@
-# DiceFrame v1.7.5
+# DiceFrame v1.7.6
 
 ## 中文
 
-这个版本主要修复删除游戏后遗留临时世界模板和群聊 Bot 绑定的问题。
+这个版本优化了 AI 生成的默认 Token 预算，减少不必要的重试，让对局叙事更流畅。
 
 ### 优化与修复
 
-- 删除游戏时，会一并清理该游戏生成且未被其他存档使用的临时世界模板。
-- 启动时会清理旧版本遗留的孤立临时模板，同时保留用户主动创建和保存的模板。
-- QQ / NapCat Bot 连续确认绑定的游戏已经不存在后，会自动解除群绑定，不再每隔数秒重复报错。
-- 调整启动顺序，避免程序恢复存档前错误地把有效 Bot 绑定判定为失效。
-- MaiBot Bridge 同步支持识别已删除的游戏并解除失效绑定。
+- 提升"分析、摘要、简报、文本生成"等步骤的默认 Token 上限，多 NPC 与长团场景下不再频繁触发截断重试。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.7.5-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.7.5-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.7.6-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.7.6-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release fixes temporary world templates and chat Bot bindings being left behind after a game is deleted.
+This release tunes default AI generation token budgets to reduce needless retries and make narration smoother.
 
 ### Improvements and Fixes
 
-- Deleting a game now also removes its generated temporary world template when no other save uses it.
-- Startup cleanup removes orphaned temporary templates from older versions while preserving templates created or saved by users.
-- QQ / NapCat automatically unbinds a group after repeatedly confirming that its bound game no longer exists, stopping recurring sync errors.
-- Save recovery now finishes before Bot plugins start, preventing valid bindings from being treated as stale.
-- MaiBot Bridge now also recognizes deleted games and clears stale bindings.
+- Raised default token limits for analysis, summary, brief, and text generation steps, so multi-NPC and long campaigns no longer trigger frequent truncation retries.
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.7.5-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.7.5-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.7.6-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.7.6-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.7.5"
+__version__ = "1.7.6"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"


### PR DESCRIPTION
## 改动

发布 DiceFrame v1.7.6。

- `src/version.py`：1.7.5 → 1.7.6
- `RELEASE_NOTES.md`：更新为本版本面向玩家的更新说明

## 本版本内容

v1.7.6 包含 #31 已合并的 token 默认值优化（analysis/summary/brief/text_gen 提到 1024，减少多 NPC 与长团场景下的截断重试）。

## 验证

- `py_compile src/version.py` 通过，版本号读取为 1.7.6
- RELEASE_NOTES.md 完整性检查通过（无截断、无空字节）
- `git diff --check` 通过

## 后续

合并后由用户单独授权推送 `v1.7.6` tag，届时将同时触发 GitHub Release（两个 Windows zip + .sha256）和 Docker 发布（GHCR + Docker Hub）。
