### PR TITLE
release: DiceFrame v1.9.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v1.9.0
+# DiceFrame v1.9.1
 
 ## 中文
 
@@ -24,8 +24,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.9.0-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.9.0-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.9.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.9.1-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -52,6 +52,6 @@ This release brings save import/export and a plugin-store overhaul: games can be
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v1.9.0-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v1.9.0-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v1.9.1-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v1.9.1-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/src/plugin_host/host.py
+++ b/src/plugin_host/host.py
@@ -91,6 +91,18 @@ class PluginRuntime:
     error: str = ""
 
 
+async def _rename_dir_with_retry(src: Path, dst: Path, *, attempts: int = 3, delay: float = 0.3) -> None:
+    """重命名目录；Windows 下杀毒软件实时扫描可能短暂锁定目录，失败时小间隔重试。"""
+    for attempt in range(1, attempts + 1):
+        try:
+            src.rename(dst)
+            return
+        except OSError:
+            if attempt >= attempts:
+                raise
+            await asyncio.sleep(delay)
+
+
 class PluginHost:
     def __init__(self, plugins_dir: Path, data_dir: Path, *, base_env: dict[str, str] | None = None) -> None:
         self.plugins_dir = plugins_dir
@@ -447,15 +459,15 @@ class PluginHost:
                 if target_dir.exists():
                     if plugin_id in self.plugins:
                         await self.stop(plugin_id)
-                    target_dir.rename(backup_dir)
-                staging_dir.rename(target_dir)
+                    await _rename_dir_with_retry(target_dir, backup_dir)
+                await _rename_dir_with_retry(staging_dir, target_dir)
                 if backup_dir.exists():
                     shutil.rmtree(backup_dir)
             except Exception:
                 if target_dir.exists() and not (target_dir / "plugin.json").exists():
                     shutil.rmtree(target_dir, ignore_errors=True)
                 if backup_dir.exists() and not target_dir.exists():
-                    backup_dir.rename(target_dir)
+                    await _rename_dir_with_retry(backup_dir, target_dir)
                 if staging_dir.exists():
                     shutil.rmtree(staging_dir, ignore_errors=True)
                 raise

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/src/webui/services/plugins.py
+++ b/src/webui/services/plugins.py
@@ -126,6 +126,23 @@ def _autoimport_plugin_content(api: "WebAPI", plugin_id: str) -> None:
                 logger.warning("自动灌注插件 %s 内容失败（%s）", plugin_id, kind, exc_info=True)
 
 
+def _maybe_autoimport_after_install(api: "WebAPI", plugin_id: str) -> None:
+    """安装/更新内容包后自动同步世界书并灌入内容，避免已启用插件更新后内容缺失。"""
+    if not api._plugins:
+        return
+    try:
+        detail = api._plugins.public_detail(plugin_id)
+    except Exception:
+        return
+    if not detail.get("enabled") or detail.get("status") != "active":
+        return
+    try:
+        sync_plugin_lorebooks(api)
+        _autoimport_plugin_content(api, plugin_id)
+    except Exception:
+        logger.warning("安装后自动灌入插件内容失败，已跳过: %s", plugin_id, exc_info=True)
+
+
 async def update_plugin_config(api: "WebAPI", plugin_id: str, changes: dict[str, Any]) -> dict[str, Any]:
     if not api._plugins: return {"ok": False, "error": "插件宿主未启用"}
     result = await api._plugins.update_config(plugin_id, changes)
@@ -148,7 +165,9 @@ async def control_plugin(api: "WebAPI", plugin_id: str, action: str) -> dict[str
 async def install_plugin(api: "WebAPI", payload: bytes, overwrite: bool = False) -> dict[str, Any]:
     if not api._plugins:
         return {"ok": False, "error": "插件宿主未启用"}
-    return {"ok": True, **await api._plugins.install_from_zip(payload, overwrite=overwrite)}
+    detail = await api._plugins.install_from_zip(payload, overwrite=overwrite)
+    _maybe_autoimport_after_install(api, detail.get("id", ""))
+    return {"ok": True, **detail}
 
 async def list_plugin_marketplace(api: "WebAPI") -> dict[str, Any]:
     if not api._plugins:
@@ -158,7 +177,9 @@ async def list_plugin_marketplace(api: "WebAPI") -> dict[str, Any]:
 async def install_marketplace_plugin(api: "WebAPI", plugin_id: str, overwrite: bool = False) -> dict[str, Any]:
     if not api._plugins:
         return {"ok": False, "error": "插件宿主未启用"}
-    return {"ok": True, **await api._plugins.install_from_marketplace(plugin_id, overwrite=overwrite)}
+    result = await api._plugins.install_from_marketplace(plugin_id, overwrite=overwrite)
+    _maybe_autoimport_after_install(api, plugin_id)
+    return {"ok": True, **result}
 
 async def update_marketplace_plugin(api: "WebAPI", plugin_id: str) -> dict[str, Any]:
     if not api._plugins:

--- a/tests/test_plugin_host.py
+++ b/tests/test_plugin_host.py
@@ -642,6 +642,158 @@ def test_autoimport_plugin_content_without_world_only_imports_cards():
     assert len(saved_entries) == 0  # 无世界，npc 跳过
 
 
+def test_rename_dir_with_retry_retries_transient_permission_error(tmp_path, monkeypatch):
+    """Windows 下目录被短暂锁定时自动重试，最终成功。"""
+    import asyncio
+
+    import src.plugin_host.host as host_module
+
+    calls = {"n": 0}
+
+    def fake_rename(self, target):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(5, "Access is denied")
+        return None
+
+    monkeypatch.setattr(Path, "rename", fake_rename)
+    src_dir = tmp_path / "src"
+    dst_dir = tmp_path / "dst"
+    src_dir.mkdir()
+    dst_dir.mkdir()
+
+    async def run():
+        await host_module._rename_dir_with_retry(src_dir, dst_dir)
+
+    asyncio.run(run())
+    assert calls["n"] == 3
+
+
+def test_rename_dir_with_retry_gives_up_after_attempts(tmp_path, monkeypatch):
+    """超过重试次数后继续抛错。"""
+    import asyncio
+
+    import src.plugin_host.host as host_module
+
+    calls = {"n": 0}
+
+    def fake_rename(self, target):
+        calls["n"] += 1
+        raise PermissionError(5, "Access is denied")
+
+    monkeypatch.setattr(Path, "rename", fake_rename)
+    src_dir = tmp_path / "src"
+    dst_dir = tmp_path / "dst"
+    src_dir.mkdir()
+    dst_dir.mkdir()
+
+    async def run():
+        await host_module._rename_dir_with_retry(src_dir, dst_dir, attempts=3, delay=0)
+
+    with pytest.raises(PermissionError):
+        asyncio.run(run())
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_install_marketplace_plugin_triggers_autoimport_when_enabled():
+    """已启用内容包从商店安装/更新后自动同步世界书并灌入内容。"""
+    from src.webui.services.plugins import install_marketplace_plugin
+
+    saved_cards: list = []
+    saved_entries: list = []
+
+    class _Contrib:
+        def __init__(self, key):
+            self.plugin_id = "pack"
+            self.key = key
+
+    class _ContribRegistry:
+        def list(self, kind):
+            return [_Contrib("w1")]
+
+    class _Plugins:
+        contributions = _ContribRegistry()
+
+        def __init__(self):
+            self.synced = False
+
+        async def install_from_marketplace(self, plugin_id, overwrite=False):
+            return {"id": plugin_id, "name": "pack"}
+
+        def public_detail(self, plugin_id):
+            return {"id": plugin_id, "enabled": True, "status": "active"}
+
+        def sync_lorebooks(self, lore):
+            self.synced = True
+            return 0
+
+        def list_content_resources(self):
+            return {
+                "character_template": [{"plugin_id": "pack", "id": "hero", "character_name": "Hero", "plugin_name": "pack"}],
+                "npc": [{"plugin_id": "pack", "id": "himmel", "name": "Himmel", "description": "hero"}],
+                "spell": [], "item": [], "class": [],
+            }
+
+    class _Lore:
+        def get_world(self, wid):
+            return wid == "w1"
+
+        def get_entry(self, eid):
+            return None
+
+        def update_entry(self, eid, entry):
+            saved_entries.append(entry)
+
+    class _Api:
+        _plugins = _Plugins()
+        _lore = _Lore()
+
+        def save_character_card(self, card):
+            saved_cards.append(card)
+            return {"ok": True}
+
+        def save_entry(self, entry):
+            saved_entries.append(entry)
+            return {"ok": True}
+
+    api = _Api()
+    result = await install_marketplace_plugin(api, "pack")
+
+    assert result["ok"] is True
+    assert api._plugins.synced is True
+    assert len(saved_cards) == 1
+    assert saved_cards[0]["character_name"] == "Hero"
+    assert len(saved_entries) == 1
+    assert saved_entries[0]["source_plugin"] == "pack"
+
+
+@pytest.mark.asyncio
+async def test_install_marketplace_plugin_skips_autoimport_when_disabled():
+    """未启用插件安装后不触发自动导入。"""
+    from src.webui.services.plugins import install_marketplace_plugin
+
+    class _Plugins:
+        async def install_from_marketplace(self, plugin_id, overwrite=False):
+            return {"id": plugin_id, "name": "pack"}
+
+        def public_detail(self, plugin_id):
+            return {"id": plugin_id, "enabled": False, "status": "disabled"}
+
+        def sync_lorebooks(self, lore):
+            raise AssertionError("should not sync")
+
+        def list_content_resources(self):
+            raise AssertionError("should not list")
+
+    class _Api:
+        _plugins = _Plugins()
+        _lore = None
+
+    result = await install_marketplace_plugin(_Api(), "pack")
+    assert result["ok"] is True
+
+
 def test_invalid_manifest_isolated_from_other_plugins(tmp_path):
     plugins = tmp_path / "plugins"
     write_plugin(plugins, "good")


### PR DESCRIPTION
## v1.9.1 补丁发布

- \src/plugin_host/host.py\：安装/更新插件时目录改名增加自动重试（Windows 杀毒实时扫描可能短暂锁定目录导致 WinError 5）
- \src/webui/services/plugins.py\：商店安装/更新内容包后自动同步世界书并灌入内容（此前只有启用插件时才触发）
- \	ests/test_plugin_host.py\：新增 4 个覆盖测试
- 版本号 \1.9.0 -> 1.9.1\，\RELEASE_NOTES.md\ 同步更新

## 验证

- \scripts/healthcheck.py\ 全绿（ruff / mypy / pytest+coverage / 前端构建）
- \uild_release.py\ 打包通过