### PR TITLE
feat: 叙事压缩按语言配置、英文压缩优化 (v1.9.5)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,55 +1,65 @@
-# DiceFrame v1.9.2
+# DiceFrame v1.9.5
 
 ## 中文
 
-这个版本带来了语音朗读与更可靠的插件更新：GM 叙事和玩家行动可以点一下喇叭朗读（可选自动朗读、可调速），插件商店现在能识别真正的"有新版本"，只有真的有新版才显示更新按钮。同时修复了 QQ/NapCat 插件的崩溃循环重启，以及未选头像时自动分配造成的不一致问题。
+这个版本带来了语音朗读、插件更新检测与稳定性修复：GM 叙事和玩家行动可以点击喇叭朗读（可选自动朗读、可调速），插件商店能识别真正的"有新版本"；同时修复了 QQ/NapCat 插件的崩溃循环、Docker 升级丢插件等问题。
 
 ### 新功能
 
-- 语音朗读：时间线里的 GM 叙事和玩家行动都可以点击喇叭朗读，支持自动朗读新叙事、调节语速，使用浏览器本地语音，无需联网。
-- 插件商店检测更新：商店现在对比插件仓库的最新正式 Release 与本地已装版本，只有真有新版才显示"更新"按钮和"新版本"提示，不再一律显示更新。
+- 语音朗读：时间线里的 GM 叙事和玩家行动都可以点击喇叭朗读，支持自动朗读新叙事、调节语速（0.5–5.0），使用浏览器本地语音，无需联网。
+- 插件商店检测更新：商店对比插件仓库的最新正式 Release 与本地已装版本，只有真有新版才显示"更新"按钮和"新版本"提示。
 - 创建新冒险时可直接导入 DiceFrame 角色卡，与角色管理页一致。
 
 ### 修复
 
 - 修复 QQ/NapCat 插件崩溃循环重启：残留锁文件把无关进程误判为存活导致无限重启，现在会校验进程身份，僵尸/无关进程残留锁会自动清理自愈。
 - 修复插件崩溃重启不等待：反复起不来的插件现在会逐步退避重试，不再 3 秒高频冲击，稳定运行后自动恢复正常节奏。
-- 未选择头像的角色不再自动分配头像，改为显示空白占位，避免"没选却有个默认头像"的困惑。
+- 修复 qq-napcat 在 Docker 下无限重启：父进程监控误判容器主进程为"已退出"导致插件反复重启，现在只做纯存活检测，NapCat 断连时静默重试连接，不再整个退出循环。
+- 修复 Docker 升级后插件丢失：插件源码目录纳入持久卷挂载，容器重建后已安装插件不再消失。**已部署的 Docker/NAS 用户需要手动给 compose 加一行挂载 `- ./plugins:/app/plugins` 并重建容器，否则升级后插件源码仍会丢失。**
+- 修复语音朗读读出样式代码：朗读前剥离 HTML 标签与实体，不再把 `<span>` 之类标签读出来。
+- 未选择头像的角色不再自动分配头像，改为显示空白占位。
 
 ### 优化
 
-- 插件自动更新时机调整：启动不再检查更新，改为打开插件商店时后台检查，减少启动开销。
-- 主程序更新页按钮文案统一为"下载更新"。
+- 插件更新改为手动：内容包/主题等声明型插件不再自动更新，商店提示新版后由你点"更新"安装，避免作者新代码未经确认就自动生效。
+- GM 叙事字数约束强化：普通叙事 200-260 字、战斗/Boss 不超过 400 字，超长视为不合格；叙事压缩触发线提前，超长更早被收敛。
+- 英文叙事压缩优化：英文按词数设定压缩目标（普通约 150 词、战斗约 200 词），不再被压缩到中文同等字符数的 1/3；叙事压缩目标改为按语言配置，为未来新增语言铺路。
+- 朗读语速上限提升至 5.0。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.9.2-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.9.2-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.9.5-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.9.5-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release adds text-to-speech reading and more reliable plugin updates: GM narration and player actions can be read aloud with a speaker button (optional auto-read, adjustable speed), and the plugin store now detects real "new versions" — the update button only appears when a newer version actually exists. It also fixes the QQ/NapCat plugin's crash-restart loop and stops auto-assigning portraits when none was chosen.
+This release adds text-to-speech reading and plugin update detection with stability fixes: GM narration and player actions can be read aloud with a speaker button (optional auto-read, adjustable speed), and the plugin store now detects real "new versions". It also fixes the QQ/NapCat plugin crash loops, Docker upgrades dropping plugins, and more.
 
 ### New Features
 
-- Text-to-speech: GM narration and player actions in the timeline can be read aloud with a speaker button; supports auto-reading new narration and adjustable speech rate, using the browser's local voices with no network needed.
-- Plugin store update detection: the store now compares each plugin's latest stable release against your installed version; the "Update" button and "New version" badge only appear when a newer version really exists.
+- Text-to-speech: GM narration and player actions in the timeline can be read aloud with a speaker button; supports auto-reading new narration and adjustable speech rate (0.5–5.0), using the browser's local voices with no network needed.
+- Plugin store update detection: the store compares each plugin's latest stable release against your installed version; the "Update" button and "New version" badge only appear when a newer version really exists.
 - DiceFrame character cards can now be imported directly while creating a new game, matching the character management page.
 
 ### Fixes
 
 - Fixed QQ/NapCat plugin crash-restart loop: a stale lock file could mistake an unrelated process as alive and cause endless restarts; process identity is now verified, and locks from zombie/unrelated processes are cleaned up automatically.
-- Fixed plugin crash restarts not backing off: plugins that repeatedly fail to start now retry with growing delays instead of hammering every 3 seconds, and recover to the normal rhythm once stable.
-- Characters without a chosen portrait now show an empty placeholder instead of an auto-assigned one, removing the "didn't pick one but got a default" confusion.
+- Fixed plugin crash restarts not backing off: plugins that repeatedly fail to start now retry with growing delays instead of hammering every 3 seconds, and recover once stable.
+- Fixed qq-napcat infinite restarts under Docker: parent-process monitoring misjudged the container's main process as "exited", causing the plugin to restart in a loop; it now uses pure liveness detection and silently retries the NapCat connection instead of exiting the whole loop.
+- Fixed plugins disappearing after Docker upgrades: the plugin source directory is now on a persistent volume, so installed plugins survive container rebuilds. **Existing Docker/NAS users need to add the mount `- ./plugins:/app/plugins` to their compose file and recreate the container — otherwise plugin sources will still be lost on upgrade.**
+- Fixed the narrator reading out markup: HTML tags and entities are stripped before reading, so tags like `<span>` are no longer spoken.
+- Characters without a chosen portrait now show an empty placeholder instead of an auto-assigned one.
 
 ### Improvements
 
-- Plugin auto-update timing: startup no longer checks for updates; the store checks in the background when opened, reducing startup overhead.
-- The update page button label is now consistently "Download update".
+- Plugin updates are now manual: declarative plugins (content packs/themes) no longer auto-update; the store notifies you of a new version and it installs only after you click "Update", so newly published author code never applies without your confirmation.
+- Stricter GM narration length: ordinary narration must stay within 200-260 characters and combat/boss scenes within 400; narration compression triggers earlier for oversized text.
+- English narration compression tuned: English narration is compressed toward word-count targets (about 150 words normally, 200 in combat) instead of being shrunk to a third of the Chinese character target; compression limits are now configured per language, paving the way for future languages.
+- Speech rate upper limit raised to 5.0.
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v1.9.2-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v1.9.2-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v1.9.5-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v1.9.5-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/src/commands/round_llm.py
+++ b/src/commands/round_llm.py
@@ -11,7 +11,7 @@ from src.commands.tag_json import safe_parse_json
 from src.commands.tag_parser import parse_tag_state
 from src.engine.game_instance import GameInstance
 from src.engine.health import record_health_event
-from src.engine.language import is_english
+from src.engine.language import is_english, normalize_language
 from src.llm.client import OutputTruncatedError, length_retry_budgets
 from src.llm.parser import (
     find_protocol_suffix_start,
@@ -22,9 +22,14 @@ from src.llm.parser import (
 from src.llm.protocol import leaked_protocol_line_start, strip_protocol_markup_from_public_line
 
 logger = logging.getLogger("trpg")
-_NARRATION_SOFT_LIMIT_CHARS = 260
-_NARRATION_COMPRESS_TRIGGER_CHARS = 500
-_NARRATION_COMBAT_TARGET_CHARS = 400
+# 叙事压缩目标，按语言归一后的 key（normalize_language 返回值）取配置。
+# 中文按字符数（普通 260 / 战斗 400），英文按词数换算成字符（普通 ≈150 词、
+# 战斗 ≈200 词，触发线设在超过提示词上限才压）。新增语言时在此加一行配置，
+# 并同步补充该语言的压缩 prompt 文案；未登记的语言回退中文配置。
+_NARRATION_LIMITS = {
+    "zh-CN": {"trigger": 500, "soft": 260, "combat": 400},
+    "en": {"trigger": 1200, "soft": 900, "combat": 1100},
+}
 _NARRATION_COMPRESS_MIN_TOKENS = 1024
 _NARRATION_COMPRESS_MAX_TOKENS = 2048
 
@@ -132,21 +137,21 @@ async def _compress_long_narration(
     max_tokens: int,
 ) -> None:
     narration = str(response.narration or "").strip()
-    if _narration_len(narration) <= _NARRATION_COMPRESS_TRIGGER_CHARS:
+    lang = normalize_language(getattr(response, "language", ""))
+    limits = _NARRATION_LIMITS.get(lang, _NARRATION_LIMITS["zh-CN"])
+    is_en = lang == "en"
+    if _narration_len(narration) <= limits["trigger"]:
         return
     combat_words = ("战斗", "攻击", "砍", "刺", "射", "突袭", "格挡", "防御", "回避")
-    target = (
-        _NARRATION_COMBAT_TARGET_CHARS
-        if combat_model != "none" and any(word in actions_text for word in combat_words)
-        else _NARRATION_SOFT_LIMIT_CHARS
-    )
-    if is_english(getattr(response, "language", "")):
+    is_combat = combat_model != "none" and any(word in actions_text for word in combat_words)
+    target = limits["combat"] if is_combat else limits["soft"]
+    if is_en:
         prompt = (
             "Compress the following TRPG GM narration. Output only the compressed "
             "narration, without --- or any state tags.\n"
             "Requirements: keep established facts, NPC names, key clues, check/combat "
             "results, and the immediate pressure for the players; do not add new lore "
-            f"or change outcomes. Keep it under about {target} characters and at most 2 paragraphs.\n\n"
+            f"or change outcomes. Keep it under about {target} characters (~{target // 6} words) and at most 2 paragraphs.\n\n"
             f"Original narration:\n{narration}"
         )
     else:

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.9.4"
+__version__ = "1.9.5"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/tests/test_round_llm_compression.py
+++ b/tests/test_round_llm_compression.py
@@ -40,6 +40,37 @@ class CompressionLLM:
         )
 
 
+class EnglishCompressionLLM:
+    default = "compression-test"
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def call(self, system_prompt: str, user_message: str, **kwargs) -> LLMResponse:
+        self.calls.append({"system_prompt": system_prompt, "user_message": user_message, "kwargs": kwargs})
+        if "Compress the following TRPG GM narration" in user_message:
+            content = "Alaric lowers his voice, pointing to the silver needle and the list of offerings as both pointing to the hidden archive of the White Horse Temple. The night wind dies; a new name is surfacing on the silk scroll."
+        else:
+            long_text = "Alaric unrolls the silk scroll. " * 100
+            content = (
+                f"{long_text}\n---\n"
+                "KEY_ITEM:u1:Silver Needle\n"
+                "QUICK_ACTIONS:Sneak into the archive|Follow the needle's trail\n"
+                "MEMORY:The silver needle can trace the caster"
+            )
+        return LLMResponse(
+            content=content,
+            narration=content.split("---", 1)[0].strip(),
+            state_update=None,
+            memory_delta=None,
+            info_asymmetry=None,
+            plot_update=None,
+            total_tokens=10,
+            is_narration_only=False,
+            provider_used="compression-test",
+        )
+
+
 @pytest.mark.asyncio
 async def test_long_narration_is_compressed_without_reparsing_tags():
     llm = CompressionLLM()
@@ -62,3 +93,52 @@ async def test_long_narration_is_compressed_without_reparsing_tags():
     assert data["state_update"]["loot"][0]["item"] == "摄魂银针"
     assert data["quick_actions"] == ["潜入藏经阁", "追踪银针黑气"]
     assert "KEY_ITEM:u1:摄魂银针" in response.content
+
+
+@pytest.mark.asyncio
+async def test_long_english_narration_compresses_to_english_target():
+    """英文叙事用英文压缩目标（~900 字符 ≈ 150 词），不是中文的 260 字符。"""
+    llm = EnglishCompressionLLM()
+    instance = GameInstance(game_key=("web", "compression-en", "bot"))
+    instance.language = "en"
+
+    response, data = await call_llm_with_tag_retry(
+        llm,
+        instance,
+        "You are a test GM.",
+        "context",
+        "hp_based",
+        "",
+        1024,
+    )
+
+    assert len(llm.calls) == 2
+    # 压缩 prompt 携带英文目标（~150 words），而非中文的 260 字符
+    assert "~150 words" in llm.calls[1]["user_message"]
+    assert "White Horse Temple" in response.narration
+    assert data["state_update"]["loot"][0]["item"] == "Silver Needle"
+    assert data["quick_actions"] == ["Sneak into the archive", "Follow the needle's trail"]
+    assert "KEY_ITEM:u1:Silver Needle" in response.content
+
+
+@pytest.mark.asyncio
+async def test_unregistered_language_falls_back_to_chinese_limits():
+    """未登记压缩配置的语言回退中文目标（future-proof：加语言只需登记字典条目）。"""
+    llm = CompressionLLM()
+    instance = GameInstance(game_key=("web", "compression-ja", "bot"))
+    instance.language = "ja"  # 尚未登记的语言
+
+    response, data = await call_llm_with_tag_retry(
+        llm,
+        instance,
+        "你是测试 GM。",
+        "上下文",
+        "hp_based",
+        "",
+        1024,
+    )
+
+    assert len(llm.calls) == 2
+    # 回退中文目标：压缩后叙事 < 260 字符，且走中文压缩 prompt
+    assert "请压缩以下 TRPG GM 正文" in llm.calls[1]["user_message"]
+    assert len(response.narration) < 260


### PR DESCRIPTION
## Summary

版本 1.9.5：叙事压缩按语言配置、英文压缩优化。

### 优化
- **英文叙事压缩优化**：英文压缩目标按词数设定（普通约 150 词、战斗约 200 词），不再被压缩到中文同等字符数的 1/3。
- **压缩目标按语言配置**：改为 `_NARRATION_LIMITS` 字典，按 `normalize_language` key 取配置；未登记语言回退中文。新增语言只需登记字典条目 + 补充压缩 prompt 文案，为未来扩展铺路。
- 中文行为完全不变（500 触发、260/400 目标）。

## 影响
- 后端：`round_llm.py` 压缩逻辑语言化。
- 测试：`test_round_llm_compression.py` 新增英文场景 + 未登记语言回退。
- 版本：`version.py` 1.9.5，RELEASE_NOTES 完整日志。

## Test plan
- 后端 pytest：634 通过（压缩测试 3 个：中文/英文/回退）
- 前端 typecheck / Vitest 71 / build 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)