### PR TITLE
docs: README 下载链接指向 Latest Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ QQ 交流群：1060613588
 
 普通 Windows 用户建议直接下载便携版：
 
-[前往 Releases 下载](https://github.com/diceframe/diceframe/releases)
+[前往 Releases 下载最新版](https://github.com/diceframe/diceframe/releases/latest)
 
 下载最新的 `DiceFrame-vX.Y.Z-windows-portable.zip`，解压后运行 `DiceFrame.exe`。首次打开后，在浏览器设置页填写 API 地址、模型名和 API Key。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,7 +31,7 @@ It brings the Web UI, character sheets, lorebooks, dice checks, state changes, c
 
 ### Windows Portable
 
-Download the latest `DiceFrame-vX.Y.Z-windows-portable.zip` from [Releases](https://github.com/diceframe/diceframe/releases), extract it, and run `DiceFrame.exe`. Enter the model base URL, model name, and API key in Settings.
+Download the latest `DiceFrame-vX.Y.Z-windows-portable.zip` from [Releases](https://github.com/diceframe/diceframe/releases/latest), extract it, and run `DiceFrame.exe`. Enter the model base URL, model name, and API key in Settings.
 
 Windows portable builds can check for and apply updates from Settings.
 


### PR DESCRIPTION
README/README_EN 的 Windows 便携包下载链接从 releases 目录改为 releases/latest，避免用户看到预览版。