### PR TITLE
fix: stabilize tablet layout and NPC portraits

### DIFF
--- a/frontend-v2/src/features/admin/CharactersView.vue
+++ b/frontend-v2/src/features/admin/CharactersView.vue
@@ -42,6 +42,7 @@ interface CharacterEditForm {
   portrait?: CharacterPortrait
 }
 interface LevelUpState { player: import('@/api/types').Player; levelUpPoints: number }
+interface NpcPortraitEdit { npcId: string; name: string; portrait?: CharacterPortrait }
 interface CardEditForm {
   card_id: string
   character_name: string
@@ -92,6 +93,7 @@ const busy = ref(false)
 const edit = ref<CharacterEditForm | null>(null)
 const editLevelUp = ref<LevelUpState | null>(null)
 const editCard = ref<CardEditForm | null>(null)
+const editNpcPortrait = ref<NpcPortraitEdit | null>(null)
 const showWizard = ref(false)
 
 const rules = ref<RuleSummary[]>([])
@@ -147,7 +149,7 @@ function currentRuleBinding(): Pick<CharacterCard, 'rule_id' | 'rule_name' | 'ru
   }
 }
 function levelUpPoints(player: import('@/api/types').Player): number { return Number(player.character_sheet?.level_up_points || 0) }
-function npcKey(card: CharacterCard): string { return String(card.id || card.card_id || card.name || card.character_name || Math.random()) }
+function npcKey(card: CharacterCard): string { return String(card.npc_id || card.id || card.card_id || card.name || card.character_name || Math.random()) }
 function npcSummary(card: CharacterCard): string {
   return [
     card.relation ? `${t('relationshipPrefix')} ${card.relation}` : '',
@@ -375,6 +377,30 @@ async function deleteCard(c: CharacterCard) {
   } catch (e: unknown) { error.value = errorMessage(e) }
 }
 
+function openNpcPortrait(npc: CharacterCard) {
+  editNpcPortrait.value = {
+    npcId: npcKey(npc),
+    name: String(npc.character_name || npc.name || t('unnamed')),
+    portrait: npc.portrait ? { ...npc.portrait } : undefined,
+  }
+}
+
+async function saveNpcPortrait() {
+  const npc = editNpcPortrait.value
+  if (!npc || !game.value) return
+  busy.value = true
+  try {
+    const result = await api<{ ok?: boolean; error?: string }>(
+      `/games/${encodeURIComponent(game.value)}/npc/${encodeURIComponent(npc.npcId)}/portrait`,
+      { method: 'PUT', body: JSON.stringify({ portrait: npc.portrait ?? null }) },
+    )
+    if (!result.ok) throw new Error(result.error || t('saveFailed'))
+    editNpcPortrait.value = null
+    await load()
+    toast.success(t('characterSaved'))
+  } catch (e: unknown) { error.value = errorMessage(e) } finally { busy.value = false }
+}
+
 async function onWizardSubmit(c: CharacterSheet & { character_name: string }) {
   busy.value = true
   try {
@@ -435,7 +461,11 @@ async function onWizardSubmit(c: CharacterSheet & { character_name: string }) {
     <div class="card-grid" v-if="data?.npcs?.length">
       <article v-for="n in data.npcs" :key="npcKey(n)" class="char-card">
         <div class="character-card-summary">
-          <PortraitImage :portrait="n.portrait" :rule-id="ruleId" :seed="String(n.id || n.character_name || n.name || '')" :name="String(n.character_name || n.name || '')" :size="56" />
+          <button type="button" class="portrait-edit-button" :title="t('clickToChangeAvatar')" @click="openNpcPortrait(n)">
+            <PortraitImage v-if="n.portrait" :portrait="n.portrait" :rule-id="ruleId" :seed="npcKey(n)" :name="String(n.character_name || n.name || '')" :size="56" />
+            <span v-else class="portrait-image npc-portrait-empty" aria-hidden="true">＋</span>
+            <span>{{ t('clickToChangeAvatar') }}</span>
+          </button>
           <div>
           <h2>{{ n.character_name || n.name || t('unnamed') }}<small v-if="n.tier === 'core'" class="muted"> · {{ t('core') }}</small></h2>
           <p class="muted">{{ npcSummary(n) }}</p>
@@ -522,6 +552,14 @@ async function onWizardSubmit(c: CharacterSheet & { character_name: string }) {
       <template #actions>
         <button @click="editCard = null">{{ t('cancel') }}</button>
         <button class="primary" :disabled="busy" @click="saveCardEdit">{{ t('saveAction') }}</button>
+      </template>
+    </Modal>
+
+    <Modal v-if="editNpcPortrait" :title="`${editNpcPortrait.name} · ${t('characterAvatar')}`" @close="editNpcPortrait = null">
+      <PortraitPicker v-model="editNpcPortrait.portrait" :rule-id="ruleId" :seed="editNpcPortrait.npcId" :name="editNpcPortrait.name" />
+      <template #actions>
+        <button @click="editNpcPortrait = null">{{ t('cancel') }}</button>
+        <button class="primary" :disabled="busy" @click="saveNpcPortrait">{{ t('saveAction') }}</button>
       </template>
     </Modal>
 

--- a/frontend-v2/src/styles.css
+++ b/frontend-v2/src/styles.css
@@ -136,6 +136,7 @@ details:not([open])>:not(summary){display:none}
 .character-profile,.character-card-summary{display:flex;align-items:center;gap:11px;min-width:0}.character-card-summary>div{min-width:0}.character-card-summary p{margin:4px 0 0}
 .portrait-edit-button{position:relative;display:block;min-width:64px;min-height:64px;padding:0;border:0;background:transparent!important;overflow:visible}.portrait-edit-button:hover{transform:translateY(-1px);filter:none}.portrait-edit-button:focus-visible{outline:2px solid var(--gold);outline-offset:3px}.portrait-edit-button>span:last-child{position:absolute;left:50%;bottom:-5px;transform:translateX(-50%);min-width:max-content;padding:1px 5px;border-radius:999px;background:rgba(12,14,14,.9);border:1px solid rgba(242,207,131,.42);color:var(--gold-2);font-size:9px;line-height:1.4;opacity:0;transition:opacity .15s}.portrait-edit-button:hover>span:last-child,.portrait-edit-button:focus-visible>span:last-child{opacity:1}
 .portrait-image{position:relative;display:inline-grid;place-items:center;flex:0 0 auto;overflow:hidden;border:1px solid rgba(242,207,131,.42);border-radius:10px;background:linear-gradient(135deg,rgba(216,173,82,.28),rgba(21,27,27,.92));box-shadow:inset 0 1px 0 rgba(255,255,255,.08),0 4px 12px rgba(0,0,0,.2)}.portrait-image>img{width:100%;height:100%;object-fit:cover}.portrait-builtin{display:grid;place-items:center;background-repeat:no-repeat;background-size:200% 200%}.portrait-builtin i{display:none;font-style:normal;font-weight:700;color:var(--gold-2)}
+.npc-portrait-empty{width:56px;height:56px;border-style:dashed;background:rgba(15,18,18,.48);color:var(--muted);font-size:22px;font-weight:400}
 .portrait-picker{display:grid;gap:9px;padding:11px;border:1px solid var(--line-soft);border-radius:8px;background:rgba(216,173,82,.055)}.portrait-picker-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.portrait-picker-head>div{display:grid;gap:3px}.portrait-picker-head small{color:var(--muted)}.portrait-options{display:flex;align-items:center;gap:7px;flex-wrap:wrap}.portrait-option{min-width:0;padding:3px;border-radius:10px;background:rgba(14,18,18,.52)}.portrait-option.selected{border-color:var(--gold);box-shadow:0 0 0 2px rgba(216,173,82,.2)}.portrait-upload,.portrait-auto{min-height:38px}.portrait-picker>.form-hint{margin:0}
 .field-label-row{display:flex;align-items:center;justify-content:space-between;gap:10px}.field-label-row small{color:var(--muted);font-variant-numeric:tabular-nums}.character-background-input{min-height:180px;max-height:52vh;resize:vertical;field-sizing:content;line-height:1.65}
 .stat-row{margin:7px 0}
@@ -646,4 +647,33 @@ body.light .system-status-tag.tone-success{
 }
 @media(min-width:981px){
   .play-layout{height:calc(100dvh - 58px)}
+}
+
+/* Narrow desktop/tablet: keep the table viewport-sized and let GM controls
+   slide over the story instead of adding a second, page-height grid row. */
+@media(min-width:801px) and (max-width:980px){
+  .play-page{height:100dvh;min-height:0;display:flex;flex-direction:column;overflow:hidden}
+  .workspace .play-page{height:calc(100dvh - 56px)}
+  .play-layout,.workspace .play-layout{
+    position:relative;
+    flex:1 1 auto;
+    min-height:0;
+    height:auto;
+    overflow:hidden;
+    grid-template-columns:minmax(220px,250px) minmax(0,1fr) 48px;
+    grid-template-areas:"sidebar main controls";
+  }
+  .play-layout.collapsed{grid-template-columns:48px minmax(0,1fr) 48px}
+  .play-layout.no-console{grid-template-columns:minmax(220px,250px) minmax(0,1fr);grid-template-areas:"sidebar main"}
+  .play-layout.collapsed.no-console{grid-template-columns:48px minmax(0,1fr)}
+  .play-main .timeline-wrap{min-height:0}
+  .game-sidebar{max-height:none}
+  .play-control-rail{
+    width:min(340px,46vw);
+    max-height:none;
+    justify-self:end;
+    z-index:4;
+    box-shadow:-14px 0 28px rgba(0,0,0,.32);
+  }
+  .play-control-rail.collapsed{width:48px;box-shadow:none}
 }

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -407,6 +407,9 @@ class WebAPI:
     async def update_character(self, game_key: str, user_id: str, updates: dict) -> dict[str, Any]:
         return await characters.update_character(self, game_key, user_id, updates)
 
+    async def update_npc_portrait(self, game_key: str, npc_id: str, portrait: Any) -> dict[str, Any]:
+        return await characters.update_npc_portrait(self, game_key, npc_id, portrait)
+
     async def resolve_payment(self, game_key: str, payment_id: str, accepted: bool, session_uid: str = "") -> dict[str, Any]:
         return await characters.resolve_payment(self, game_key, payment_id, accepted, session_uid)
 

--- a/src/webui/routes/games.py
+++ b/src/webui/routes/games.py
@@ -478,6 +478,19 @@ async def api_char_delete(request: web.Request) -> web.Response:
     return web.json_response(await api.delete_character(gk, uid))
 
 
+async def api_npc_portrait_update(request: web.Request) -> web.Response:
+    gk = request.match_info["game_key"]
+    npc_id = request.match_info["npc_id"]
+    api = _get_api(request)
+    inst = request.app["subsystems"].registry.get(api._parse_key(gk))
+    if not inst:
+        return web.json_response({"error": "游戏不存在"}, status=404)
+    if request.get("user_id", "") != inst.gm_uid:
+        return web.json_response({"error": "仅 GM 可修改 NPC 头像"}, status=403)
+    body = await request.json()
+    return web.json_response(await api.update_npc_portrait(gk, npc_id, body.get("portrait")))
+
+
 async def api_player_create(request: web.Request) -> web.Response:
     gk = request.match_info["game_key"]
     body = await request.json()
@@ -694,6 +707,7 @@ def register_games(app: web.Application) -> None:
     app.router.add_get("/api/games/{game_key}/export", api_export_game)
     app.router.add_route("PUT", "/api/games/{game_key}/character/{user_id}", api_char_update)
     app.router.add_route("DELETE", "/api/games/{game_key}/character/{user_id}", api_char_delete)
+    app.router.add_route("PUT", "/api/games/{game_key}/npc/{npc_id}/portrait", api_npc_portrait_update)
     app.router.add_post("/api/games/{game_key}/players", api_player_create)
     app.router.add_post("/api/games/{game_key}/verify-room-password", api_verify_room_password)
     app.router.add_post("/api/games/{game_key}/room-password", api_set_room_password)

--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -378,6 +378,62 @@ async def update_character(api: "WebAPI", game_key: str, user_id: str, updates: 
     return {"ok": True}
 
 
+def _validated_portrait(api: "WebAPI", portrait: Any) -> dict[str, str] | None:
+    if portrait is None:
+        return None
+    if not isinstance(portrait, dict):
+        raise ValueError("头像数据无效")
+    kind = str(portrait.get("kind") or "")
+    if kind == "builtin":
+        portrait_id = str(portrait.get("id") or "")
+        if not portrait_id or len(portrait_id) > 100:
+            raise ValueError("内置头像编号无效")
+        return {"kind": "builtin", "id": portrait_id}
+    if kind == "upload":
+        asset_id = str(portrait.get("asset_id") or "")
+        if not asset_id or api.avatar_file(asset_id) is None:
+            raise ValueError("上传头像不存在")
+        return {"kind": "upload", "asset_id": asset_id}
+    raise ValueError("头像类型无效")
+
+
+async def update_npc_portrait(api: "WebAPI", game_key: str, npc_id: str, portrait: Any) -> dict[str, Any]:
+    inst = api._reg.get(api._parse_key(game_key))
+    if not inst:
+        return {"ok": False, "error": "游戏不存在"}
+    npc_key = str(npc_id or "").strip()
+    if not npc_key:
+        return {"ok": False, "error": "NPC 不存在"}
+    npc = inst.npcs.get(npc_key)
+    if npc is None:
+        for key, candidate in inst.npcs.items():
+            if str(candidate.get("id") or candidate.get("npc_id") or "") == npc_key:
+                npc_key, npc = key, candidate
+                break
+    if npc is None and api._lore and inst.world_id:
+        entry = api._lore.get_entry(npc_key)
+        if entry and entry.get("world_id") == inst.world_id and entry.get("type") == "npc":
+            name = str(entry.get("name") or npc_key)
+            npc = {
+                "name": name,
+                "character_name": name,
+                "tier": entry.get("tier", ""),
+            }
+            inst.npcs[npc_key] = npc
+    if npc is None:
+        return {"ok": False, "error": "NPC 不存在"}
+    try:
+        normalized = _validated_portrait(api, portrait)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    if normalized is None:
+        npc.pop("portrait", None)
+    else:
+        npc["portrait"] = normalized
+    await api._reg.save(inst)
+    return {"ok": True, "portrait": npc.get("portrait")}
+
+
 async def resolve_payment(api: "WebAPI", game_key: str, payment_id: str, accepted: bool, session_uid: str = "") -> dict[str, Any]:
     inst = api._reg.get(api._parse_key(game_key))
     if not inst:

--- a/tests/test_webui_create_flow.py
+++ b/tests/test_webui_create_flow.py
@@ -1022,6 +1022,37 @@ async def test_character_wizard_update_changes_display_name_and_sheet(web_api):
 
 
 @pytest.mark.asyncio
+async def test_npc_portrait_is_explicit_and_persisted(web_api):
+    api, _lorebook, registry, _fake_llm, _worlds_dir = web_api
+    created = await api.create_game(
+        "template_world",
+        "NPC 头像测试",
+        players=[{"character_name": "主持人", "attributes": {"str": 10}}],
+        gm_uid="web_session_gm",
+    )
+    inst = registry.get(api._parse_key(created["game_key"]))
+    inst.npcs["npc-guide"] = {"name": "向导", "character_name": "向导"}
+
+    before = api.list_characters(created["game_key"])["npcs"][0]
+    assert "portrait" not in before
+
+    updated = await api.update_npc_portrait(
+        created["game_key"],
+        "npc-guide",
+        {"kind": "builtin", "id": "freeform_fantasy:5"},
+    )
+    assert updated == {
+        "ok": True,
+        "portrait": {"kind": "builtin", "id": "freeform_fantasy:5"},
+    }
+    assert inst.npcs["npc-guide"]["portrait"] == updated["portrait"]
+
+    reset = await api.update_npc_portrait(created["game_key"], "npc-guide", None)
+    assert reset == {"ok": True, "portrait": None}
+    assert "portrait" not in inst.npcs["npc-guide"]
+
+
+@pytest.mark.asyncio
 async def test_create_player_allows_overpointed_sheet(web_api):
     api, _lorebook, registry, _fake_llm, _worlds_dir = web_api
     created = await api.create_game(


### PR DESCRIPTION
## 改动

- 修复 801–980px 窄桌面/平板窗口中 GM 控制栏堆到左侧后造成的底部空白与页面过长。
- GM 控制栏在该区间改为右侧覆盖式抽屉：收起保留 48px，展开独立滚动，不再撑高页面。
- 角色管理中的 NPC 默认显示空头像，只有 GM 明确选择或上传后才配置头像。
- NPC 头像选择沿用当前游戏规则的 8 张内置头像，并支持自定义上传；选择持久化到游戏存档。
- 新增 GM-only NPC 头像更新接口及服务验证。

## 兼容性

- 不改变 800px 以下手机布局和 981px 以上宽屏布局。
- 不修改现有玩家头像、角色卡头像或旧存档结构；没有头像的 NPC 保持无头像。

## 验证

- `python scripts/healthcheck.py`
- 575 个后端测试通过
- 39 个前端单元测试通过
- 前端 lint、typecheck、生产构建通过
- API 合约、架构及乱码检查通过