### PR TITLE
docs: napcat 改为从插件商店安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,17 +144,17 @@ Windows 下也可以双击 `web_ui.bat` 启动；它会检查依赖，并在缺�
 
 ## QQ / NapCat
 
-推荐的群聊方式是内置 QQ / NapCat 插件。
+推荐的群聊方式是使用 QQ / NapCat 插件，从插件商店安装即可。
 
 基本流程：
 
-1. 在 WebUI 设置页打开插件配置。
+1. 在 WebUI 设置页进入"插件 → 插件商店"，安装 `QQ / NapCat` 插件。
 2. 配置 NapCat 的 WebSocket 地址、端口和 token。
 3. 启用 `QQ / NapCat` 插件。
 4. 在游戏页复制 Bot 绑定命令。
 5. 到群里发送绑定命令，把网页游戏和群聊关联起来。
 
-DiceFrame Bot API Token 由宿主自动生成并注入，内置 QQ / NapCat 无需填写。外部 MaiBot Bridge 等适配器可在“设置 → Bot API”复制服务地址和 Token。
+DiceFrame Bot API Token 由宿主自动生成并注入，QQ / NapCat 无需填写。外部 MaiBot Bridge 等适配器可在“设置 → Bot API”复制服务地址和 Token。
 
 Bot 会跟随绑定对局的语言显示帮助和主要操作提示；中文与英文对局都可直接使用对应语言的命令。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -121,7 +121,7 @@ More player-facing help is in [docs/USER_GUIDE_EN.md](docs/USER_GUIDE_EN.md).
 
 ## Plugins and Chat Adapters
 
-The built-in QQ/NapCat plugin receives its DiceFrame Bot API Token automatically; users configure only the NapCat connection. External bridges such as MaiBot copy the service URL and token from Settings → Bot API.
+Install the QQ/NapCat plugin from the plugin store. It receives its DiceFrame Bot API Token automatically; users configure only the NapCat connection. External bridges such as MaiBot copy the service URL and token from Settings → Bot API.
 
 The Bot follows the bound game's language for help and primary operation messages, with native Chinese and English commands available.
 

--- a/docs/DOCKER_DEPLOY_CN.md
+++ b/docs/DOCKER_DEPLOY_CN.md
@@ -64,15 +64,15 @@ docker compose build --no-cache
 
 ## QQ / NapCat
 
-Docker 版主服务仍然使用内置插件宿主。启用 QQ 插件时，Bot 作为主服务容器内的子进程运行，和 PC 版的插件生命周期一致。
+QQ / NapCat 插件从插件商店安装，不再内置。启用时，Bot 作为主服务容器内的子进程运行，和 PC 版的插件生命周期一致。
 
 推荐流程：
 
 1. 先启动 WebUI：`docker compose up -d`
-2. 在 WebUI 插件页启用 `QQ / NapCat`
+2. 在 WebUI 插件商店安装 `QQ / NapCat`，然后在插件页启用
 3. 如果 NapCat 不在容器内，填写宿主机或 NAS 上可从容器访问的 `NAPCAT_HOST` / `NAPCAT_PORT`
 
-内置 QQ 插件不需要填写 DiceFrame Bot API Token，服务会自动生成并持久化。外部 MaiBot Bridge 可在 WebUI 的“设置 → Bot API”复制 Token。
+QQ / NapCat 插件不需要填写 DiceFrame Bot API Token，服务会自动生成并持久化。外部 MaiBot Bridge 可在 WebUI 的“设置 → Bot API”复制 Token。
 
 也可以在首次启动前写入 `.env`：
 

--- a/docs/DOCKER_DEPLOY_EN.md
+++ b/docs/DOCKER_DEPLOY_EN.md
@@ -58,13 +58,13 @@ Settings only notifies Docker/NAS installations about a new version; it does not
 
 ## QQ / NapCat
 
-The Docker deployment uses the same built-in plugin host. When enabled, QQ/NapCat runs as a child process inside the main service container.
+The QQ/NapCat plugin is installed from the plugin store instead of being bundled. When enabled, it runs as a child process inside the main service container.
 
 1. Start the WebUI with `docker compose up -d`.
-2. Enable QQ / NapCat on the WebUI plugin page.
+2. Install QQ / NapCat from the plugin store, then enable it on the plugin page.
 3. If NapCat runs outside the container, use a host or NAS address reachable from the container for `NAPCAT_HOST` and `NAPCAT_PORT`.
 
-The built-in QQ plugin does not require a manually entered DiceFrame Bot API Token. DiceFrame generates and persists it. An external MaiBot bridge copies the value from Settings → Bot API.
+The QQ/NapCat plugin does not require a manually entered DiceFrame Bot API Token. DiceFrame generates and persists it. An external MaiBot bridge copies the value from Settings → Bot API.
 
 Optional initial values:
 

--- a/docs/USER_GUIDE_CN.md
+++ b/docs/USER_GUIDE_CN.md
@@ -145,11 +145,11 @@ GM 叙事后，系统会显示“状态变动”。这里记录的是这轮真�
 
 ## 群聊 Bot
 
-DiceFrame 可以通过 QQ / NapCat 插件把网页对局接到群聊里。Bot 只通过 Web 服务的 HTTP API 工作，不直接读写存档。
+DiceFrame 可以通过 QQ / NapCat 插件把网页对局接到群聊里，插件从商店安装即可。Bot 只通过 Web 服务的 HTTP API 工作，不直接读写存档。
 
 基本流程：
 
-1. 在 WebUI 设置页打开插件配置。
+1. 在 WebUI 设置页进入"插件 → 插件商店"，安装 `QQ / NapCat` 插件。
 2. 配置 NapCat 的 WebSocket 地址、端口和 token。
 3. 启用 `QQ / NapCat` 插件。
 4. 在游戏页复制 Bot 绑定命令。
@@ -157,7 +157,7 @@ DiceFrame 可以通过 QQ / NapCat 插件把网页对局接到群聊里。Bot �
 
 绑定成功后，群聊就和当前网页游戏关联起来了。
 
-内置 QQ / NapCat 不需要填写 DiceFrame Bot API Token，宿主会自动生成并注入。使用 MaiBot 等外部桥接时，到“设置 → Bot API”复制 DiceFrame 服务地址和 Token，再填写到外部插件；重新生成 Token 后需要同步更新外部插件。
+QQ / NapCat 不需要填写 DiceFrame Bot API Token，宿主会自动生成并注入。使用 MaiBot 等外部桥接时，到“设置 → Bot API”复制 DiceFrame 服务地址和 Token，再填写到外部插件；重新生成 Token 后需要同步更新外部插件。
 
 Bot 会跟随当前对局的语言显示帮助、状态、前情、地图、支付和错误提示。中文对局使用下面的中文命令；英文对局可以直接发送 `help`、`join`、`status`、`recap`、`map`、`roll`、`pay`、`advance`、`away`、`back` 等英文命令。
 

--- a/docs/USER_GUIDE_EN.md
+++ b/docs/USER_GUIDE_EN.md
@@ -92,15 +92,15 @@ In multiplayer, the player who is paying confirms the purchase. The purchase com
 
 ## Chat Bot
 
-DiceFrame can connect a Web game to QQ group chat through the built-in QQ/NapCat plugin. The adapter uses HTTP APIs and does not read saves directly.
+DiceFrame can connect a Web game to QQ group chat through the QQ/NapCat plugin, installed from the plugin store. The adapter uses HTTP APIs and does not read saves directly.
 
-1. Open plugin settings in the WebUI.
+1. Install QQ / NapCat from Settings → Plugins → Plugin Store.
 2. Enter the NapCat WebSocket address, port, and token.
 3. Enable QQ / NapCat.
 4. Copy the Bot binding command from the game page.
 5. Send it to the target group.
 
-The built-in plugin receives its DiceFrame Bot API Token automatically. For an external bridge such as MaiBot, copy the DiceFrame URL and token from Settings → Bot API into that bridge. Regenerating the token invalidates the old value.
+The plugin receives its DiceFrame Bot API Token automatically. For an external bridge such as MaiBot, copy the DiceFrame URL and token from Settings → Bot API into that bridge. Regenerating the token invalidates the old value.
 
 The Bot follows the current game's language for help, status, recap, map, payment, character-creation, and error messages. The examples below use the English commands; Chinese games retain the corresponding Chinese commands.
 


### PR DESCRIPTION
## Summary
- README / USER_GUIDE / DOCKER_DEPLOY（中英）把 QQ/NapCat 话术从"内置插件"改为"从插件商店安装"，引导用户去商店下载。
- 与 1.9.6 起的拆离保持一致（napcat 不再内置）。

## 影响
- 纯文档改动，无代码行为变化。

## 验证
- 无需代码测试；文档为 markdown 话术调整。