### PR TITLE
release: v1.9.12-beta.1 预览版（插件词库定制）

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,53 +1,31 @@
-# DiceFrame v1.9.11
+# DiceFrame v1.9.12-beta.1
 
 ## 中文
 
-这个版本带来地图、卡片、更新频道与插件稳定性改进：地图在几百个地点时自动铺开不再堆成一圈，支持缩放平移和回到当前场景；卡片渲染成为通用能力，外部聊天机器人也能发送卡片；设置页可切换预览版/正式版更新频道，并显示已安装插件的版本与更新提示；升级主程序后，已安装的插件不再丢失，会自动保留并继续使用；QQ/NapCat 插件内置，开箱即用。同时修复了便携版插件无法启动、插件开关状态不同步、更新提示跳转和旧版本升级迁移的问题。
+这是一个预览版，用于测试插件规则词库的改进。正式版用户可继续使用现有插件，本次改动不影响已有玩法。
 
 ### 新功能
 
-- 插件跨版本保留：升级主程序后，从商店安装的插件不再丢失，会自动保留并继续使用；老用户升级时，之前安装的插件会自动迁移到数据目录，配置保持原样。
-- QQ/NapCat 插件内置：安装主程序即可使用，开箱即用，无需从插件商店单独下载。
-- 地图改进：地点自动力导向铺开，几百个地点不再挤成一圈；支持滚轮缩放、拖拽平移，一键回到当前场景。
-- 卡片通用化：卡片渲染成为通用能力，外部聊天机器人也能收到并发送卡片。
-- 更新频道：设置页可切换预览版/正式版，开启预览版会二次确认并提示不稳定。
-- 已安装插件区显示当前版本号，商店有新版时提示更新。
-
-### 修复
-
-- 修复便携版插件无法启动的问题，商店与内置插件均可正常启用。
-- 修复插件启用开关点击后状态不更新的问题，开关现在正确反映插件运行状态。
-- 修复从更新弹窗跳转到设置页后，新版本更新包不自动开始下载的问题。
-- 修复从 1.9.5 及更早的便携版升级时，已安装的用户插件没有自动迁移到数据目录的问题。
+- 插件内容包现在可以自定义判定触发词：创作者能在规则模板里声明自己的"触发词 → 检定意图"词表，或继承主程序的通用词库，决定哪些自然语言词触发什么检定、用什么属性/技能。
+- 判定触发词表改为按语言组织，为后续新增语言（如日语）做准备，新增语言只需补充词表，不会影响其他语言场景。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v1.9.11-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v1.9.11-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v1.9.12-beta.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v1.9.12-beta.1-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This release improves maps, cards, update channels, and plugin stability: maps with hundreds of locations now spread out automatically instead of piling into a circle, with zoom, pan, and a return-to-current-scene action; card rendering becomes a shared capability so external chat bots can send cards too; the settings page lets you switch between preview and stable update channels and shows installed plugin versions and update hints; plugins installed from the store are preserved across program upgrades; and the QQ/NapCat plugin is built in and works out of the box. It also fixes portable-build plugin startup, the plugin toggle state, update-prompt navigation, and plugin migration from older builds.
+This is a preview release for testing plugin rule vocabulary improvements. Stable users can keep using existing plugins; this release does not change existing behavior.
 
 ### New Features
 
-- Plugin preservation across versions: after upgrading the main program, plugins installed from the store are no longer lost; they are preserved and keep working. For existing users, previously installed plugins migrate to the data directory automatically with settings intact.
-- QQ/NapCat plugin built in: it works right after installing DiceFrame, no separate download from the plugin store needed.
-- Map improvements: locations are laid out with force-directed spacing, so hundreds of locations no longer pile into one circle; scroll to zoom, drag to pan, and one click returns to the current scene.
-- Card generalization: card rendering is now a shared capability, so external chat bots can receive and send cards.
-- Update channel: the settings page lets you switch between preview and stable channels; enabling the preview channel asks for confirmation and warns that it may be unstable.
-- Installed plugins now show their current version, and a hint appears when the store has a newer version.
-
-### Fixes
-
-- Fixed plugins failing to start in portable builds; both store-installed and built-in plugins can be enabled.
-- Fixed the plugin enable switch not updating its state after being clicked; it now correctly reflects the plugin's running state.
-- Fixed the update package not starting to download automatically after navigating from the update dialog to the settings page.
-- Fixed user-installed plugins not migrating to the data directory when upgrading from 1.9.5 and earlier portable builds.
+- Plugin content packs can now customize check triggers: creators can declare their own "trigger word to check intent" vocabulary in a rule template, or inherit the main program's generic vocabulary, deciding which natural-language phrases trigger which check and which attribute/skill to use.
+- Check trigger vocabularies are now organized by language, preparing for future languages (such as Japanese); adding a language only requires adding vocabulary entries and does not affect other languages.
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v1.9.11-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v1.9.11-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v1.9.12-beta.1-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v1.9.12-beta.1-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,8 @@
 ### 新功能
 
 - 插件内容包现在可以自定义判定触发词：创作者能在规则模板里声明自己的"触发词 → 检定意图"词表，或继承主程序的通用词库，决定哪些自然语言词触发什么检定、用什么属性/技能。
-- 判定触发词表改为按语言组织，为后续新增语言（如日语）做准备，新增语言只需补充词表，不会影响其他语言场景。
+- 判定触发词表改为按语言组织，为后续新增语言做准备；新增语言只需补充词表，不会影响其他语言场景。
+- 新增日语语言支持：可识别 `ja` / `日本語`，规则与内容可拆分日语字段。
 
 ### 下载指南
 
@@ -22,7 +23,8 @@ This is a preview release for testing plugin rule vocabulary improvements. Stabl
 ### New Features
 
 - Plugin content packs can now customize check triggers: creators can declare their own "trigger word to check intent" vocabulary in a rule template, or inherit the main program's generic vocabulary, deciding which natural-language phrases trigger which check and which attribute/skill to use.
-- Check trigger vocabularies are now organized by language, preparing for future languages (such as Japanese); adding a language only requires adding vocabulary entries and does not affect other languages.
+- Check trigger vocabularies are now organized by language, preparing for future languages; adding a language only requires adding vocabulary entries and does not affect other languages.
+- Added Japanese language support: recognizes `ja` / `日本語`, and rules and content can have Japanese fields.
 
 ### Download Guide
 

--- a/docs/PLUGIN_DEVELOPMENT_CN.md
+++ b/docs/PLUGIN_DEVELOPMENT_CN.md
@@ -347,6 +347,56 @@ content/
 - 规则模板按语言拆分文件：`<rule_id>.json`（中文版，纯中文）+ `<rule_id>_en.json`（英文版，纯英文全文）。`rule_id` 保持不变（是引用键，`world.default_rule` 指向它，不随语言变，区别于世界模板的 `world_id`）。`RuleSystem.path_for(rules_dir, rule_id, language)` 按游戏语言选文件（`_en.json` 不存在则回退中文版）。规则列表与详情会配对合并各语言文件，前端按界面语言显示对应字段。自定义规则可不拆，保持单文件并在字段后加 `_en` 后缀（如 `attr_hint_en`）做英文显示。新增语言：在 `engine/language.py` 的 `_LANG_FIELD_SUFFIXES` 登记后缀，加 `<rule_id>_<suffix>.json`，加载/展示自动生效。
 - 规则字段、枚举、协议标签和内部难度键保持稳定，例如 `rule_id`、`dice_system`、`combat_model`、`mechanics`、`difficulty_instructions` 的键、GM 标签 `HP/GOLD/QUICK_ACTIONS` 等不随内容语言改名。
 
+#### 7.2.1 骰子触发定制（intents 词表）
+
+内容包可以完全自定义"哪些自然语言词触发什么检定"。规则模板里的 `intents` 表定义意图（意图 = 一类检定，如潜行、调查、施法）及各自的触发词。
+
+**触发优先级**（从规则词表到全局兜底）：
+
+1. 规则模板自带 `intents`：用规则自己的词表，完全自控。
+2. 规则模板 `extends: "intents_base"`（或插件目录内的词表基类）：继承主程序/基类的词库，子规则可覆盖个别意图。
+3. 两者都没有：回退到全局通用词表（`templates/rules/fallback_intents.json`），只提供有限的通用触发。
+
+**`intents` 字段结构**：
+
+```json
+{
+  "intents": {
+    "defaults": {
+      "applies_to_dice_systems": ["d20", "d100"],
+      "zh_match": "substring",
+      "en_match": "word",
+      "case_sensitive": false,
+      "prefer_longest": true
+    },
+    "stealth": {
+      "aliases": {
+        "zh-CN": ["潜行", "潜入", "隐匿", "悄悄"],
+        "en": ["sneak", "stealth", "hide", "creep"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["潜行", "隐匿"],
+        "en": ["stealth", "dexterity"]
+      },
+      "default_attribute": "dex",
+      "priority": 10
+    }
+  }
+}
+```
+
+- `aliases`：触发词，按语言分键（`zh-CN` / `en` / 未来语言）。玩家行动包含任一别名即命中该意图。
+- `skill_candidates`：命中后候选技能，按角色卡技能名匹配。
+- `default_attribute`：命中后默认用哪个属性检定（`str` / `dex` / `int` / `wis` / `cha` 等）。
+- `priority`：多个意图同时命中时，数值小者优先（先匹配者胜）。
+- `applies_to_dice_systems`：该意图适用于哪些骰制（`d20` / `d100`）。不匹配当前局骰制的意图会被跳过，防止 COC 触发只属于 DND 的意图（反之亦然）。
+
+**`dice_system` 决定骰子本身**：`intents` 只决定"触发哪个检定、用什么属性/技能"，骰子算法（d20 还是 d100、成功线、大成功/大失败）由规则模板顶层的 `dice_system` 和 `mechanics` 决定。
+
+**继承主程序词库**：插件规则的 `extends` 支持继承主程序 `templates/rules/` 下的词表（如 `intents_base`），只需写 `"extends": "intents_base"`。继承是"按需"的——不需要词库的规则可以不继承，用全局兜底即可。
+
+**多语言扩展**：词表是数据驱动的，加语言只需给 `aliases` / `skill_candidates` 增加对应语言键（如 `ja`），并保证 `engine/language.py` 登记了该语言后缀。新增语言不会污染其他语言场景。
+
 ### 7.3 主题插件
 
 适用于 CSS 变量、色板、背景、图标和界面风格。主题插件通常是声明型插件。

--- a/docs/PLUGIN_DEVELOPMENT_EN.md
+++ b/docs/PLUGIN_DEVELOPMENT_EN.md
@@ -227,6 +227,56 @@ Supported contributions are `rules`, `world_templates`, `character_templates`, `
 
 Use stable IDs and avoid built-in IDs. Content is never imported automatically. Worlds and catalog records declare `language`; world text is not automatically translated. Rules use `<rule_id>.json` for Chinese and `<rule_id>_en.json` for English, with Chinese fallback. Protocol fields and GM tags remain language-neutral.
 
+#### 7.2.1 Customizing dice triggers (intents)
+
+A content pack can fully control which natural-language phrases trigger which check. The `intents` table in a rule template defines intents (a class of check, such as stealth, investigate, or casting) and their trigger words.
+
+**Trigger precedence** (rule vocabulary first, global fallback last):
+
+1. Rule template defines its own `intents`: fully self-contained.
+2. Rule template `extends: "intents_base"` (or a vocabulary base inside the plugin): inherits the main program/base vocabulary; a child rule can override individual intents.
+3. Neither: falls back to the global generic vocabulary (`templates/rules/fallback_intents.json`) with limited triggers.
+
+**`intents` field structure**:
+
+```json
+{
+  "intents": {
+    "defaults": {
+      "applies_to_dice_systems": ["d20", "d100"],
+      "zh_match": "substring",
+      "en_match": "word",
+      "case_sensitive": false,
+      "prefer_longest": true
+    },
+    "stealth": {
+      "aliases": {
+        "zh-CN": ["潜行", "潜入", "隐匿", "悄悄"],
+        "en": ["sneak", "stealth", "hide", "creep"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["潜行", "隐匿"],
+        "en": ["stealth", "dexterity"]
+      },
+      "default_attribute": "dex",
+      "priority": 10
+    }
+  }
+}
+```
+
+- `aliases`: trigger words, keyed by language (`zh-CN` / `en` / future languages). An action containing any alias matches that intent.
+- `skill_candidates`: candidate skills matched against the character sheet when the intent hits.
+- `default_attribute`: the default attribute for the check (`str` / `dex` / `int` / `wis` / `cha`, etc.).
+- `priority`: when several intents match, lower value wins (first match by sort order).
+- `applies_to_dice_systems`: which dice systems this intent applies to (`d20` / `d100`). Intents that do not match the current game's dice system are skipped, preventing COC from triggering intents meant only for DND and vice versa.
+
+**`dice_system` controls the dice itself**: `intents` only decide which check triggers and which attribute/skill to use; the dice algorithm (d20 vs d100, success thresholds, criticals) is set by the rule template's top-level `dice_system` and `mechanics`.
+
+**Inheriting the main vocabulary**: a plugin rule's `extends` can reference vocabulary under the main program's `templates/rules/` (for example `intents_base`) by writing `"extends": "intents_base"`. Inheritance is opt-in — rules that do not need the vocabulary can omit it and rely on the global fallback.
+
+**Multi-language extension**: vocabularies are data-driven. Adding a language only requires adding keys (such as `ja`) to `aliases` / `skill_candidates` and registering the language suffix in `engine/language.py`. New languages do not pollute other languages.
+
 ### 7.3 Themes
 
 Themes register JSON through `contributes.theme` or `contributes.themes`. The frontend applies filtered CSS custom properties and stores the selected theme in the current browser. Variable names begin with `--`; suspicious values containing `url(`, semicolons, or braces are ignored. Scripts, components, layouts, and arbitrary CSS are unsupported.

--- a/src/engine/checks.py
+++ b/src/engine/checks.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import re
 import uuid
+from pathlib import Path
 from typing import Any
 
 from src.engine.dice import roll
@@ -11,49 +14,48 @@ from src.engine.game_instance import GameInstance
 from src.engine.language import is_english
 from src.rules.rule_system import RuleSystem
 
+logger = logging.getLogger("trpg")
 
-_INTENT_SPECS: tuple[tuple[str, tuple[str, ...], tuple[str, ...], str], ...] = (
-    (
-        "stealth",
-        ("潜行", "潜入", "隐匿", "隐藏", "悄悄", "偷偷", "蹑手蹑脚", "无声", "绕后"),
-        ("潜行", "隐匿", "潜伏", "躲藏"),
-        "dex",
-    ),
-    (
-        "investigate",
-        ("调查", "探查", "检查", "搜查", "搜索", "观察", "侦查", "寻找", "找线索", "辨认", "识别", "追踪"),
-        ("侦查", "调查", "观察", "搜索", "图书馆使用", "追踪"),
-        "int",
-    ),
-    (
-        "perception",
-        ("聆听", "倾听", "察觉", "感知", "留意", "环顾"),
-        ("侦查", "聆听", "察觉", "感知"),
-        "wis",
-    ),
-    (
-        "social",
-        ("说服", "交涉", "谈判", "欺骗", "威吓", "威胁", "套话", "表演"),
-        ("说服", "话术", "魅惑", "威吓", "欺骗", "表演"),
-        "cha",
-    ),
-    (
-        "athletics",
-        ("攀爬", "攀登", "跳跃", "游泳", "冲刺", "奔跑", "推开", "拉开", "撬开", "撞开", "搬起", "举起"),
-        ("攀爬", "游泳", "跳跃", "运动", "体能"),
-        "str",
-    ),
-    (
-        "combat",
-        ("攻击", "射击", "开枪", "挥砍", "砍", "刺", "踢", "突袭", "格挡", "闪避", "施法", "吟唱"),
-        ("射击", "手枪", "步枪", "格斗", "斗殴", "剑术", "法术"),
-        "dex",
-    ),
-)
 
-_GENERIC_CHECK_WORDS = (
-    "检定", "判定", "掷骰", "roll", "check",
-)
+def _load_fallback_intents() -> dict:
+    """加载全局兜底词表（数据驱动，支持多语言）。
+
+    供没有自带 intents 词表的规则使用。放 templates/rules/fallback_intents.json：
+    - intents: {intent_id: {aliases: {lang: [...]}, skill_candidates, default_attribute}}
+    - generic_check_words: {lang: [...]} 通用检定词
+    """
+    path = Path(__file__).resolve().parents[2] / "templates" / "rules" / "fallback_intents.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.warning("通用检定兜底词表加载失败: %s", exc)
+        return {}
+
+
+_FALLBACK_INTENTS: dict = _load_fallback_intents()
+
+
+def _fallback_intent_specs(language: str) -> list[tuple[str, tuple[str, ...], tuple[str, ...], str]]:
+    """兜底意图表（数据驱动），结构同旧 _INTENT_SPECS：[(intent, aliases, skills, attr)]。"""
+    result: list[tuple[str, tuple[str, ...], tuple[str, ...], str]] = []
+    intents = _FALLBACK_INTENTS.get("intents") or {}
+    lang = "zh-CN" if not is_english(language) else "en"
+    for intent, block in intents.items():
+        aliases = block.get("aliases") or {}
+        skills = block.get("skill_candidates") or {}
+        alias_list = tuple(aliases.get(lang) or aliases.get("zh-CN") or ())
+        skill_list = tuple(skills.get(lang) or skills.get("zh-CN") or ())
+        if not alias_list:
+            continue
+        result.append((intent, alias_list, skill_list, str(block.get("default_attribute") or "")))
+    return result
+
+
+def _fallback_generic_words(language: str) -> tuple[str, ...]:
+    """兜底通用检定词（按语言取，回退中文）。"""
+    words = _FALLBACK_INTENTS.get("generic_check_words") or {}
+    lang = "zh-CN" if not is_english(language) else "en"
+    return tuple(words.get(lang) or words.get("zh-CN") or ())
 
 
 def _normalized(text: object) -> str:
@@ -127,14 +129,14 @@ def build_check_request(
     candidates: tuple[str, ...] = ()
     attribute = selected_attribute
 
-    # 意图识别：优先规则词表（数据驱动），规则未带词表时回退到内置 _INTENT_SPECS。
+    # 意图识别：优先规则词表（数据驱动），规则未带词表时回退到全局兜底词表。
     intent = rule.find_intent(action.get("text"), instance.language, dice_system) if rule else ""
     if intent:
         candidates = rule.intent_skill_candidates(intent, instance.language) if rule else ()
         if not attribute:
             attribute = rule.intent_default_attribute(intent) if rule else ""
     else:
-        for intent_name, aliases, skill_candidates, attr_key in _INTENT_SPECS:
+        for intent_name, aliases, skill_candidates, attr_key in _fallback_intent_specs(instance.language):
             if any(_normalized(alias) in text for alias in aliases):
                 intent = intent_name
                 candidates = skill_candidates
@@ -149,7 +151,7 @@ def build_check_request(
 
     explicit_check = bool(selected_skill or selected_attribute)
     # 通用检定词：优先用规则词表的 generic 意图（整词边界，避免 'roll' 命中
-    # 'scroll'）；规则没词表时回退内置 _GENERIC_CHECK_WORDS（子串）。
+    # 'scroll'）；规则没词表时回退全局兜底词（按语言子串）。
     generic_check = False
     if not explicit_check:
         if rule and "generic" in rule.intents:
@@ -157,7 +159,7 @@ def build_check_request(
                 action.get("text"), instance.language, dice_system
             ) == "generic"
         else:
-            generic_check = any(word in text for word in _GENERIC_CHECK_WORDS)
+            generic_check = any(word in text for word in _fallback_generic_words(instance.language))
     if not (explicit_check or intent or direct_skill or generic_check):
         return None
 

--- a/src/engine/language.py
+++ b/src/engine/language.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 
 DEFAULT_LANGUAGE = "zh-CN"
-SUPPORTED_LANGUAGES = {"zh-CN", "en"}
+SUPPORTED_LANGUAGES = {"zh-CN", "en", "ja"}
 
 # 本地化字段后缀登记：中文（zh-*）无后缀（直接用原字段）；
 # 新增语言在此登记后缀后，{key}_{suffix} 式字段即可被 localized_field 查到。
 # 字段可选，缺失时回退原字段，不强制维护。
-_LANG_FIELD_SUFFIXES = {"en": "en"}
+_LANG_FIELD_SUFFIXES = {"en": "en", "ja": "ja"}
 
 
 def normalize_language(value: object) -> str:
     text = str(value or "").strip().lower().replace("_", "-")
     if text in {"en", "en-us", "en-gb", "english"}:
         return "en"
+    if text in {"ja", "jp", "japanese", "日本語"}:
+        return "ja"
     if text in {"zh", "zh-cn", "cn", "chinese", "简体中文", "中文"}:
         return "zh-CN"
     return DEFAULT_LANGUAGE
@@ -52,7 +54,12 @@ def field_suffixes() -> set[str]:
 
 
 def language_name(value: object) -> str:
-    return "English" if is_english(value) else "简体中文"
+    lang = normalize_language(value)
+    if lang == "en":
+        return "English"
+    if lang == "ja":
+        return "日本語"
+    return "简体中文"
 
 
 def gm_language_instruction(value: object) -> str:

--- a/src/rules/rule_system.py
+++ b/src/rules/rule_system.py
@@ -62,7 +62,12 @@ def _resolve_rule_template(path: Path, seen: set[Path] | None = None) -> dict:
     if not parent_path.suffix:
         parent_path = parent_path.with_suffix(".json")
     if not parent_path.is_absolute():
-        parent_path = path.parent / parent_path
+        # 优先相对当前规则目录；找不到时回退主程序 templates/rules/，让插件规则
+        # 也能继承主程序词库（如 intents_base），实现"按需继承"而非全局强绑。
+        candidates = [path.parent / parent_path]
+        builtin_rules = Path(__file__).resolve().parents[2] / "templates" / "rules"
+        candidates.append(builtin_rules / parent_path.name)
+        parent_path = next((c for c in candidates if c.exists()), candidates[0])
     if not parent_path.exists():
         raise FileNotFoundError(f"规则模板基类不存在: {parent_path}")
 

--- a/src/version.py
+++ b/src/version.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "1.9.11"
+__version__ = "1.9.12-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"

--- a/templates/rules/fallback_intents.json
+++ b/templates/rules/fallback_intents.json
@@ -1,0 +1,77 @@
+{
+  "rule_id": "fallback_intents",
+  "rule_name": "通用检定兜底词表",
+  "abstract": true,
+  "intents": {
+    "stealth": {
+      "aliases": {
+        "zh-CN": ["潜行", "潜入", "隐匿", "隐藏", "悄悄", "偷偷", "蹑手蹑脚", "无声", "绕后"],
+        "en": ["sneak", "stealth", "hide", "creep", "slip", "conceal"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["潜行", "隐匿", "潜伏", "躲藏"],
+        "en": ["stealth", "sleight of hand", "dexterity"]
+      },
+      "default_attribute": "dex"
+    },
+    "investigate": {
+      "aliases": {
+        "zh-CN": ["调查", "探查", "检查", "搜查", "搜索", "观察", "侦查", "寻找", "找线索", "辨认", "识别", "追踪"],
+        "en": ["investigate", "examine", "search", "inspect", "look for clues"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["侦查", "调查", "观察", "搜索", "图书馆使用", "追踪"],
+        "en": ["investigation", "perception", "search"]
+      },
+      "default_attribute": "int"
+    },
+    "perception": {
+      "aliases": {
+        "zh-CN": ["聆听", "倾听", "察觉", "感知", "留意", "环顾"],
+        "en": ["listen", "perceive", "notice", "spot", "look around"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["侦查", "聆听", "察觉", "感知"],
+        "en": ["perception", "spot", "listen"]
+      },
+      "default_attribute": "wis"
+    },
+    "social": {
+      "aliases": {
+        "zh-CN": ["说服", "交涉", "谈判", "欺骗", "威吓", "威胁", "套话", "表演"],
+        "en": ["persuade", "convince", "negotiate", "deceive", "intimidate", "threaten"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["说服", "话术", "魅惑", "威吓", "欺骗", "表演"],
+        "en": ["persuasion", "deception", "intimidation"]
+      },
+      "default_attribute": "cha"
+    },
+    "athletics": {
+      "aliases": {
+        "zh-CN": ["攀爬", "攀登", "跳跃", "游泳", "冲刺", "奔跑", "推开", "拉开", "撬开", "撞开", "搬起", "举起"],
+        "en": ["climb", "jump", "swim", "sprint", "run", "push", "lift"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["攀爬", "游泳", "跳跃", "运动", "体能"],
+        "en": ["athletics", "acrobatics"]
+      },
+      "default_attribute": "str"
+    },
+    "combat": {
+      "aliases": {
+        "zh-CN": ["攻击", "射击", "开枪", "挥砍", "砍", "刺", "踢", "突袭", "格挡", "闪避", "施法", "吟唱"],
+        "en": ["attack", "shoot", "strike", "slash", "stab", "kick", "parry", "dodge"]
+      },
+      "skill_candidates": {
+        "zh-CN": ["射击", "手枪", "步枪", "格斗", "斗殴", "剑术", "法术"],
+        "en": ["attack", "shooting", "melee", "weapon"]
+      },
+      "default_attribute": "dex"
+    }
+  },
+  "generic_check_words": {
+    "zh-CN": ["检定", "判定", "掷骰"],
+    "en": ["roll", "check"]
+  }
+}


### PR DESCRIPTION
## Summary
- 插件规则词库定制：`extends` 支持回退继承主程序 `templates/rules/`（如 intents_base），插件内容包可自定义判定触发词。
- 兜底词表数据驱动化：`_INTENT_SPECS`/`_GENERIC_CHECK_WORDS` 硬编码移到 `fallback_intents.json`，按语言组织。
- 日语语言支持：`engine/language.py` 识别 ja/日本語，`_ja` 后缀。
- 补 PLUGIN_DEVELOPMENT 7.2.1 骰子触发定制文档。

## 影响
- 向后兼容：现有插件与玩法不受影响；新增"插件可继承词库"能力。
- 加语言只需加词表键，不再改硬编码。

## 验证
- 编译通过；568 全量测试 + 56 规则/骰子测试通过；JSON 有效。