### PR TITLE
release: v1.9.11 插件开关状态修复

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,51 +1,29 @@
-# DiceFrame v1.9.10
+# DiceFrame v1.9.11
 
 ## 中文
 
-这个版本带来地图、卡片、更新频道与插件稳定性改进：地图在几百个地点时自动铺开不再堆成一圈，支持缩放平移和回到当前场景；卡片渲染成为通用能力，外部聊天机器人也能发送卡片；设置页可切换预览版/正式版更新频道，并显示已安装插件的版本与更新提示；升级主程序后，已安装的插件不再丢失，会自动保留并继续使用；QQ/NapCat 插件内置，开箱即用。同时修复了便携版插件无法启动、更新提示跳转和旧版本升级迁移的问题。
-
-### 新功能
-
-- 插件跨版本保留：升级主程序后，从商店安装的插件不再丢失，会自动保留并继续使用；老用户升级时，之前安装的插件会自动迁移到数据目录，配置保持原样。
-- QQ/NapCat 插件内置：安装主程序即可使用，开箱即用，无需从插件商店单独下载。
-- 地图改进：地点自动力导向铺开，几百个地点不再挤成一圈；支持滚轮缩放、拖拽平移，一键回到当前场景。
-- 卡片通用化：卡片渲染成为通用能力，外部聊天机器人也能收到并发送卡片。
-- 更新频道：设置页可切换预览版/正式版，开启预览版会二次确认并提示不稳定。
-- 已安装插件区显示当前版本号，商店有新版时提示更新。
+这个版本修复了插件开关的问题：点击启用插件后，开关有时不会点亮，实际进程已经启动但界面没有同步。现在开关状态会正确跟随插件运行状态。
 
 ### 修复
 
-- 修复便携版插件无法启动的问题，商店与内置插件均可正常启用。
-- 修复从更新弹窗跳转到设置页后，新版本更新包不自动开始下载的问题。
-- 修复从 1.9.5 及更早的便携版升级时，已安装的用户插件没有自动迁移到数据目录的问题。
+- 修复插件启用开关点击后状态不更新的问题，开关现在正确反映插件运行状态。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.9.10-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.9.10-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.9.11-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.9.11-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release improves maps, cards, update channels, and plugin stability: maps with hundreds of locations now spread out automatically instead of piling into a circle, with zoom, pan, and a return-to-current-scene action; card rendering becomes a shared capability so external chat bots can send cards too; the settings page lets you switch between preview and stable update channels and shows installed plugin versions and update hints; plugins installed from the store are preserved across program upgrades; and the QQ/NapCat plugin is built in and works out of the box. It also fixes portable-build plugin startup, update-prompt navigation, and plugin migration from older builds.
-
-### New Features
-
-- Plugin preservation across versions: after upgrading the main program, plugins installed from the store are no longer lost; they are preserved and keep working. For existing users, previously installed plugins migrate to the data directory automatically with settings intact.
-- QQ/NapCat plugin built in: it works right after installing DiceFrame, no separate download from the plugin store needed.
-- Map improvements: locations are laid out with force-directed spacing, so hundreds of locations no longer pile into one circle; scroll to zoom, drag to pan, and one click returns to the current scene.
-- Card generalization: card rendering is now a shared capability, so external chat bots can receive and send cards.
-- Update channel: the settings page lets you switch between preview and stable channels; enabling the preview channel asks for confirmation and warns that it may be unstable.
-- Installed plugins now show their current version, and a hint appears when the store has a newer version.
+This release fixes the plugin toggle: after enabling a plugin, the switch sometimes did not light up even though the process had started, and the UI did not sync. The switch now correctly reflects the plugin's running state.
 
 ### Fixes
 
-- Fixed plugins failing to start in portable builds; both store-installed and built-in plugins can be enabled.
-- Fixed the update package not starting to download automatically after navigating from the update dialog to the settings page.
-- Fixed user-installed plugins not migrating to the data directory when upgrading from 1.9.5 and earlier portable builds.
+- Fixed the plugin enable switch not updating its state after being clicked; it now correctly reflects the plugin's running state.
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v1.9.10-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v1.9.10-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v1.9.11-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v1.9.11-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/src/plugin_host/host.py
+++ b/src/plugin_host/host.py
@@ -658,11 +658,12 @@ class PluginHost:
         await self.restart(plugin_id)
         return self.public_detail(plugin_id)
 
-    async def start(self, plugin_id: str, *, reset_backoff: bool = True) -> None:
+    async def start(self, plugin_id: str, *, reset_backoff: bool = True, require_enabled: bool = True) -> None:
         runtime = self._require(plugin_id)
         if reset_backoff:
             runtime.restart_delay_sec = _RESTART_BASE_DELAY
-        if not runtime.config.get("enabled"):
+        # 启动时只拉起 enabled 的插件；前端开关用 require_enabled=False 强制启动进程。
+        if require_enabled and not runtime.config.get("enabled"):
             runtime.status = "disabled"
             return
         if runtime.process and runtime.process.returncode is None:

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.9.10"
+__version__ = "1.9.11"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/src/webui/services/plugins.py
+++ b/src/webui/services/plugins.py
@@ -155,9 +155,11 @@ async def update_plugin_config(api: "WebAPI", plugin_id: str, changes: dict[str,
 
 async def control_plugin(api: "WebAPI", plugin_id: str, action: str) -> dict[str, Any]:
     if not api._plugins: return {"ok": False, "error": "插件宿主未启用"}
+    # 前端进程开关要求强制启动/停止，不受 config.enabled 拦截（enabled 是"开机自启"概念）。
+    start_kwargs = {"require_enabled": False} if action in ("start", "restart") else {}
     method = {"start": api._plugins.start, "stop": api._plugins.stop, "restart": api._plugins.restart}.get(action)
     if not method: return {"ok": False, "error": "插件操作无效"}
-    await method(plugin_id)
+    await method(plugin_id, **start_kwargs)
     if action in ("start", "restart"):
         sync_plugin_lorebooks(api)
     return {"ok": True, **api._plugins.public_detail(plugin_id)}


### PR DESCRIPTION
## Summary
- 修复插件启用开关点击后状态不同步：`start` 加 `require_enabled` 参数，前端进程开关强制启动/停止进程，不再被 `config.enabled` 静默拦截。
- 版本号 1.9.11 + Release Notes。

## 影响
- 点插件开关启动后，开关正确点亮，与实际进程运行状态一致。

## 验证
- 编译通过；76 后端测试 passed。