### PR TITLE
release: prepare DiceFrame v1.8.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,61 +1,72 @@
-# DiceFrame v1.8.2
+# DiceFrame v1.8.3
 
 ## 中文
 
-这个版本在完整角色与跨端游玩体验的基础上，修复窄桌面窗口下的游玩页布局，并完善 NPC 头像管理；同时沿用 v1.8.1 的全部功能与修复记录。
+这个版本在完整角色与跨端游玩体验的基础上，重构检定触发为数据驱动的多语言词表：修正「观察」类动作的检定归属（DND 5e 下改为感知检定，不再误判为智力），英文触发词改为整词匹配以消除误报，并让词表随规则走——不同规则自动对应各自的骰制。同时沿用 v1.8.2 的全部功能与修复记录。
 
 ### 新功能
 
-- 新增独立角色库：无需先创建游戏即可建卡、编辑和保存角色，并记录所属规则；跨规则使用时会明确提示转换，旧角色卡仍可继续读取。
-- 新增角色头像系统：内置六套规则主题头像，每套 8 张，支持稳定自动分配和 PNG/JPEG/WebP 自定义上传；头像会显示在角色状态、对话时间线和分享建卡页中，玩家与 GM 可在游玩页直接更换。
-- 新增幸运改判流程：支持的 d100 规则在失败后会暂停结算，玩家可直接选择消耗对应点数的幸运改为成功，或保留失败；Web、QQ/NapCat 与外部 Bot Bridge 共用同一套持久化判定，避免重复扣除。
-- 扩展插件管理：插件主题、内容资源、工具和市场状态使用统一描述与独立界面逻辑，安装、更新和能力展示更清晰。
+- 检定触发改为数据驱动词表：内置 6 类意图（潜行/调查/感知/社交/运动/战斗）+ 通用检定，中英文双份、覆盖 400+ 常见触发词；规则模板可继承或覆盖词表，自定义规则也能定义自己的判定方式。
+- 修正「观察」类动作的判定：在 D&D 5e 等 d20 规则下，观察周围/看看/张望/瞅瞅/环视等动作改为感知检定（Wisdom），不再错误地走智力检定；在 CoC 规则下自动走「侦查」技能检定（d100）。
+- 检定按规则对应骰子：同一动作在 d20 规则（dnd5e / 自由奇幻 / 武侠 / 赛博朋克）走属性检定 vs DC，在 CoC（freeform_coc）走 d100 技能阈值，在无骰规则（tavern_free）不触发检定。
+- 英文触发词支持：英文玩家用自然语言（look around / sneak / persuade / attack 等）即可触发检定，且使用整词边界匹配，避免「roll」误命中「scroll」这类误报。
+- 为后续多语言扩展预留结构：词表按语言键组织，新增语言只需补对应语言列与后缀登记，不改判定逻辑。
 
 ### 优化与修复
 
-- 修复 801–980px 宽度下 GM 控制栏收起后留下大块空白、展开后页面过长的问题；控制栏改为右侧浮层抽屉，并支持独立滚动。
-- 完善 NPC 头像管理：未明确设置头像的 NPC 默认显示空头像，不再自动套用规则头像；GM 可在角色管理中点击头像，从当前规则的 8 张内置头像中选择或上传自定义图片，选择结果随存档持久化。
-- 将内置头像图集改为适配界面分辨率的高质量 WebP，并让便携包只保留运行所需的编译产物；发布流程会阻止 PNG 图集回流、头像重复打包和体积异常增长。
-- 加强模型输出协议隔离：异常的状态标签、检定标签和修复文本不会再混入公开叙事；必要时自动进行一次格式修复重试。
-- Token 自动升档成功后会在 GM 页面显示低干扰提示，便于发现默认预算不足；截断重试会记录实际使用档位。
+- 消除检定判定两条路径不一致：属性推断（`_guess_attribute_key`）与意图识别共用同一份词表，同一句「观察」不再出现一边走感知、一边走智力。
+- 修复英文局基本无法触发检定的问题：此前触发词几乎全为中文，英文局只能靠 UI 手动选择；现在英文触发词与整词边界匹配一起补齐。
+- 通用检定词改走词表：避免「roll/check」在英文句中误命中单词内部的子串。
 - 世界模板、世界书和角色卡按内容语言筛选，减少中英文内容混杂。
-- 优化 QQ/NapCat 与 Bot Bridge：补充幸运选择、英文消息、扩展协议和 Web 同步去重；已删除游戏的失效绑定会在连续确认后自动清理。
-- 修复分享建卡长页面背景断层、公开分享页错误请求后台更新/插件接口，以及 GM 游玩页头像无法点击的问题。
-- 改进回合回滚、待处理检定恢复、运行时配置热更新和 SSE 身份票据，降低重启或配置更新对正在进行对局的影响。
-- 便携版更新现在明确只保留当前与上一套程序文件，并在后续更新成功后清理根目录旧版 `app/`、`python/`，同时保留 `data/`、`logs/` 和启动器。
+- 强化模型输出协议隔离：异常的状态标签、检定标签和修复文本不会混入公开叙事。
+- 改进回合回滚、待处理检定恢复、运行时配置热更新和 SSE 身份票据。
+
+### 自 v1.8.2 以来的完整功能（合并发布）
+
+- 新增独立角色库：无需先创建游戏即可建卡、编辑和保存角色，并记录所属规则；跨规则使用时会明确提示转换，旧角色卡仍可继续读取。
+- 新增角色头像系统：内置六套规则主题头像，每套 8 张，支持稳定自动分配和 PNG/JPEG/WebP 自定义上传；头像会显示在角色状态、对话时间线和分享建卡页中。
+- 新增幸运改判流程：支持的 d100 规则在失败后会暂停结算，玩家可直接选择消耗对应点数的幸运改为成功，或保留失败；Web、QQ/NapCat 与外部 Bot Bridge 共用同一套持久化判定。
+- 扩展插件管理：插件主题、内容资源、工具和市场状态使用统一描述与独立界面逻辑。
+- 修复 801–980px 宽度下 GM 控制栏布局问题；完善 NPC 头像管理；内置头像改为高质量 WebP 并精简便携包体积。
+- Token 自动升档成功后显示低干扰提示；优化 QQ/NapCat 与 Bot Bridge 的幸运选择、英文消息、扩展协议和 Web 同步去重。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.8.2-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.8.2-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.8.3-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.8.3-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release builds on the complete character and cross-client play experience, fixes the play layout at narrow desktop widths, and completes NPC portrait management. It retains the full feature and fix history from v1.8.1 below.
+This release rebuilds check triggering on a data-driven multilingual keyword table: "observe"-style actions now resolve to the correct check (Perception instead of Intelligence under D&D 5e), English trigger words use word-boundary matching to avoid false positives, and the table follows the active ruleset so each rule keeps its own dice system. It retains the full feature and fix history from v1.8.2 below.
 
 ### New Features
 
-- Added a standalone character library. Create, edit, and save characters without starting a game, retain their ruleset identity, receive explicit cross-ruleset conversion warnings, and keep legacy cards readable.
-- Added character portraits with six ruleset-themed packs of eight portraits each, stable automatic assignment, and custom PNG/JPEG/WebP uploads. Portraits appear in character status, conversation timelines, and shared character creation; players and GMs can change them from the play view.
-- Added a Luck-spend decision flow for supported d100 rules. A failed check pauses before narration so the player can spend the exact Luck difference to succeed or keep the failure. Web, QQ/NapCat, and external Bot Bridge clients share the same persisted, idempotent decision.
-- Expanded plugin management with unified descriptors and separated views for themes, content resources, tools, marketplace state, installation, and updates.
+- Data-driven check intents: six intents (stealth / investigate / perception / social / athletics / combat) plus generic checks, in both Chinese and English with 400+ common trigger phrases. Rule templates can inherit or override the table, so custom rules define their own check behavior.
+- Fixed "observe"-style actions: under d20 rules (D&D 5e etc.), actions like observe / look around / glance / scan now resolve to a Perception (Wisdom) check instead of an Intelligence check; under CoC they resolve to a Spot Hidden skill check (d100).
+- Checks follow the ruleset's dice system: the same action uses attribute-vs-DC under d20 rules (dnd5e / freeform fantasy / wuxia / cyberpunk), a d100 skill threshold under CoC, and no check at all under dice-less rules (tavern_free).
+- English trigger words: English players can trigger checks with natural language (look around / sneak / persuade / attack), and matching uses word boundaries so "roll" no longer falsely matches "scroll".
+- Structure ready for more languages: alias lists are keyed by language, so adding a language only requires new language columns plus a suffix registration, not logic changes.
 
 ### Improvements and Fixes
 
-- Fixed the GM control rail at 801–980px widths so collapsing it no longer leaves a large empty area and expanding it no longer stretches the page. It is now a right-side overlay drawer with independent scrolling.
-- Completed NPC portrait management. NPCs without an explicitly selected portrait now show an empty placeholder instead of receiving an automatic ruleset portrait; GMs can click the portrait in character management to choose from all eight portraits for the current ruleset or upload a custom image, with the choice persisted in the save.
-- Converted built-in portrait atlases to high-quality, UI-sized WebP assets and removed frontend source copies from portable packages. Release validation now blocks legacy PNG atlases, duplicate portable assets, and future portrait-size regressions.
-- Strengthened model-output protocol isolation so malformed state tags, check tags, and repair text no longer leak into public narration; one strict format-repair retry is used when needed.
-- Added a subtle GM notice when automatic token-budget escalation succeeds, and retained the actual successful retry budget for diagnostics.
+- Unified the two check-resolution paths: attribute guessing and intent recognition now share one keyword table, so "observe" can no longer resolve to Wisdom on one path and Intelligence on another.
+- Fixed English games being unable to trigger checks from free text: trigger words were almost all Chinese, so English games relied on manual UI selection.
+- Generic check words now use the keyword table, avoiding substring false positives like "roll" inside other words.
 - Filtered world templates, lorebooks, and character cards by content language to reduce mixed Chinese and English content.
-- Improved QQ/NapCat and Bot Bridge behavior with Luck decisions, English responses, extension handling, Web-sync deduplication, and confirmed cleanup of bindings for deleted games.
-- Fixed the shared character-creation background ending before long forms, unauthorized owner-only requests on public share pages, and non-clickable GM portraits in the play view.
-- Improved round rollback, pending-check recovery, transactional runtime configuration reloads, and SSE identity tickets to reduce disruption to active games.
-- Clarified portable update retention: only the current and previous application payloads are kept, obsolete root `app/` and `python/` payloads are removed after later successful updates, and `data/`, `logs/`, and the launcher remain untouched.
+- Strengthened model-output protocol isolation so malformed state tags, check tags, and repair text no longer leak into public narration.
+
+### Full History From v1.8.2 (Included in This Release)
+
+- Standalone character library: create, edit, and save characters without starting a game, keep ruleset identity, receive explicit cross-ruleset conversion warnings, and keep legacy cards readable.
+- Character portraits: six ruleset-themed packs of eight portraits each, stable automatic assignment, and custom PNG/JPEG/WebP uploads shown in character status, timelines, and shared character creation.
+- Luck-spend decision flow for supported d100 rules: a failed check pauses before narration so the player can spend the exact Luck difference to succeed or keep the failure; shared, idempotent persistence across Web, QQ/NapCat, and external Bot Bridge.
+- Expanded plugin management with unified descriptors and separated views for themes, content, tools, marketplace, installation, and updates.
+- Fixed GM control rail layout at 801–980px; completed NPC portrait management; converted built-in portraits to high-quality UI-sized WebP and slimmed the portable package.
+- Low-disturbance notice when automatic token-budget escalation succeeds; improved QQ/NapCat and Bot Bridge luck, English responses, extension handling, and Web-sync deduplication.
 
 ### Download Guide
 
-- **Most Windows users**: Download `DiceFrame-v1.8.2-windows-portable.zip`.
-- **Source package users**: Download `DiceFrame-v1.8.2-windows.zip`.
+- **Most Windows users**: Download `DiceFrame-v1.8.3-windows-portable.zip`.
+- **Source package users**: Download `DiceFrame-v1.8.3-windows.zip`.
 - `.sha256` files are used for update verification and do not need to be downloaded manually.

--- a/src/commands/dice_resolver.py
+++ b/src/commands/dice_resolver.py
@@ -485,19 +485,20 @@ class DiceResolver:
 
     @staticmethod
     def _guess_attribute_key(actions_text: str, rule: RuleSystem) -> str:
-        hints = [
-            ("dex", ("敏捷", "潜行", "躲", "闪", "射击", "弓", "跳", "攀", "快")),
-            ("str", ("力量", "攻击", "砍", "劈", "推", "撬", "举", "格斗")),
-            ("con", ("体质", "忍耐", "抗", "承受", "耐力")),
-            ("int", ("智力", "调查", "破解", "分析", "知识", "研究", "黑入", "维修")),
-            ("wis", ("感知", "观察", "侦查", "聆听", "察觉", "追踪")),
-            ("cha", ("魅力", "说服", "欺骗", "威胁", "交涉", "表演")),
-        ]
-        keys = set(rule.attribute_keys)
-        for key, words in hints:
-            if key in keys and any(word in actions_text for word in words):
-                return key
-        return "dex" if "dex" in keys else (rule.attribute_keys[0] if rule.attribute_keys else "dex")
+        """从规则词表推断属性：命中意图取该意图的默认属性，过滤到规则合法属性键。
+
+        与 src/engine/checks.py 共享同一份 intents 词表，避免两条路径对同一
+        文本给出不同属性（旧实现是单独硬编码的提示词表）。
+        """
+        if rule:
+            intent = rule.find_intent(actions_text, "")
+            if intent:
+                attr = rule.intent_default_attribute(intent)
+                if attr in rule.attribute_keys:
+                    return attr
+        if rule and "dex" in rule.attribute_keys:
+            return "dex"
+        return rule.attribute_keys[0] if rule and rule.attribute_keys else "dex"
 
     @staticmethod
     def _dnd5e_advantage_mode(actions_text: str, action: dict, rule: RuleSystem) -> tuple[str, str]:

--- a/src/engine/checks.py
+++ b/src/engine/checks.py
@@ -127,13 +127,20 @@ def build_check_request(
     candidates: tuple[str, ...] = ()
     attribute = selected_attribute
 
-    for intent_name, aliases, skill_candidates, attr_key in _INTENT_SPECS:
-        if any(_normalized(alias) in text for alias in aliases):
-            intent = intent_name
-            candidates = skill_candidates
-            if not attribute:
-                attribute = attr_key
-            break
+    # 意图识别：优先规则词表（数据驱动），规则未带词表时回退到内置 _INTENT_SPECS。
+    intent = rule.find_intent(action.get("text"), instance.language, dice_system) if rule else ""
+    if intent:
+        candidates = rule.intent_skill_candidates(intent, instance.language) if rule else ()
+        if not attribute:
+            attribute = rule.intent_default_attribute(intent) if rule else ""
+    else:
+        for intent_name, aliases, skill_candidates, attr_key in _INTENT_SPECS:
+            if any(_normalized(alias) in text for alias in aliases):
+                intent = intent_name
+                candidates = skill_candidates
+                if not attribute:
+                    attribute = attr_key
+                break
 
     direct_skill = _find_skill(character_sheet, text, ())
     skill = selected_skill or direct_skill
@@ -141,7 +148,16 @@ def build_check_request(
         skill = _find_skill(character_sheet, text, candidates)
 
     explicit_check = bool(selected_skill or selected_attribute)
-    generic_check = any(word in text for word in _GENERIC_CHECK_WORDS)
+    # 通用检定词：优先用规则词表的 generic 意图（整词边界，避免 'roll' 命中
+    # 'scroll'）；规则没词表时回退内置 _GENERIC_CHECK_WORDS（子串）。
+    generic_check = False
+    if not explicit_check:
+        if rule and "generic" in rule.intents:
+            generic_check = rule.find_intent(
+                action.get("text"), instance.language, dice_system
+            ) == "generic"
+        else:
+            generic_check = any(word in text for word in _GENERIC_CHECK_WORDS)
     if not (explicit_check or intent or direct_skill or generic_check):
         return None
 

--- a/src/rules/rule_system.py
+++ b/src/rules/rule_system.py
@@ -9,7 +9,13 @@ import operator
 from collections.abc import Callable
 from pathlib import Path
 
-from src.engine.language import DEFAULT_LANGUAGE, field_suffixes, lang_suffix, localized_field
+from src.engine.language import (
+    DEFAULT_LANGUAGE,
+    field_suffixes,
+    lang_suffix,
+    localized_field,
+    normalize_language,
+)
 
 logger = logging.getLogger("trpg")
 
@@ -131,6 +137,123 @@ class RuleSystem:
             if localized.exists():
                 return localized
         return base
+
+    # ---- 检定意图（intents）----
+
+    @property
+    def intents(self) -> dict:
+        """检定意图表：{intent_id: {aliases, skill_candidates, default_attribute, priority}}。
+
+        从规则模板读取（可经 extends 继承），缺失时返回空 dict。
+        """
+        return self.template.get("intents") or {}
+
+    def intent_aliases(self, intent: str, language: str = "") -> tuple[str, ...]:
+        """某意图在指定语言下的触发词。按模板里登记的别名顺序返回。
+
+        优先取该语言的别名键（如 zh-CN / en）；缺失时回退到任意已有的语言键，
+        保证中英混写也能命中。找不到返回空元组。
+        """
+        block = self.intents.get(intent) or {}
+        aliases = block.get("aliases") or {}
+        lang = normalize_language(language)
+        if lang in aliases:
+            return tuple(aliases[lang])
+        # 回退：任意语言的别名都可用，避免纯中文规则在英文局完全失效。
+        for value in aliases.values():
+            if value:
+                return tuple(value)
+        return ()
+
+    def intent_skill_candidates(self, intent: str, language: str = "") -> tuple[str, ...]:
+        """某意图的技能候选词，用于按角色卡技能名做子串匹配。"""
+        block = self.intents.get(intent) or {}
+        candidates = block.get("skill_candidates") or {}
+        lang = normalize_language(language)
+        if lang in candidates:
+            return tuple(candidates[lang])
+        for value in candidates.values():
+            if value:
+                return tuple(value)
+        return ()
+
+    def intent_default_attribute(self, intent: str) -> str:
+        """某意图的默认属性键；无默认时返回空串。"""
+        return str((self.intents.get(intent) or {}).get("default_attribute") or "")
+
+    def intent_applies_to(self, intent: str, dice_system: str) -> bool:
+        """某意图是否适用于当前骰制（d20 / d100）。"""
+        block = self.intents.get(intent) or {}
+        allowed = block.get("applies_to_dice_systems")
+        if allowed is None:
+            allowed = (self.intents.get("defaults") or {}).get("applies_to_dice_systems")
+        if not allowed:
+            return True
+        return str(dice_system).lower() in allowed
+
+    def intent_match_mode(self, intent: str, language: str) -> str:
+        """语言对应的匹配方式：'word'（整词边界，英文）或 'substring'（中文）。"""
+        defaults = self.intents.get("defaults") or {}
+        if normalize_language(language) == "en":
+            return defaults.get("en_match", "word")
+        return defaults.get("zh_match", "substring")
+
+    def prefer_longest_match(self) -> bool:
+        return bool((self.intents.get("defaults") or {}).get("prefer_longest", True))
+
+    def generic_intent_id(self) -> str:
+        """通用检定意图 id；词表里没有则回退 'generic'。"""
+        return "generic" if "generic" in self.intents else "generic"
+
+    def find_intent(self, text: str, language: str = "", dice_system: str = "") -> str:
+        """扫描词表，返回命中的第一个意图 id（按 priority 升序，即先匹配者胜）。
+
+        返回空串表示没有命中任何意图。
+        """
+        source = str(text or "")
+        lang = normalize_language(language)
+        if lang != "en":
+            # 中文按去掉空白后的子串匹配（与 checks.py _normalized 一致）。
+            haystack = source.replace(" ", "").lower()
+            is_word_match = False
+        else:
+            haystack = source
+            is_word_match = True
+        entries = [
+            (intent, self.intents.get(intent) or {})
+            for intent in self.intents
+            if intent != "defaults"
+        ]
+        if not entries:
+            return ""
+        entries.sort(
+            key=lambda item: int(item[1].get("priority", 99)),
+        )
+        prefer_longest = self.prefer_longest_match()
+        best_intent = ""
+        best_len = 0
+        for intent, block in entries:
+            if not block.get("aliases"):
+                continue
+            if dice_system and not self.intent_applies_to(intent, dice_system):
+                continue
+            mode = self.intent_match_mode(intent, language)
+            matched_len = 0
+            for alias in self.intent_aliases(intent, language):
+                if not alias:
+                    continue
+                if is_word_match:
+                    import re
+
+                    if re.search(rf"\b{re.escape(alias)}\b", haystack):
+                        matched_len = max(matched_len, len(alias))
+                elif alias in haystack:
+                    matched_len = max(matched_len, len(alias))
+            if matched_len > 0:
+                if not prefer_longest or matched_len > best_len:
+                    best_len = matched_len
+                    best_intent = intent
+        return best_intent
 
     # ---- 属性 ----
 

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/templates/rules/base_d20.json
+++ b/templates/rules/base_d20.json
@@ -1,4 +1,5 @@
 {
+  "extends": "intents_base",
   "rule_version": "1.1",
   "rule_id": "base_d20",
   "rule_name": "d20 基础规则",

--- a/templates/rules/freeform_coc.json
+++ b/templates/rules/freeform_coc.json
@@ -1,4 +1,5 @@
 {
+  "extends": "intents_base",
   "rule_version": "1.2",
   "rule_id": "freeform_coc",
   "rule_name": "CoC 7e 调查恐怖轻量规则",

--- a/templates/rules/intents_base.json
+++ b/templates/rules/intents_base.json
@@ -1,0 +1,312 @@
+{
+  "rule_id": "intents_base",
+  "rule_name": "检定意图词表基础数据",
+  "abstract": true,
+  "intents": {
+    "defaults": {
+      "applies_to_dice_systems": ["d20", "d100"],
+      "zh_match": "substring",
+      "en_match": "word",
+      "case_sensitive": false,
+      "prefer_longest": true
+    },
+    "stealth": {
+      "aliases": {
+        "zh-CN": [
+          "潜行", "潜入", "隐匿", "隐藏", "躲藏", "潜伏", "悄悄", "偷偷", "偷偷摸摸",
+          "鬼鬼祟祟", "蹑手蹑脚", "悄无声息", "无声", "无声无息", "绕后", "摸进",
+          "摸上去", "溜进", "溜走", "偷溜", "闪进", "潜踪", "隐没", "隐身", "藏匿",
+          "隐蔽", "暗中", "屏息", "猫着腰", "潜步", "摸到背后", "潜近", "迂回",
+          "避人耳目", "藏身", "躲进", "尾随", "尾行", "跟梢", "趁人不注意",
+          "神不知鬼不觉", "神出鬼没", "无声潜入", "溜号", "偷溜出去"
+        ],
+        "en": [
+          "sneak", "sneak in", "sneak up", "stealth", "stealthy", "hide", "hiding",
+          "hide out", "conceal", "concealed", "conceal myself", "creep", "creep up",
+          "creep along", "slip", "slip in", "slip out", "slip past", "slip away",
+          "skulk", "lurk", "slink", "pad", "move silently", "move quietly", "be quiet",
+          "tiptoe", "tiptoe in", "noiseless", "undetected", "unnoticed", "unobserved",
+          "stay hidden", "keep hidden", "keep low", "duck behind", "duck into",
+          "stay out of sight", "keep out of sight", "fade into", "ghost past",
+          "ghost through", "shadow", "tail", "stalk", "infiltrate", "infiltrated",
+          "covert", "covertly", "ninja", "vanish", "disappear into", "blend in",
+          "melt into", "sneak around", "sneak behind", "behind their back", "quietly",
+          "keep to the shadows", "stick to the shadows", "hug the wall", "low profile",
+          "keep a low profile", "lie low", "stay low", "under cover",
+          "cover of darkness", "out of sight", "avoid notice", "avoid detection",
+          "escape notice"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["潜行", "隐匿", "潜伏", "躲藏"],
+        "en": ["stealth", "sleight of hand", "dexterity"]
+      },
+      "default_attribute": "dex",
+      "priority": 10
+    },
+    "investigate": {
+      "aliases": {
+        "zh-CN": [
+          "调查", "调查现场", "探查", "检查房间", "搜查", "搜寻", "翻找", "翻箱倒柜",
+          "寻找", "找线索", "寻线索", "查证", "核实", "验证", "核对", "排查",
+          "排查线索", "勘验", "勘测", "验尸", "尸检", "检查尸体", "检查痕迹",
+          "寻找痕迹", "辨认", "识别", "鉴定", "追踪", "追查", "跟踪", "顺藤摸瓜",
+          "追线索", "破案", "查案", "查资料", "查书", "翻阅", "翻查", "查阅", "检索",
+          "研究", "分析", "剖析", "推理", "推断", "推敲", "搜身", "摸尸", "搜刮",
+          "阅读", "看文件", "看资料", "看线索", "比对", "对照", "审阅", "观察细节",
+          "找细节", "发现线索", "推理一下", "想想", "思索", "琢磨", "思考", "动脑",
+          "动脑筋", "推理分析", "分析线索", "研究线索", "追根究底", "查明", "查清",
+          "弄清楚", "搞明白", "检查", "搜索", "探查"
+        ],
+        "en": [
+          "investigate", "investigation", "examine", "examination", "inspect",
+          "inspection", "scrutinize", "study", "analyze", "analyse", "analysis",
+          "research", "search", "searching", "search for clues", "look for clues",
+          "find clues", "hunt", "hunt for", "hunt for clues", "dig", "dig into",
+          "dig deeper", "probe", "look into", "check out", "check", "figure out",
+          "work out", "deduce", "deduction", "reason", "reasoning", "reason it out",
+          "solve", "crack", "decipher", "decode", "interpret", "read", "reading",
+          "go through", "go over", "rifle through", "sift through", "comb through",
+          "pore over", "search the body", "search the scene", "examine the scene",
+          "forensics", "forensic", "autopsy", "trace", "track", "track down",
+          "follow the trail", "follow up", "trail", "chase leads", "gather evidence",
+          "collect evidence", "evidence", "clues", "fingerprints", "verify", "confirm",
+          "double-check", "fact-check", "cross-reference", "archives", "records",
+          "files", "rummage", "magnify", "magnifying glass", "piece it together",
+          "connect the dots", "draw a conclusion", "test a theory",
+          "investigate the room", "search the room", "check the room",
+          "examine the room", "case the place", "follow the money",
+          "follow the paper trail", "audit", "do the math"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["侦查", "调查", "搜索", "图书馆使用", "追踪", "开锁"],
+        "en": ["investigation", "perception", "library use", "research", "search"]
+      },
+      "default_attribute": "int",
+      "priority": 20
+    },
+    "perception": {
+      "aliases": {
+        "zh-CN": [
+          "观察", "看看", "看一看", "张望", "瞅", "瞅瞅", "环视", "环顾", "环顾四周",
+          "扫视", "打量", "瞄", "瞄一眼", "看", "看着", "窥视", "偷窥", "眺望", "远眺",
+          "瞭望", "巡视", "观望", "端详", "凝视", "凝望", "注视", "盯着", "盯", "瞥",
+          "瞥一眼", "偷瞄", "望", "远望", "察觉", "发觉", "发现", "留意", "留心",
+          "留神", "注意", "注意到", "听", "听见", "听到", "聆听", "倾听", "偷听",
+          "窃听", "感觉", "感到", "闻到", "嗅到", "嗅", "察觉异常", "觉得不对",
+          "觉得不对劲", "有预感", "第六感", "直觉", "感应", "感知", "警觉", "警戒",
+          "警惕", "提防", "小心", "四下张望", "东张西望", "打量四周", "看看四周",
+          "看看周围", "四周看看", "查看", "察看", "查看周围", "观察四周", "扫视全场",
+          "目光扫过", "视线扫过", "抬眼", "抬头看", "望向", "盯着看", "认真看",
+          "仔细看", "仔细观察", "侦查", "侦察", "侦查四周", "侦察四周"
+        ],
+        "en": [
+          "perceive", "perception", "observe", "observing", "observation", "look",
+          "look at", "look around", "look about", "look over", "look closely",
+          "have a look", "take a look", "take a good look", "get a look at", "glance",
+          "glance around", "glance over", "glance at", "scan", "scanning", "survey",
+          "watch", "watching", "watch for", "keep watch", "look out", "keep an eye",
+          "keep an eye out", "look out for", "see", "seeing", "spot", "notice",
+          "catch sight of", "glimpse", "peek", "peek at", "peek around", "peer",
+          "peer at", "peer into", "squint", "scrutinize", "take in", "take it all in",
+          "absorb", "listen", "listen for", "listen closely", "listen carefully",
+          "hear", "hearing", "overhear", "eavesdrop", "strain to hear", "make out",
+          "detect", "detection", "discern", "sense", "feel", "smell", "sniff",
+          "sniff the air", "taste", "register", "note", "eyeball", "gander",
+          "looksee", "reconnoiter", "recon", "scout", "alert", "vigilant",
+          "on guard", "be on the lookout", "watchful", "attentive", "pay attention",
+          "pick up on", "gut feeling", "hunch", "sixth sense", "intuition",
+          "sweep the room", "sweep the area", "scan the room", "listen for footsteps"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["侦查", "聆听", "察觉", "感知", "观察"],
+        "en": ["perception", "investigation", "spot hidden", "listen"]
+      },
+      "default_attribute": "wis",
+      "priority": 30
+    },
+    "social": {
+      "aliases": {
+        "zh-CN": [
+          "说服", "劝服", "劝说", "劝导", "游说", "交涉", "谈判", "协商", "商议",
+          "商讨", "讨价还价", "砍价", "讲价", "杀价", "议价", "欺骗", "骗", "哄骗",
+          "蒙骗", "欺诈", "忽悠", "画饼", "画大饼", "威吓", "恐吓", "威胁", "恫吓",
+          "吓唬", "威胁恐吓", "套话", "套取", "套近乎", "打听", "探听", "询问", "问",
+          "提问", "质询", "质问", "盘问", "审问", "审讯", "逼问", "套问", "表演",
+          "演戏", "装", "伪装", "假装", "扮", "乔装", "化装", "撒谎", "说谎", "吹牛",
+          "吹嘘", "自夸", "炫耀", "迷惑", "魅惑", "诱惑", "引诱", "勾引", "撩",
+          "调情", "讨好", "巴结", "奉承", "拍马屁", "阿谀", "谄媚", "请托", "恳求",
+          "哀求", "祈求", "请求", "提议", "结盟", "拉拢", "招揽", "招募", "演讲",
+          "演说", "号召", "鼓动", "煽动", "激将", "安抚", "劝慰", "安慰", "调停",
+          "调解", "斡旋", "打圆场", "说情", "求情", "贿赂", "行贿", "收买", "买通",
+          "讹诈", "敲诈", "勒索", "社交", "寒暄", "搭讪", "攀谈", "闲聊", "聊天",
+          "八卦", "传话", "放话", "吹捧", "恭维", "赞美"
+        ],
+        "en": [
+          "persuade", "persuasion", "convince", "talk into", "talk out of",
+          "talk around", "talk down", "coax", "cajole", "sweet-talk", "sweet talk",
+          "charm", "beguile", "captivate", "win over", "sway", "influence",
+          "negotiate", "negotiation", "negotiations", "bargain", "barter", "haggle",
+          "deal", "make a deal", "cut a deal", "broker", "mediate", "mediation",
+          "deception", "deceive", "deceiving", "lie", "lying", "bluff", "con", "scam",
+          "swindle", "hustle", "manipulate", "manipulation", "gaslight", "fool",
+          "mislead", "misdirect", "intimidate", "intimidation", "threaten", "threat",
+          "menace", "bully", "browbeat", "coerce", "coercion", "strong-arm", "press",
+          "pressure", "order", "command", "demand", "bluster", "interrogate",
+          "question", "quiz", "grill", "probe", "pry", "fish", "fish for",
+          "pump for info", "extract info", "perform", "performance", "act", "acting",
+          "put on", "feign", "pretend", "bluff your way", "fast-talk", "fast talk",
+          "flatter", "flattery", "butter up", "schmooze", "suck up", "kiss up",
+          "grovel", "beg", "plead", "implore", "entreat", "beseech", "appeal",
+          "petition", "request", "ask", "propose", "proposition", "pitch",
+          "sales pitch", "recruit", "recruiting", "rally", "inspire", "exhort",
+          "incite", "taunt", "mock", "insult", "banter", "tease", "joke", "seduce",
+          "flirt", "hit on", "socialize", "mingle", "chat", "small talk", "gossip",
+          "spin", "spin a story", "argue", "debate", "reason with", "talk sense into",
+          "comfort", "console", "reassure", "calm down", "de-escalate",
+          "smooth things over", "make peace", "apologize", "trade favors",
+          "call in a favor", "win their trust", "bribe", "bribery", "buy off",
+          "pay off", "blackmail", "extort", "shake down", "grift", "network",
+          "backroom deal"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["说服", "话术", "魅惑", "威吓", "欺骗", "表演", "心理学"],
+        "en": ["persuasion", "intimidation", "deception", "performance", "insight", "charm"]
+      },
+      "default_attribute": "cha",
+      "priority": 40
+    },
+    "athletics": {
+      "aliases": {
+        "zh-CN": [
+          "攀爬", "攀", "攀登", "攀岩", "爬", "爬上去", "爬上", "爬下", "爬墙", "翻越",
+          "翻过", "跳过", "跳跃", "跳", "蹦", "跃", "跃过", "跳远", "跳高", "跳水",
+          "游泳", "游", "泅渡", "潜水", "冲刺", "全力奔跑", "奔跑", "跑", "疾跑",
+          "狂奔", "追赶", "追逐", "追", "逃", "逃跑", "逃离", "逃脱", "挣脱",
+          "挣脱束缚", "甩开追兵", "推开", "推", "拉开", "拉", "撬开", "撬", "撬动",
+          "撞开", "撞", "冲撞", "撞门", "踹门", "踢开", "搬起", "搬", "举起", "举",
+          "抬", "抬起", "扛", "扛起", "抱", "抱起", "托举", "拎起", "拖", "拖动",
+          "拽", "拉拽", "拽开", "掰开", "拧开", "扭开", "压住", "顶住", "挡住",
+          "撑住", "稳住", "站稳", "保持平衡", "平衡", "走钢丝", "悬垂", "抓住",
+          "抓稳", "攀住", "挂住", "扒住", "徒手", "较劲", "角力", "摔跤", "扳手腕",
+          "拔河", "比力气", "举重", "硬拉", "翻墙", "越墙", "跳上", "跳下", "跳过去",
+          "跨过去", "越过", "渡河", "蹚水"
+        ],
+        "en": [
+          "climb", "climbing", "scale", "scaling", "clamber", "scramble", "shin",
+          "shin up", "ascend", "crawl", "rappel", "abseil", "jump", "jumping", "leap",
+          "bound", "vault", "hurdle", "hop", "skip", "dive", "dive into", "swim",
+          "swimming", "swim across", "wade", "wade across", "ford", "cross the river",
+          "sprint", "run", "running", "run for", "dash", "bolt", "race", "flee",
+          "fleeing", "escape", "escaping", "getaway", "make a run for it",
+          "break free", "struggle free", "wrench", "wrench free", "pull", "push",
+          "shove", "heave", "shove open", "shove aside", "force open", "force the door",
+          "break open", "bust open", "batter down", "break down", "kick in", "ram",
+          "lift", "lifting", "raise", "hoist", "haul", "heft", "carry", "lug", "drag",
+          "tow", "yank", "tug", "pry", "pry open", "lever", "prise", "wrestle",
+          "grapple", "strain", "muscle", "brute force", "overpower", "strong-arm",
+          "bench press", "deadlift", "hold the door", "brace", "brace yourself",
+          "keep balance", "balance on", "tightrope", "cross the gap", "jump the gap",
+          "hang", "hang from", "hold on", "grab hold", "grab", "cling", "cling to",
+          "pull yourself up", "haul yourself up", "squeeze through", "squeeze past",
+          "wiggle through", "shimmy", "hand over hand", "pull-up", "chin-up", "grip",
+          "handhold", "foothold", "leverage", "swing across", "zipline", "acrobatics",
+          "parkour", "free run", "leap of faith"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["攀爬", "游泳", "跳跃", "运动", "体能"],
+        "en": ["athletics", "acrobatics"]
+      },
+      "default_attribute": "str",
+      "priority": 50
+    },
+    "combat": {
+      "aliases": {
+        "zh-CN": [
+          "攻击", "攻击他", "进攻", "出击", "开打", "打", "动手", "出手", "挥剑",
+          "挥砍", "劈", "砍", "斩", "斩击", "削", "刺", "戳", "捅", "扎", "突刺",
+          "冲锋", "突击", "突袭", "偷袭", "伏击", "射击", "开枪", "开枪射击", "开火",
+          "狙击", "扫射", "连射", "点射", "射", "射箭", "拉弓", "搭箭", "开弓", "扔",
+          "投掷", "掷", "丢", "抛", "投石", "飞刀", "格挡", "抵挡", "招架", "挡开",
+          "拨开", "闪避", "躲避", "躲开", "避开", "闪开", "闪身", "侧身", "翻滚",
+          "后撤", "后跳", "施法", "施放法术", "放法术", "释放法术", "咏唱", "吟唱",
+          "念咒", "施咒", "凝聚法力", "引导法术", "近战", "肉搏", "拳打", "揍", "捶",
+          "抓", "咬", "扑", "扑咬", "撞", "顶", "抱摔", "擒拿", "制伏", "压制",
+          "缴械", "夺武器", "防御", "防守", "抵御", "格斗", "搏斗", "缠斗", "混战",
+          "激战", "挥拳", "出拳", "拳击", "掌击", "肘击", "膝撞", "踢", "踢腿",
+          "飞踢", "鞭腿", "拔刀", "出刀", "斩向", "砍向", "刺向", "袭向", "扑向",
+          "冲向", "杀", "击杀", "砍杀", "格杀", "歼灭", "扫荡", "突围", "决斗",
+          "单挑", "挑战", "开战", "战斗", "交战", "瞄准", "瞄准射击", "扣动扳机",
+          "上膛", "装填", "躲子弹", "火力掩护", "掩护", "断后", "殿后", "召唤",
+          "魔法攻击", "法术攻击"
+        ],
+        "en": [
+          "attack", "attacking", "strike", "strike at", "hit", "punch", "swing",
+          "swing at", "slash", "slice", "cut", "cleave", "chop", "stab", "thrust",
+          "lunge", "jab", "poke", "pierce", "impale", "shoot", "shooting", "fire",
+          "open fire", "gun down", "snipe", "spray", "unload", "let off",
+          "pull the trigger", "aim", "aim at", "take aim", "target", "engage",
+          "charge", "rush", "rush at", "lunge at", "dive at", "pounce", "tackle",
+          "grapple", "wrestle", "kick", "roundhouse", "knee", "elbow", "headbutt",
+          "bite", "claw", "swipe", "maul", "smash", "bash", "clobber", "bludgeon",
+          "club", "batter", "swing the sword", "blade", "draw the blade", "unsheathe",
+          "duel", "parry", "block", "defend", "defend against", "dodge", "duck",
+          "weave", "sidestep", "roll away", "evade", "take cover", "duck behind",
+          "counter", "counterattack", "riposte", "flurry", "combo", "rapid strikes",
+          "cast", "casting", "cast a spell", "spell", "magic", "arcane",
+          "incantation", "chant", "invoke", "summon", "conjure", "weave magic",
+          "unleash", "blast", "fireball", "bolt", "ray", "necromancy", "enchant",
+          "buff", "heal", "cure", "smite", "holy", "divine", "elemental", "flame",
+          "lightning", "frost", "poison", "venom", "breath weapon", "shapeshift",
+          "transform", "rage", "frenzy", "berserk", "power attack", "reckless",
+          "sneak attack", "ambush", "flank", "surround", "corner", "pin down",
+          "suppress", "overwatch", "hold the line", "hold them off", "fight back",
+          "fight off", "fend off", "keep at bay", "retreat", "withdraw", "disengage",
+          "fall back", "pull back", "breach", "storm", "siege", "raid", "kill",
+          "killing", "slay", "slaughter", "butcher", "vanquish", "defeat", "subdue",
+          "disarm", "trip", "throw", "throw a weapon", "hurl", "lob", "chuck",
+          "fling", "grenade", "molotov", "bomb", "explosive", "detonate", "blow up",
+          "demolish", "melee", "close combat", "hand-to-hand", "fistfight", "brawl",
+          "fight", "fighting", "combat", "battle", "skirmish", "clash", "shootout",
+          "gunfight", "firefight", "exchange fire", "trade blows", "throw down",
+          "scrap", "rumble", "duke it out", "go toe-to-toe", "sucker punch",
+          "cheap shot", "get the drop", "take them down", "finish them", "execute",
+          "decapitate", "maim", "wound", "injure", "crush", "stomp", "trample",
+          "mow down", "carve through", "cut down", "lay waste", "join the fray",
+          "enter combat", "engage the enemy", "tangle with", "go after",
+          "strike back", "hit back", "fight your way", "cut your way", "shoot your way"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": ["射击", "手枪", "步枪", "格斗", "斗殴", "剑术", "法术", "闪避"],
+        "en": ["attack", "shooting", "firearms", "melee", "combat", "spellcasting", "dodge"]
+      },
+      "default_attribute": "dex",
+      "priority": 60
+    },
+    "generic": {
+      "aliases": {
+        "zh-CN": [
+          "检定", "判定", "掷骰", "投骰", "丢骰", "骰子", "测试", "试试", "试一下",
+          "让我试试", "试试看", "考验", "试试手气", "表现", "一展身手", "亮一手"
+        ],
+        "en": [
+          "roll", "check", "make a check", "do a check", "dice roll", "roll a check",
+          "test", "save", "saving throw", "ability check", "skill check", "attempt",
+          "give it a shot", "give it a go", "take a shot", "try your luck",
+          "test your luck", "show your skill", "show what you've got"
+        ]
+      },
+      "skill_candidates": {
+        "zh-CN": [],
+        "en": []
+      },
+      "default_attribute": null,
+      "priority": 99
+    }
+  }
+}

--- a/tests/test_intents_table.py
+++ b/tests/test_intents_table.py
@@ -1,0 +1,105 @@
+"""数据驱动检定词表（intents）的回归测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.commands.dice_resolver import DiceResolver
+from src.engine.checks import build_check_request
+from src.engine.game_instance import GameInstance, GameState
+from src.rules.rule_system import RuleSystem
+
+
+def _d20_instance() -> GameInstance:
+    instance = GameInstance(("web", "room", "bot"))
+    instance.state = GameState.ACTIVE_ACTION
+    instance.round_number = 1
+    instance.language = "zh-CN"
+    instance.players["p1"] = {
+        "character_name": "冒险者",
+        "character_sheet": {
+            "attributes": {"dex": 16, "int": 12, "wis": 14},
+            "skills": [{"name": "潜行", "value": 20}, {"name": "侦查", "value": 45}],
+        },
+    }
+    return instance
+
+
+def _dnd_rule() -> RuleSystem:
+    return RuleSystem.load(Path("templates/rules/dnd5e.json"))
+
+
+def _coc_rule() -> RuleSystem:
+    return RuleSystem.load(Path("templates/rules/freeform_coc.json"))
+
+
+def test_observe_maps_to_perception_wis_for_d20():
+    """『观察/看看/张望/瞅瞅』在 D&D 5e 下应走感知（wis），而不是智力。"""
+    instance = _d20_instance()
+    rule = _dnd_rule()
+    for text in ("观察周围的情况", "看看周边的情况", "用眼睛张望四周", "瞅瞅前面"):
+        request = build_check_request(instance, {"user_id": "p1", "text": text}, rule)
+        assert request is not None
+        assert request["intent"] == "perception"
+        assert request["attribute"] == "wis"
+
+
+def test_observe_maps_to_spot_hidden_skill_for_coc():
+    """『观察周围』在 CoC 下应走侦查技能（d100），而不是属性检定。"""
+    instance = _d20_instance()
+    rule = _coc_rule()
+    request = build_check_request(instance, {"user_id": "p1", "text": "观察周围的情况"}, rule)
+    assert request is not None
+    assert request["dice_system"] == "d100"
+    assert request["skill"] == "侦查"
+
+
+def test_english_word_boundary_matching():
+    """英文触发词应走整词边界匹配，避免 'roll' 命中 'scroll' 之类误报。"""
+    instance = _d20_instance()
+    instance.language = "en"
+    rule = _dnd_rule()
+
+    hit = build_check_request(instance, {"user_id": "p1", "text": "look around the room"}, rule)
+    assert hit is not None
+    assert hit["intent"] == "perception"
+
+    miss = build_check_request(instance, {"user_id": "p1", "text": "I pick up the scroll on the desk"}, rule)
+    assert miss is None, "'scroll' 不应命中 'roll'"
+
+
+def test_english_stealth_and_attack():
+    instance = _d20_instance()
+    instance.language = "en"
+    rule = _dnd_rule()
+
+    stealth = build_check_request(instance, {"user_id": "p1", "text": "sneak behind the guard"}, rule)
+    assert stealth is not None and stealth["intent"] == "stealth"
+
+    attack = build_check_request(instance, {"user_id": "p1", "text": "attack the goblin"}, rule)
+    assert attack is not None and attack["intent"] == "combat"
+
+
+def test_tavern_free_never_rolls_even_with_intents():
+    """dice_system none 规则即使有词表也不触发检定。"""
+    instance = _d20_instance()
+    rule = RuleSystem.load(Path("templates/rules/tavern_free.json"))
+    assert build_check_request(
+        instance, {"user_id": "p1", "text": "悄悄上楼", "selected_skill": "潜行"}, rule
+    ) is None
+
+
+def test_coc_inherits_intents_from_base():
+    """freeform_coc 未 extends base_d20，但应通过 intents_base 继承词表。"""
+    rule = _coc_rule()
+    assert "perception" in rule.intents
+    assert "观察" in rule.intent_aliases("perception", "zh-CN")
+
+
+def test_guess_attribute_key_consistent_with_intents():
+    """_guess_attribute_key 应与词表给出同一属性（观察->wis）。"""
+    resolver = DiceResolver()
+    rule = _dnd_rule()
+    assert resolver._guess_attribute_key("观察周围", rule) == "wis"
+    assert resolver._guess_attribute_key("说服他", rule) == "cha"
+    assert resolver._guess_attribute_key("攻击他", rule) == "dex"


### PR DESCRIPTION
## 概述

发布 v1.8.3：重构检定触发为数据驱动的多语言词表，并发布自 v1.8.2 以来的完整功能。

## 变更

- **数据驱动检定词表**：内置 6 类意图（潜行/调查/感知/社交/运动/战斗）+ 通用检定，中英文双份、覆盖 400+ 触发词；规则模板可继承或覆盖。
- **修正「观察」类动作**：D&D 5e 等下改为感知检定（Wisdom），不再误判为智力；CoC 下自动走「侦查」技能检定（d100）。
- **检定按规则对应骰子**：d20 规则走属性检定 vs DC，CoC 走 d100 技能阈值，无骰规则不触发。
- **英文触发词 + 整词边界匹配**：英文自然语言可触发检定，避免「roll」误命中「scroll」。
- **消除两条判定路径不一致**：`_guess_attribute_key` 与意图识别共用同一份词表。

## 验证

- 后端 582 测试全过，覆盖率 63.04%
- 前端 39 测试全过 + 生产构建成功
- `scripts/healthcheck.py` → All checks passed!
- `build_release.py` → `DiceFrame-v1.8.3-windows.zip` 生成且无内部文件/秘密