### PR TITLE
fix: release 校验头像改 v3 jpg + 版本 2.0.0-beta.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DiceFrame v2.0.0-beta.2
+# DiceFrame v2.0.0-beta.3
 
 ## 中文
 
@@ -30,8 +30,8 @@
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-beta.2-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.0.0-beta.2-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-beta.3-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.0.0-beta.3-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
@@ -64,6 +64,6 @@ This is the first 2.0.0 preview, accumulating 41 commits and 367 file changes si
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v2.0.0-beta.2-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.0.0-beta.2-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v2.0.0-beta.3-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.0.0-beta.3-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -31,8 +31,9 @@ except ImportError:  # Direct execution: python scripts/build_release.py
 
 DIST_DIR = ROOT / "dist"
 BUILD_ROOT = DIST_DIR / "_release_build"
-EXPECTED_BUILTIN_AVATAR_ATLASES = 12
-MAX_BUILTIN_AVATAR_COMPRESSED_BYTES = 4 * 1024 * 1024
+# v3 头像：6 规则 × 8 张 jpg（4 realistic + 4 anime）。旧 WebP 图集（12 张）已弃用。
+EXPECTED_BUILTIN_AVATAR_ATLASES = 48
+MAX_BUILTIN_AVATAR_COMPRESSED_BYTES = 8 * 1024 * 1024
 BUILTIN_BACKGROUND_FILES = {
     "dark-fantasy-atmosphere.jpg",
     "campaign-mountain-city.jpg",
@@ -302,18 +303,18 @@ def validate_zip(output_zip: Path) -> None:
 
 def validate_avatar_payload(infos: list[zipfile.ZipInfo], *, require_source: bool) -> None:
     normalized = [(info, info.filename.replace("\\", "/")) for info in infos]
-    built = [info for info, name in normalized if "/static-v2/avatars/" in name and name.endswith(".webp")]
-    source = [info for info, name in normalized if "/frontend-v2/public/avatars/" in name and name.endswith(".webp")]
+    built = [info for info, name in normalized if "/static-v2/avatars/v3/" in name and name.endswith(".jpg")]
+    source = [info for info, name in normalized if "/frontend-v2/public/avatars/v3/" in name and name.endswith(".jpg")]
     legacy_png = [name for _, name in normalized if "/avatars/" in name and name.lower().endswith(".png")]
     if legacy_png:
         raise RuntimeError("Release zip contains legacy PNG portrait atlases")
     if len(built) != EXPECTED_BUILTIN_AVATAR_ATLASES:
         raise RuntimeError(
-            f"Release zip must contain {EXPECTED_BUILTIN_AVATAR_ATLASES} built WebP portrait atlases, got {len(built)}"
+            f"Release zip must contain {EXPECTED_BUILTIN_AVATAR_ATLASES} built v3 portrait images, got {len(built)}"
         )
     if require_source and len(source) != EXPECTED_BUILTIN_AVATAR_ATLASES:
         raise RuntimeError(
-            f"Source release must contain {EXPECTED_BUILTIN_AVATAR_ATLASES} source WebP portrait atlases, got {len(source)}"
+            f"Source release must contain {EXPECTED_BUILTIN_AVATAR_ATLASES} source v3 portrait images, got {len(source)}"
         )
     compressed_size = sum(info.compress_size for info in built + source)
     if compressed_size > MAX_BUILTIN_AVATAR_COMPRESSED_BYTES:

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.0.0-beta.2"
+__version__ = "2.0.0-beta.3"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Summary
- 头像系统从 12 个 WebP 图集改为 6 规则×8 张 v3 jpg（48 张），但 build_release.py 校验仍查旧 webp 路径
- validate_avatar_payload 更新匹配 v3 jpg 格式，修复 release workflow 构建失败（'got 0'）
- MAX_BUILTIN_AVATAR_COMPRESSED_BYTES 4MB→8MB
- 版本 2.0.0-beta.3（beta.2 tag 已推但构建失败，不能复用）

## Test plan
- test_release_build.py 2 测试通过
- 模拟 48 jpg 校验通过、少一张正确拦截