### PR TITLE
fix: release 构建脚本绕过 aiohttp import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v2.0.0-beta.1
+# DiceFrame v2.0.0-beta.2
 
 ## 中文
 
@@ -30,8 +30,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-beta.1-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.0.0-beta.1-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-beta.2-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.0.0-beta.2-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -64,6 +64,6 @@ This is the first 2.0.0 preview, accumulating 41 commits and 367 file changes si
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v2.0.0-beta.1-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.0.0-beta.1-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v2.0.0-beta.2-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.0.0-beta.2-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/scripts/build_assistant_knowledge.py
+++ b/scripts/build_assistant_knowledge.py
@@ -19,7 +19,15 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.webui import assistant_knowledge as ak
+# 直接按文件加载 assistant_knowledge 模块，绕过 src/webui/__init__.py
+# （后者 import WebAPI -> aiohttp，构建环境未装依赖会失败）
+import importlib.util
+_spec = importlib.util.spec_from_file_location(
+    "assistant_knowledge", ROOT / "src" / "webui" / "assistant_knowledge.py"
+)
+ak = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ak  # 注册后 exec，dataclass 才能解析模块
+_spec.loader.exec_module(ak)
 
 
 def build(output: Path | None = None) -> Path:

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.0.0-beta.1"
+__version__ = "2.0.0-beta.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Summary
- build_assistant_knowledge 导入 src.webui.assistant_knowledge 时触发 __init__.py -> WebAPI -> aiohttp
- 构建环境未装 aiohttp，release workflow v2.0.0-beta.1 构建失败
- 改用 importlib.util 直接按文件加载模块，不触发包初始化

## Test plan
- 本地 python scripts/build_assistant_knowledge.py 正常输出 196 chunks