### PR TITLE
build: portable 包不再打包 cloudflared 二进制

### DIFF
--- a/scripts/build_portable.py
+++ b/scripts/build_portable.py
@@ -299,7 +299,7 @@ def main() -> int:
 
     if BUILD_ROOT.exists():
         remove_generated_tree(BUILD_ROOT)
-    build_release.prepare_package_tree(app_dir)
+    build_release.prepare_package_tree(app_dir, include_cloudflared=False)
     (app_dir / "web_ui.bat").unlink(missing_ok=True)
     build_release.build_frontend(app_dir)
     remove_generated_tree(app_dir / "frontend-v2")

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -194,7 +194,7 @@ def download_cloudflared(package_dir: Path) -> None:
         print(f"cloudflared saved to {target}")
     except Exception as exc:  # noqa: BLE001
         print(f"Warning: cloudflared download failed, plugin will fetch at runtime: {exc}")
-def prepare_package_tree(package_dir: Path) -> None:
+def prepare_package_tree(package_dir: Path, *, include_cloudflared: bool = True) -> None:
     if package_dir.exists():
         shutil.rmtree(package_dir)
     package_dir.mkdir(parents=True)
@@ -211,7 +211,8 @@ def prepare_package_tree(package_dir: Path) -> None:
     for rel in FRONTEND_DIRS:
         copy_tree(ROOT / "frontend-v2" / rel, frontend_dir / rel)
 
-    download_cloudflared(package_dir)
+    if include_cloudflared:
+        download_cloudflared(package_dir)
 
 
 def build_frontend(package_dir: Path) -> None:


### PR DESCRIPTION
## 改动

portable 包跳过 cloudflared 二进制打包；source 包保留。

- `build_release.prepare_package_tree` 新增 `include_cloudflared` 参数（默认 True）
- `build_portable.py` 调用时传 `False`

## 原因

beta.2 起 portable 包体积从 20.3MB 涨到 37.6MB，多出的 ~17MB 是打包进每个包的 cloudflared 二进制。用外网接入插件的用户只是少数，不需要让所有 portable 用户背这份体积。用户需要时从商店装插件，插件自带二进制下载兜底（方案 B）。

## 验证

- `py_compile` 通过
- `prepare_package_tree(include_cloudflared=False)` 实际运行确认包内无 cloudflared 目录
- source 包默认路径未变（仍带 cloudflared）