### PR TITLE
docs: 设置页移除 QQ 群号

### DIFF
--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -840,7 +840,6 @@ function redownloadUpdatePackage() {
               <p>{{ t('officialWebsite') }}: <a href="https://diceframe.com" target="_blank" rel="noopener">diceframe.com</a></p>
               <p>{{ t('projectAddress') }}: <a href="https://github.com/diceframe/diceframe" target="_blank" rel="noopener">diceframe/diceframe</a></p>
               <p>{{ t('issueFeedback') }}: <a href="https://github.com/diceframe/diceframe/issues" target="_blank" rel="noopener">{{ t('submitIssue') }}</a></p>
-              <p>{{ t('qqGroup') }}: 1060613588</p>
             </section>
             <section class="sponsor-card" :aria-label="t('supportProject')">
               <div>


### PR DESCRIPTION
设置页联系区移除 QQ 群号，只保留官方网站、项目地址、问题反馈。