### PR TITLE
fix: Docker 插件持久化、朗读语速上限、TTS 标签剥离、qq-napcat 重启修复 (v1.9.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ COPY --from=frontend-build /build/static-v2 ./static-v2
 RUN mkdir -p /app/data
 
 EXPOSE 9876
-VOLUME ["/app/data"]
+VOLUME ["/app/data", "/app/plugins"]
 
 CMD ["python", "web_server.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,5 @@ services:
       NAPCAT_TOKEN: "${NAPCAT_TOKEN:-}"
     volumes:
       - ./data:/app/data
+      - ./plugins:/app/plugins
     restart: unless-stopped

--- a/docs/DOCKER_DEPLOY_CN.md
+++ b/docs/DOCKER_DEPLOY_CN.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 python web_server.py
 ```
 
-Docker 里固定把运行数据放在 `/app/data`，compose 会映射到项目根目录的 `./data`。存档、配置、访问令牌、插件运行数据都留在宿主机，不会被镜像重建清掉。
+Docker 里固定把运行数据放在 `/app/data`，compose 会映射到项目根目录的 `./data`。存档、配置、访问令牌、插件运行数据都留在宿主机，不会被镜像重建清掉。插件源码目录 `/app/plugins` 也映射到 `./plugins`，升级或重建容器后已安装的插件不会丢失。
 
 ## 快速启动
 
@@ -101,4 +101,5 @@ TRPG_DATA_DIR=./data-docker docker compose up
 ```yaml
 volumes:
   - ./data-docker:/app/data
+  - ./plugins-docker:/app/plugins
 ```

--- a/docs/DOCKER_DEPLOY_EN.md
+++ b/docs/DOCKER_DEPLOY_EN.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 python web_server.py
 ```
 
-The container stores runtime data in `/app/data`; Compose maps it to `./data` in the project directory. Saves, settings, access credentials, and plugin runtime data remain on the host when the image is rebuilt.
+The container stores runtime data in `/app/data`; Compose maps it to `./data` in the project directory. Saves, settings, access credentials, and plugin runtime data remain on the host when the image is rebuilt. The plugin source directory `/app/plugins` is also mapped to `./plugins`, so installed plugins survive image upgrades or container rebuilds.
 
 ## Quick Start
 
@@ -93,4 +93,5 @@ or change the Compose volume:
 ```yaml
 volumes:
   - ./data-docker:/app/data
+  - ./plugins-docker:/app/plugins
 ```

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -706,7 +706,7 @@ function redownloadUpdatePackage() {
               </div>
               <div class="form-row">
                 <label>{{ t('ttsRate') }}</label>
-                <NInputNumber :value="ttsRateValue" :min="0.5" :max="2" :step="0.1" @update:value="setTtsRateValue" style="width:140px" />
+                <NInputNumber :value="ttsRateValue" :min="0.5" :max="5" :step="0.1" @update:value="setTtsRateValue" style="width:140px" />
               </div>
             </section>
             <section class="settings-group-card">

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -496,7 +496,7 @@ export const en = {
   generationParams: 'Generation Parameters',
   ttsSettings: 'Text-to-Speech',
   ttsAutoSpeak: 'Auto-read new GM narration',
-  ttsRate: 'Speech rate (0.5–2.0)',
+  ttsRate: 'Speech rate (0.5–5.0)',
   aboutDiceFrame: 'About DiceFrame',
   aboutIntro1: 'DiceFrame is a self-hosted AI tabletop. Give it a world you want to play in, and the AI can act as GM; players say what they want to do in a browser or chat group, while story, dice, character state, and recaps are organized together.',
   aboutIntro2: 'It works for small friend groups, quick ideas, long-running campaigns, or solo world tests. Play fantasy, cosmic horror, cyberpunk, wuxia, or swap in your own rules and lorebooks.',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -496,7 +496,7 @@ export const zhCN = {
   generationParams: '生成参数',
   ttsSettings: '语音朗读',
   ttsAutoSpeak: '新 GM 叙事自动朗读',
-  ttsRate: '朗读语速（0.5–2.0）',
+  ttsRate: '朗读语速（0.5–5.0）',
   aboutDiceFrame: '关于 DiceFrame',
   aboutIntro1: 'DiceFrame 是一张可以自己开起来的 AI 跑团桌。你只要给出一个想玩的世界，AI 就能当 GM 带大家进入故事；玩家在浏览器或群聊里说“我想做什么”，剧情、骰子、角色状态和前情都会被一起整理好。',
   aboutIntro2: '它适合熟人小团、临时脑洞、长期连载，也适合一个人先试跑世界。你可以玩奇幻、克苏鲁、赛博朋克、武侠仙侠，也可以把规则和世界书换成自己的味道。',

--- a/frontend-v2/src/utils/tts.ts
+++ b/frontend-v2/src/utils/tts.ts
@@ -13,17 +13,17 @@ export interface SpeakOptions {
 const RATE_STORAGE_KEY = 'trpg_tts_rate'
 export const DEFAULT_TTS_RATE = 1.0
 
-// 读取语速偏好（0.5–2.0），localStorage 存字符串。
+// 读取语速偏好（0.5–5.0），localStorage 存字符串。
 export function ttsRate(): number {
   try {
     const raw = Number(localStorage.getItem(RATE_STORAGE_KEY))
-    if (Number.isFinite(raw) && raw >= 0.5 && raw <= 2) return raw
+    if (Number.isFinite(raw) && raw >= 0.5 && raw <= 5) return raw
   } catch { /* localStorage 不可用时用默认 */ }
   return DEFAULT_TTS_RATE
 }
 
 export function setTtsRate(rate: number): void {
-  const clamped = Math.min(2, Math.max(0.5, Number(rate) || DEFAULT_TTS_RATE))
+  const clamped = Math.min(5, Math.max(0.5, Number(rate) || DEFAULT_TTS_RATE))
   try { localStorage.setItem(RATE_STORAGE_KEY, String(clamped)) } catch { /* 忽略 */ }
 }
 
@@ -60,12 +60,28 @@ function pickVoice(lang: string): SpeechSynthesisVoice | null {
 // 当前正在朗读的内容标识，用于单声道（播新的停旧的）。
 export const speakingKey = ref<string>('')
 
+// 剥离 HTML 标签并解码实体，得到纯文本供朗读。GM 叙事段落由
+// renderer 高亮关键词时包了 <span class="...">，朗读前必须还原。
+export function stripHtml(text: string): string {
+  const raw = String(text || '')
+  if (!raw.includes('<') && !raw.includes('&')) return raw
+  return raw
+    .replace(/<[^>]+>/g, '')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .trim()
+}
+
 export function ttsSpeak(text: string, key: string, options: SpeakOptions = {}): void {
   if (!ttsSupported() || !text.trim()) return
   const synth = window.speechSynthesis
   synth.cancel()
   speakingKey.value = key
-  const utterance = new SpeechSynthesisUtterance(text)
+  const utterance = new SpeechSynthesisUtterance(stripHtml(text))
   const voice = pickVoice(options.lang || 'zh-CN')
   if (voice) utterance.voice = voice
   utterance.lang = voice?.lang || options.lang || 'zh-CN'

--- a/frontend-v2/tests/tts.test.ts
+++ b/frontend-v2/tests/tts.test.ts
@@ -36,7 +36,7 @@ vi.stubGlobal('localStorage', {
   clear: () => { memStore.clear() },
 })
 
-import { setTtsRate, speakingKey, ttsRate, ttsSpeak, ttsStop, ttsSupported, ttsToggle } from '../src/utils/tts'
+import { setTtsRate, speakingKey, stripHtml, ttsRate, ttsSpeak, ttsStop, ttsSupported, ttsToggle } from '../src/utils/tts'
 
 describe('tts utils', () => {
   beforeEach(() => {
@@ -54,6 +54,18 @@ describe('tts utils', () => {
     expect(ttsSupported()).toBe(true)
   })
 
+  it('strips HTML tags and decodes entities for narration reading', () => {
+    expect(stripHtml('<span class="kw-quote">古堡</span>的大门')).toBe('古堡的大门')
+    expect(stripHtml('他说 &quot;来吧&quot; &amp; 出发')).toBe('他说 "来吧" & 出发')
+    expect(stripHtml('无标签纯文本')).toBe('无标签纯文本')
+  })
+
+  it('reads stripped plain text, not HTML markup', () => {
+    ttsSpeak('<span class="kw-quote">火焰</span>升腾', 'gm:html')
+    const utterance = mocks.speak.mock.calls[0][0]
+    expect(utterance.text).toBe('火焰升腾')
+  })
+
   it('uses the persisted rate preference when no explicit rate is passed', () => {
     setTtsRate(1.5)
     expect(ttsRate()).toBe(1.5)
@@ -69,9 +81,9 @@ describe('tts utils', () => {
     expect(utterance.rate).toBe(2)
   })
 
-  it('clamps the persisted rate into the 0.5–2.0 range', () => {
-    setTtsRate(5)
-    expect(ttsRate()).toBe(2)
+  it('clamps the persisted rate into the 0.5–5.0 range', () => {
+    setTtsRate(8)
+    expect(ttsRate()).toBe(5)
     setTtsRate(0.1)
     expect(ttsRate()).toBe(0.5)
   })

--- a/src/bots/qq/main.py
+++ b/src/bots/qq/main.py
@@ -100,6 +100,34 @@ def _read_lock_pid(path) -> int:
         return 0
 
 
+def _pid_exists(pid: int) -> bool:
+    """纯存活检测：只判断 PID 是否在运行，不校验进程身份。
+
+    用于父进程监控（TRPG 主进程）——主进程不是 QQ 插件，不能用
+    _pid_is_alive 的 cmdline 校验，否则会把容器 PID 1 之类的主进程
+    误判为"已退出"导致插件无限重启。
+    """
+    if pid <= 0 or pid == os.getpid():
+        return False
+    if os.name == "nt":
+        try:
+            output = subprocess.check_output(
+                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+            )
+            return str(pid) in output
+        except Exception:
+            return False
+    try:
+        state = _linux_proc_state(pid)
+    except PermissionError:
+        # 进程存在但不可读，保守视为存活
+        return True
+    return bool(state) and state != "Z"
+
+
 def _pid_is_alive(pid: int) -> bool:
     """判断 PID 是否仍是本插件进程。
 
@@ -166,7 +194,7 @@ async def _watch_parent_process(parent_pid: int, transport: Any, interval_sec: f
         return
     while True:
         await asyncio.sleep(interval_sec)
-        if not _pid_is_alive(parent_pid):
+        if not _pid_exists(parent_pid):
             logging.getLogger("trpg.qq.main").warning(
                 "检测到 TRPG 主进程已退出，群聊插件自动停止: parent_pid=%s", parent_pid
             )

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.9.3"
+__version__ = "1.9.4"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/tests/test_qq_bot.py
+++ b/tests/test_qq_bot.py
@@ -1906,3 +1906,29 @@ def test_pid_is_alive_verifies_proc_identity(monkeypatch):
 
     monkeypatch.setattr(main_module, "_linux_proc_state", deny_read)
     assert main_module._pid_is_alive(123) is True
+
+
+def test_pid_exists_treats_unrelated_process_as_alive(monkeypatch):
+    """父进程监控用 _pid_exists：PID 1 这类非 QQ 插件进程也应判定存活。"""
+    import src.bots.qq.main as main_module
+
+    monkeypatch.setattr(main_module.os, "name", "posix")
+    monkeypatch.setattr(main_module, "_linux_proc_state", lambda pid: "S")
+    # cmdline 与 QQ 插件无关（如容器 PID 1 的 web_server.py），仍应视为存活
+    assert main_module._pid_exists(1) is True
+
+    # 僵尸 / 不存在：判定已退出
+    monkeypatch.setattr(main_module, "_linux_proc_state", lambda pid: "Z")
+    assert main_module._pid_exists(1) is False
+    monkeypatch.setattr(main_module, "_linux_proc_state", lambda pid: "")
+    assert main_module._pid_exists(1) is False
+
+    # /proc 不可读：保守视为存活
+    def deny_read(pid: int) -> str:
+        raise PermissionError()
+
+    monkeypatch.setattr(main_module, "_linux_proc_state", deny_read)
+    assert main_module._pid_exists(1) is True
+
+    # 非法 PID
+    assert main_module._pid_exists(0) is False


### PR DESCRIPTION
## Summary

版本 1.9.4：修复 Docker 插件丢失、朗读语速与标签问题、qq-napcat 无限重启。

### 修复
- **Docker 插件持久化**：插件源码目录 `/app/plugins` 加入持久卷挂载，容器升级后已安装插件不再丢失（compose 加 `./plugins:/app/plugins`，部署文档同步）。
- **qq-napcat 无限重启**：父进程监控改用纯存活检测 `_pid_exists`，不再误判容器 PID 1 等主进程为"已退出"，修复 Docker 下 napcat 频繁重启循环。
- **语音朗读读出 HTML 标签**：朗读前剥离 HTML 标签与实体，不再读出 `<span class="kw-quote">` 等样式代码。

### 优化
- 朗读语速上限 2.0 → 5.0。

## 影响
- Docker：`Dockerfile` VOLUME 加 `/app/plugins`、`docker-compose.yml` 挂载、文档说明。
- 后端：`qq/main.py` 新增 `_pid_exists`、`_watch_parent_process` 改用它。
- 前端：`tts.ts` 剥离 HTML + 语速 5.0、设置页、i18n。
- 版本：`version.py` 1.9.4。

## Test plan
- 后端 pytest：632 通过（新增 `_pid_exists` 测试）
- 前端 typecheck / Vitest 71 / build 通过
- tts 测试含 HTML 剥离、语速 clamp 5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)