### PR TITLE
release: v2.0.0 正式版

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
           cache: pip
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -87,17 +87,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: requirements.txt
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare image tags
         id: meta
@@ -42,23 +42,23 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: "npm"
@@ -39,14 +39,14 @@ jobs:
           for f in *.zip; do sha256sum "$f" > "$f.sha256"; done
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: diceframe-windows-zip
           path: dist/*.zip
 
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           body_path: RELEASE_NOTES.md
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -59,15 +59,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: "npm"
@@ -83,14 +83,14 @@ jobs:
           for f in *.zip; do sha256sum "$f" > "$f.sha256"; done
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: diceframe-windows-portable
           path: dist/*portable*.zip
 
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           body_path: RELEASE_NOTES.md
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,43 +1,77 @@
-# DiceFrame v2.0.0-beta.4
+# DiceFrame v2.0.0
 
 ## 中文
 
-这是 2.0.0 的第二个预览版，自 v2.0.0-beta.3 起修复了支付与幸运选择的体验问题，并把插件商店拆分为**插件商店 / 内容商店**两个入口。预览版用户可以更新体验；正式版频道不受影响。
+这是 DiceFrame 2.0 正式版，自 v1.9.11 以来重构了插件生态、新增官方公告，并做了大量游玩体验与稳定性修复。正式版频道现在可以更新体验。
+
+### 新功能
+
+- **插件商店与内容商店**：插件页拆分为"插件商店 / 内容商店"两个选项卡——内容商店专注展示内容包类资源，插件商店聚焦机器人接入、工具、主题等插件，查找更直接。
+- **插件商店生态**：工具型插件可渲染专用操作卡片（如外网接入卡）；商店条目显示所需 DiceFrame 最低版本并提示升级；支持更大插件包为二进制进程插件铺路。
+- **一键外网接入**：新增官方 **Cloudflare 快速隧道**插件，一键生成公网 HTTPS 地址并自动写入分享链接，朋友和群聊 Bot 无需公网 IP 或域名即可加入你的对局；在"插件 → 工具"页的外网接入卡片操作。
+- **主题与皮肤**：新增 4 套内置配色皮肤——星海秘典、王廷鎏金、翡翠远境、绯红余烬，在"设置 → 主题"页卡片式一键切换，并可与明暗模式叠加；也可继续安装插件主题深度定制。
+- **插件规则词库定制**：插件作者可扩展检定意图词表（extends 继承），自定义规则体系的检定匹配更贴合。
+- **公告系统**：新增官方公告拉取与展示（内容经 Hub 网络获取）。
+
+### 体验与玩法
+
+- **世界书 / 游戏日志页**：未进入存档或未选择世界时显示整洁的单列空态引导，不再出现"只有一边一排"的错乱布局。
+- **剧情提示**：推进回合后不再用顶部气泡重复弹出剧情全文，剧情只在时间线展示。
+- **GM 指令目标解析**：角色真名（如"冒险者"）优先于泛指词匹配，修复"复活冒险者"被误判为歧义而拒绝的问题。
+- **骰子 / 规则修复**：SAN 检定大成功不再按失败结算；CoC 自定义技能基础值兜底防超模建卡；物理破坏/撬/砸/拆解类行动明确提示应进行检定。
+- **幸运机制**：多人幸运改判改为每玩家独立超时（默认 60 秒可配），不再一人挂机全桌等待。
+- **难度机制**：硬核难度禁止复活（角色可永久死亡），落实难度差异。
+- **Hub 访问**：请求超时从 3 秒/6 秒放宽到 30 秒，减少 Hub 站缓慢时误触发熔断、插件详情打不开。
+- **默认模型**：默认模型调整为 `deepseek-v4-flash`，更快更省。
+- **设置页"支持项目"与 GitHub Star**：并排一行展示、文字左对齐。
 
 ### 修复与体验
 
 - **支付流程**：创建角色余额不足时，不再反复弹出支付窗口——自动取消未完成的支付订单，避免弹窗循环打扰。
-- **幸运选择**：'保留失败'按钮改为与'消耗幸运点'一致的红色 pill 样式，两个选项一眼可辨。
-
-### 插件商店
-
-- **商店拆分**：插件页新增"插件商店 / 内容商店"两个选项卡——内容商店专注展示内容包类资源，插件商店聚焦机器人接入、工具、主题等插件，查找更直接。
+- **幸运选择**："保留失败"按钮改为与"消耗幸运点"一致的红色 pill 样式，两个选项一眼可辨。
+- **商店目录刷新**：目录缓存从 30 天缩短为 1 天，上架与更新能更快看到；目录过期时来源旁会出现刷新按钮。
 - **地图包调整**：地图包（map-pack）暂不支持在线安装，相关条目不再出现在商店可安装列表中，避免误导。
-- **目录刷新**：商店目录缓存从 30 天缩短为 1 天，上架与更新能更快看到；目录过期时来源旁会出现刷新按钮。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-beta.4-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.0.0-beta.4-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.0.0-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-This is the second 2.0.0 preview, fixing payment and luck-selection experience issues and splitting the plugin store into **Plugin Store / Content Store** tabs. Preview-channel users can update and try it; the stable channel is unaffected.
+This is the DiceFrame 2.0 stable release — a major update since v1.9.11 with a rebuilt plugin ecosystem, official announcements, and a large batch of play-experience and stability fixes. Stable-channel users can update and enjoy it.
+
+### New Features
+
+- **Plugin Store / Content Store**: the Plugins page now has "Plugin Store / Content Store" tabs — Content Store focuses on content-pack resources, while Plugin Store focuses on bot adapters, tools, themes and other plugins, making discovery more direct.
+- **Plugin ecosystem**: tool plugins render dedicated operation cards (e.g. an external-access card); store entries show the minimum DiceFrame version and prompt upgrades; larger packages are supported, paving the way for binary process plugins.
+- **One-click external access**: a new official **Cloudflare quick tunnel** plugin generates a public HTTPS address with one click and writes it into the share link, so friends and chat bots can join your table without a public IP or domain; operate it from the external-access card on Plugins → Tools.
+- **Themes & skins**: four new built-in color skins — Star Sea Codex, Golden Court, Jade Frontier, and Crimson Ember — switchable from one-card taps on the Settings → Themes page and stackable with light/dark mode; plugin themes are still available for deeper customization.
+- **Custom rule lexicons for plugins**: plugin authors can extend the check-intent lexicon (extends inheritance), so custom rule systems match their checks more closely.
+- **Announcements**: official announcements are fetched from the Hub and shown in-app.
+
+### Play & Experience
+
+- **Lorebook / game log pages**: clean single-column empty states when no save or world is selected, fixing the misaligned "only one side" layout.
+- **Narration toast**: advancing a round no longer re-pops the full narration in a top toast; it is shown only in the timeline.
+- **GM command target resolution**: exact character names (e.g. "Adventurer") now take priority over generic terms, fixing "revive Adventurer" being wrongly rejected as ambiguous.
+- **Dice & rules fixes**: SAN critical success no longer resolves as failure; CoC custom-skill base fallback prevents over-powered sheets; physical actions (prying / breaking / dismantling) now clearly warrant a check.
+- **Luck**: multiplayer luck decisions get a per-player timeout (default 60 s, configurable) instead of blocking the whole table for one player.
+- **Difficulty**: hardcore difficulty disables revival (characters can permanently die), making difficulty levels meaningful.
+- **Hub access**: request timeouts widened from 3 s/6 s to 30 s, reducing false circuit-breaking when the Hub site is slow and plugin details fail to open.
+- **Default model**: the default model is now `deepseek-v4-flash`, faster and cheaper.
+- **Support Project + GitHub Star buttons**: shown side by side in Settings, text left-aligned.
 
 ### Fixes & Experience
 
 - **Payment flow**: when balance is insufficient while creating a character, the pending payment order is now cancelled automatically instead of repeatedly popping up the payment dialog.
 - **Luck selection**: the "Keep failure" button now uses the same red pill style as "Spend luck point", so the two options are easy to tell apart.
-
-### Plugin Store
-
-- **Store split**: the Plugins page now has "Plugin Store / Content Store" tabs — Content Store focuses on content-pack resources, while Plugin Store focuses on bot adapters, tools, themes and other plugins, making discovery more direct.
-- **Map pack**: map-pack is reserved for a future map editor and no longer appears as installable in the store.
 - **Catalog refresh**: store catalog cache shortened from 30 days to 1 day so listings and updates appear faster; a refresh button appears next to the source when the catalog is stale.
+- **Map pack**: map-pack is reserved for a future map editor and no longer appears as installable in the store.
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v2.0.0-beta.4-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.0.0-beta.4-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v2.0.0-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.0.0-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/frontend-v2/src/App.vue
+++ b/frontend-v2/src/App.vue
@@ -29,8 +29,9 @@ const route = useRoute()
 const { naiveTheme, overrides, loadPluginThemes, suspendPluginTheme, restorePluginTheme } = useTheme()
 const { locale, setLocale, t } = useLocale()
 const { updateAvailable } = useUpdateCheck()
-const naiveLocale = computed(() => locale.value === 'en' ? enUS : zhCN)
-const naiveDateLocale = computed(() => locale.value === 'en' ? dateEnUS : dateZhCN)
+// naive-ui 无 ja locale；ja 界面回退英文组件语言，而非中文。
+const naiveLocale = computed(() => locale.value === 'zh-CN' ? zhCN : enUS)
+const naiveDateLocale = computed(() => locale.value === 'zh-CN' ? dateZhCN : dateEnUS)
 
 const items = [
   { id: 'overview', labelKey: 'navOverview', icon: HomeOutline },

--- a/frontend-v2/src/composables/useAnnouncements.ts
+++ b/frontend-v2/src/composables/useAnnouncements.ts
@@ -18,7 +18,9 @@ const hasUnread = computed(() => Boolean(hash.value) && hash.value !== readHash.
 const hasContent = computed(() => Boolean(content.value))
 
 function normalizeLanguage(locale: string): AnnouncementLanguage {
-  return (locale || '').toLowerCase().startsWith('en') ? 'en' : 'zh'
+  const lang = (locale || '').toLowerCase()
+  // 官方公告只有 zh/en；ja 界面回退英文公告，而非中文。
+  return lang.startsWith('en') || lang.startsWith('ja') ? 'en' : 'zh'
 }
 
 function storageKey(language: AnnouncementLanguage): string {

--- a/frontend-v2/src/composables/useUpdater.ts
+++ b/frontend-v2/src/composables/useUpdater.ts
@@ -22,8 +22,11 @@ const isDownloading = computed(() => DOWNLOAD_STATES.has(updateStatus.value?.sta
 const isUpdateBusy = computed(() => ACTIVE_STATES.has(updateStatus.value?.state || 'idle'))
 
 // 从更新弹窗的“去设置”进入时是否自动开始下载。仅在可写的 source/portable
-// 安装、确有新版、且无进行中/已完成任务时触发；docker/development/只读
-// 模式下 kind 为 null，不触发。
+// 安装、确有新版、且无进行中任务时触发；docker/development/只读模式下
+// kind 为 null，不触发。
+// 注意：state/version 反映的是上次更新的持久化结果，检测到新版本时不会重置。
+// 若上次 state 残留为 done/staged（属于旧版本），不能据此拦截——否则弹窗“前往
+// 设置”后永远不自动下载。只拦截真正进行中的任务，避免并发下载。
 export function shouldAutoDownloadUpdate(
   kind: 'source' | 'portable' | null,
   state: string | undefined,
@@ -31,7 +34,7 @@ export function shouldAutoDownloadUpdate(
   updateAvailable: boolean,
 ): boolean {
   if (!kind || focus !== 'update') return false
-  if (state && state !== 'idle' && state !== 'failed') return false
+  if (state && ACTIVE_STATES.has(state as UpdateStatusResponse['state'])) return false
   return updateAvailable
 }
 

--- a/frontend-v2/src/i18n/index.ts
+++ b/frontend-v2/src/i18n/index.ts
@@ -35,7 +35,8 @@ function initialLocale(): Locale {
 export const i18n = createI18n({
   legacy: false,
   locale: initialLocale(),
-  fallbackLocale: 'zh-CN',
+  // 缺失语言（如 ja 尚未翻译的文案）回退英文，而非中文。
+  fallbackLocale: 'en',
   messages,
   missingWarn: false,
   fallbackWarn: false,

--- a/frontend-v2/src/utils/ruleSchema.ts
+++ b/frontend-v2/src/utils/ruleSchema.ts
@@ -35,13 +35,20 @@ function isEnglish(): boolean {
   return i18n.global.locale.value === 'en'
 }
 
+// zh 界面用中文；en/ja 界面均回退英文（ja 缺失文案回退英文，而非中文）。
+function localeIsZh(): boolean {
+  const locale = i18n.global.locale.value
+  return typeof locale === 'string' && locale.startsWith('zh')
+}
+
 const LOCALE_FIELD_SUFFIX: Record<string, string> = { en: 'en' }
 
 export function localeFieldSuffix(): string {
   const locale = i18n.global.locale.value
   if (typeof locale === 'string' && locale.startsWith('zh')) return ''
   const main = typeof locale === 'string' ? locale.split('-')[0] : ''
-  return LOCALE_FIELD_SUFFIX[main] || ''
+  // ja 等非 zh 界面缺失时回退 en 后缀字段，而非原字段（zh）。
+  return LOCALE_FIELD_SUFFIX[main] || 'en'
 }
 
 export function localizedField<T = unknown>(obj: Record<string, unknown> | null | undefined, key: string): T | undefined {
@@ -54,8 +61,9 @@ export function localizedField<T = unknown>(obj: Record<string, unknown> | null 
 }
 
 export function localizedLabel(value: LabelValue, fallback: LabelValue = ''): string {
-  const localeFirst = isEnglish() ? 'en' : 'zh'
-  const localeSecond = isEnglish() ? 'zh' : 'en'
+  // zh 界面优先中文标签；en/ja 界面均回退英文标签（ja 缺失时回退英文）。
+  const localeFirst = localeIsZh() ? 'zh' : 'en'
+  const localeSecond = localeIsZh() ? 'en' : 'zh'
   if (value && typeof value === 'object') {
     return value[localeFirst] || value[localeSecond] || localizedLabel(undefined, fallback)
   }
@@ -70,8 +78,8 @@ export function attrDisplayName(attr: RuleAttr): string {
   const key = attr.key || ''
   if (attr.display_name) return attr.display_name
   // 中文界面只显示中文名(力量),不拼括号英文,避免列表/侧栏过宽;
-  // 英文界面显示英文缩写(STR)。
-  const name = isEnglish() ? (attr.name_en || ATTR_NAME_EN[key] || attr.name || key) : (attr.name || ATTR_NAME_ZH[key] || key)
+  // en/ja 界面显示英文缩写(STR)（ja 缺失时回退英文）。
+  const name = localeIsZh() ? (attr.name || ATTR_NAME_ZH[key] || key) : (attr.name_en || ATTR_NAME_EN[key] || attr.name || key)
   return name
 }
 

--- a/frontend-v2/tests/SettingsUpdateAutoDownload.test.ts
+++ b/frontend-v2/tests/SettingsUpdateAutoDownload.test.ts
@@ -22,11 +22,19 @@ describe('shouldAutoDownloadUpdate', () => {
     expect(shouldAutoDownloadUpdate(null, 'idle', 'update', true)).toBe(false)
   })
 
-  it('does not trigger while downloading, staged, or applied', () => {
+  it('does not trigger while a download task is in progress', () => {
     expect(shouldAutoDownloadUpdate('source', 'downloading', 'update', true)).toBe(false)
-    expect(shouldAutoDownloadUpdate('source', 'staged', 'update', true)).toBe(false)
-    expect(shouldAutoDownloadUpdate('source', 'done', 'update', true)).toBe(false)
+    expect(shouldAutoDownloadUpdate('source', 'verifying', 'update', true)).toBe(false)
     expect(shouldAutoDownloadUpdate('source', 'applying', 'update', true)).toBe(false)
+    expect(shouldAutoDownloadUpdate('source', 'restarting', 'update', true)).toBe(false)
+  })
+
+  it('allows downloading a newer version after a previous staged/done state', () => {
+    // state/version 是上次更新的持久化结果，检测到新版本时不会重置。若上次
+    // 残留 staged/done（属于旧版本）却因此拦截，弹窗“前往设置”后永远不自动
+    // 下载。有新版本（updateAvailable=true）时应允许重新下载。
+    expect(shouldAutoDownloadUpdate('source', 'staged', 'update', true)).toBe(true)
+    expect(shouldAutoDownloadUpdate('source', 'done', 'update', true)).toBe(true)
   })
 
   it('does not trigger when no update is available', () => {

--- a/src/commands/prompt_composer.py
+++ b/src/commands/prompt_composer.py
@@ -67,7 +67,16 @@ class PromptComposer:
                     else "You are the GM for a TRPG text adventure. Narrate in natural English. The GM prompt file is missing."
                 )
             else:
-                _GM_PROMPT_CACHE[cache_key] = "你是 TRPG 游戏的主持人（GM）。请用流畅中文进行叙述。（GM prompt 文件缺失）"
+                # ja 等非 en 语言的 prompt 缺失时先回退英文文件，再回退中文。
+                # 输出语言仍由 gm_language_instruction 单独控制，不受此回退影响。
+                en = self.prompts_dir / "gm_system_en.md"
+                zh = self.prompts_dir / "gm_system_zh.md"
+                if en.exists():
+                    _GM_PROMPT_CACHE[cache_key] = en.read_text(encoding="utf-8")
+                elif zh.exists():
+                    _GM_PROMPT_CACHE[cache_key] = zh.read_text(encoding="utf-8")
+                else:
+                    _GM_PROMPT_CACHE[cache_key] = "你是 TRPG 游戏的主持人（GM）。请用流畅中文进行叙述。（GM prompt 文件缺失）"
         prompt = _GM_PROMPT_CACHE[cache_key]
         if rule_appendix:
             heading = localized_text(cache_key, {"en": "## Current Rules", "zh-CN": "## 当前规则", "ja": "## 現在のルール"})

--- a/src/engine/checks.py
+++ b/src/engine/checks.py
@@ -43,8 +43,8 @@ def _fallback_intent_specs(language: str) -> list[tuple[str, tuple[str, ...], tu
     for intent, block in intents.items():
         aliases = block.get("aliases") or {}
         skills = block.get("skill_candidates") or {}
-        alias_list = tuple(aliases.get(lang) or aliases.get("zh-CN") or ())
-        skill_list = tuple(skills.get(lang) or skills.get("zh-CN") or ())
+        alias_list = tuple(aliases.get(lang) or aliases.get("en") or aliases.get("zh-CN") or ())
+        skill_list = tuple(skills.get(lang) or skills.get("en") or skills.get("zh-CN") or ())
         if not alias_list:
             continue
         result.append((intent, alias_list, skill_list, str(block.get("default_attribute") or "")))
@@ -52,10 +52,10 @@ def _fallback_intent_specs(language: str) -> list[tuple[str, tuple[str, ...], tu
 
 
 def _fallback_generic_words(language: str) -> tuple[str, ...]:
-    """兜底通用检定词（按语言取，回退中文）。"""
+    """兜底通用检定词（按语言取，回退英文再中文）。"""
     words = _FALLBACK_INTENTS.get("generic_check_words") or {}
     lang = localized_text(language, {"en": "en", "zh-CN": "zh-CN", "ja": "ja"})
-    return tuple(words.get(lang) or words.get("zh-CN") or ())
+    return tuple(words.get(lang) or words.get("en") or words.get("zh-CN") or ())
 
 
 def _normalized(text: object) -> str:

--- a/src/engine/language.py
+++ b/src/engine/language.py
@@ -33,10 +33,11 @@ def localized_text(language: object, texts: dict[str, str], fallback: str = "") 
     """按语言查表取文案（P3-A n-way 重构的核心 helper）。
 
     texts = {"zh-CN": "...", "en": "...", "ja": "..."}；未命中当前语言时回退
-    zh-CN，再回退 fallback。逐步替代 `if english: A else B` 的二元分叉。
+    en，再回退 zh-CN，最后回退 fallback。逐步替代 `if english: A else B` 的
+    二元分叉。第三语言（ja）缺失时优先回退英文。
     """
     lang = normalize_language(language)
-    return texts.get(lang) or texts.get("zh-CN") or fallback
+    return texts.get(lang) or texts.get("en") or texts.get("zh-CN") or fallback
 
 
 def lang_suffix(language: object) -> str:
@@ -51,12 +52,18 @@ def lang_suffix(language: object) -> str:
 
 
 def localized_field(template: dict, key: str, language: object = DEFAULT_LANGUAGE):
-    """按语言取本地化字段：优先 {key}_{suffix}，回退 {key}。字段可选，不强制维护。"""
+    """按语言取本地化字段：优先 {key}_{suffix}，第三语言（ja）缺失时回退 {key}_en，
+    再无则回退 {key}（zh 原文）。字段可选，不强制维护。"""
     suffix = lang_suffix(language)
     if suffix:
         v = template.get(f"{key}_{suffix}")
         if v is not None:
             return v
+        # ja 等非 en 语言缺失时先回退英文字段，保持与 localized_text 的回退链一致。
+        if suffix != "en":
+            en_v = template.get(f"{key}_en")
+            if en_v is not None:
+                return en_v
     return template.get(key)
 
 

--- a/src/llm/context_builder.py
+++ b/src/llm/context_builder.py
@@ -1,4 +1,4 @@
-﻿"""Context 拼接器 —— 按 TokenBudget 优先级硬分配，将游戏状态拼接为 LLM 输入。"""
+"""Context 拼接器 —— 按 TokenBudget 优先级硬分配，将游戏状态拼接为 LLM 输入。"""
 
 from __future__ import annotations
 
@@ -35,10 +35,14 @@ _BUDGET_LOREBOOK = 0.20        # Lorebook 条目
 _BUDGET_SUMMARY = 0.08         # 最新摘要 + 关键事实
 _BUDGET_MEMORY = 0.06          # 长期记忆
 _BUDGET_HISTORY_MIN = 0.22     # 对话历史最小比例
+_BUDGET_CONFIRMED = 0.03       # 已确认事项（收尾收缩时最先让出的一档）
 # 剩余 ~6% 用于玩家消息和分隔符
 
 _INVENTORY_STATE_LIMIT = 20
 _KEY_ITEMS_STATE_LIMIT = 12
+
+# 段间分隔符（收尾总长检查也按此计算）
+_SEP = "\n\n---\n\n"
 
 
 def _compact_state_view(state: dict) -> None:
@@ -81,7 +85,7 @@ def _detect_max_chars(provider_name: str = "") -> int:
 
 def _estimate_tokens(text: str) -> int:
     """估算 token 数：CJK 字符约 1 token/字，其余约 4 字符/token。"""
-    cjk = sum(1 for ch in text if '\u4e00' <= ch <= '\u9fff')
+    cjk = sum(1 for ch in text if '一' <= ch <= '鿿')
     return max(1, cjk + (len(text) - cjk) // 4)
 
 
@@ -166,6 +170,59 @@ def _format_history(log: list[dict], max_chars: int, language: str = "zh-CN") ->
     return "\n\n".join(sorted_lines)
 
 
+def _context_total_len(parts: list[str]) -> int:
+    """含段间分隔符的完整上下文长度。"""
+    return sum(len(p) for p in parts) + len(_SEP) * max(0, len(parts) - 1)
+
+
+def _shrink_section(text: str, overflow: int, drop_oldest_rounds: bool) -> str:
+    """把单段上下文收缩 overflow 字符，作为超窗时的最后保险。
+
+    - drop_oldest_rounds=True（对话历史）：保留标题行，从最旧轮次开始整轮
+      删除，保留 [Round N] 行结构不切半行，优先保住最新的轮次；
+    - 其余段：直接硬截断到目标长度。
+    """
+    target = max(1, len(text) - overflow)
+    if not drop_oldest_rounds:
+        return _truncate(text, target)
+    heading, _, body = text.partition("\n")
+    rounds = body.split("\n\n")
+    newest: list[str] = []
+    used = len(heading)
+    for r in reversed(rounds):  # 从最新轮往回保留，放不下的旧轮丢弃
+        need = len(r) + 2
+        if used + need <= target:
+            newest.append(r)
+            used += need
+    newest.reverse()  # 恢复最旧在前的顺序
+    return "\n\n".join([heading] + newest)
+
+
+def _shrink_to_window(parts: list[str], sec_idx: dict[str, int], max_total: int) -> None:
+    """上下文总长超过模型窗口时，按优先级从低到高收缩各段，就地修改 parts。
+
+    正常路径（各段都在预算内）总长由历史预算公式自限，不会走到这里；此函数
+    只兜住极端配置（已确认事项/世界书/角色状态爆大）导致的总长超窗，保证不把
+    超窗上下文发给模型。被收缩的对话历史/已确认事项已有摘要与长期记忆冗余覆盖。
+    """
+    # 优先级从低到高（越靠前越先让出）：对话历史 → 已确认事项 → 长期记忆 → 摘要 → 世界书 → 游戏状态
+    for key, drop_oldest in (
+        ("history", True),
+        ("confirmed", False),
+        ("memory", False),
+        ("summary", False),
+        ("lorebook", False),
+        ("state", False),
+    ):
+        idx = sec_idx.get(key)
+        if idx is None:
+            continue
+        overflow = _context_total_len(parts) - max_total
+        if overflow <= 0:
+            break
+        parts[idx] = _shrink_section(parts[idx], overflow, drop_oldest)
+
+
 async def build_context(
     instance: GameInstance,
     gm_prompt_filled: str,
@@ -186,9 +243,11 @@ async def build_context(
         player_message: 当前玩家说的话
         memory_store: MemoryStore 实例，用于召回长期记忆
         platform: 平台名，用于模型检测（可选）
+        history_override: 覆盖对话历史（如重新生成 swipe 时只取目标轮之前的日志）
 
     Returns:
-        完整的上下文字符串
+        完整的上下文字符串。总长保证不超过 max_total：各块先按预算分配，
+        拼接后若仍超窗（极端配置），按优先级从低到高逐段收缩兜底。
     """
     max_total = _detect_max_chars(provider_name)
     language = getattr(instance, "language", "zh-CN")
@@ -202,9 +261,11 @@ async def build_context(
         budget_lorebook = min(budget_lorebook, lorebook_budget)
     budget_summary = int(max_total * _BUDGET_SUMMARY)
     budget_memory = int(max_total * _BUDGET_MEMORY)
+    budget_confirmed = int(max_total * _BUDGET_CONFIRMED)
     budget_history_base = max(int(max_total * _BUDGET_HISTORY_MIN), max_total // 6)
 
     parts: list[str] = []
+    sec_idx: dict[str, int] = {}  # 段名 → parts 索引，供超窗收尾收缩使用
     reserved_system_chars = min(len(gm_prompt_filled), budget_system)
 
     # 1. 游戏状态（LLM 精简视图，含属性修正）
@@ -216,6 +277,7 @@ async def build_context(
         state_json = json.dumps(state, ensure_ascii=False)
     state_json = _truncate(state_json, budget_state)
     parts.append(localized_text(language, {"en": "## Game State", "zh-CN": "【游戏状态】", "ja": "## ゲーム状態"}) + f"\n{state_json}")
+    sec_idx["state"] = len(parts) - 1
 
     # 2. Lorebook 条目（核心 NPC/场景优先）
     lorebook_text = ""
@@ -239,6 +301,7 @@ async def build_context(
                      len(trimmed), ", ".join(trimmed[:5]), budget_lorebook)
     if lorebook_text:
         parts.append(localized_text(language, {"en": "## World Knowledge", "zh-CN": "【世界观知识】", "ja": "## 世界知識"}) + f"\n{lorebook_text.strip()}")
+        sec_idx["lorebook"] = len(parts) - 1
 
     # 3. 摘要 + 关键事实
     summary = sanitize_narration(instance.summary.get("narrative", ""))
@@ -256,20 +319,23 @@ async def build_context(
             summary_section_parts.append(facts_text)
     if summary_section_parts:
         parts.append(localized_text(language, {"en": "## Recent Events", "zh-CN": "【近期经历】", "ja": "## 最近の出来事"}) + "\n" + "\n".join(summary_section_parts))
+        sec_idx["summary"] = len(parts) - 1
 
-    # D1: 已确认事项（防 GM 重复讨论）
+    # D1: 已确认事项（防 GM 重复讨论；有预算上限，超窗收尾时优先让出）
     if instance.confirmed_items:
         confirmed_text = localized_text(language, {
             "en": "; ".join(instance.confirmed_items[-20:]),
             "zh-CN": "、".join(instance.confirmed_items[-20:]),
             "ja": "、".join(instance.confirmed_items[-20:]),
         })
+        confirmed_text = _truncate(confirmed_text, budget_confirmed)
         heading = localized_text(language, {
             "en": "## Confirmed Items\nIf players ask about the same thing again, move forward instead of re-explaining.",
             "zh-CN": "【已确认事项】（玩家再问相同内容时直接推进，不要重复解释）",
             "ja": "## 確認済み事項\nプレイヤーが同じことを再度尋ねても、再説明せず先へ進めること。",
         })
         parts.append(f"{heading}\n{confirmed_text}")
+        sec_idx["confirmed"] = len(parts) - 1
 
     # 4. 长期记忆召回（召回源：玩家消息 + 最近 3 轮 GM 回复，提高命中率）
     if memory_store:
@@ -287,6 +353,7 @@ async def build_context(
             if memory_text:
                 memory_text = _truncate(memory_text, budget_memory)
                 parts.append(memory_text)
+                sec_idx["memory"] = len(parts) - 1
         except Exception:
             logger.warning("长期记忆召回失败，已降级为无记忆上下文", exc_info=True)
 
@@ -298,11 +365,20 @@ async def build_context(
     history = _format_history(history_entries, history_budget, language)
     if history:
         parts.append(localized_text(language, {"en": "## Conversation History", "zh-CN": "【对话历史】", "ja": "## 会話履歴"}) + f"\n{history}")
+        sec_idx["history"] = len(parts) - 1
 
-    # 6. 玩家刚说的话
+    # 6. 玩家刚说的话（永不参与超窗收缩）
     parts.append(localized_text(language, {"en": "## Player Message", "zh-CN": "【玩家发言】", "ja": "## プレイヤーの発言"}) + f"\n{player_message}")
 
     context = "\n\n---\n\n".join(parts)
+
+    # 收尾硬上限：总长超过模型窗口时按优先级逐段收缩（最后保险，正常路径不触发）。
+    # 历史预算公式自限时总长恒 ≤ 窗口，此检查只兜住极端配置下的超窗。
+    total_len = _context_total_len(parts)
+    if total_len > max_total:
+        logger.warning("Context 超窗 %d > %d，触发收尾收缩", total_len, max_total)
+        _shrink_to_window(parts, sec_idx, max_total)
+        context = "\n\n---\n\n".join(parts)
 
     logger.debug(
         "Context 拼接完成: total_chars=%d, est_tokens=%d, max=%d",

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.0.0-beta.4"
+__version__ = "2.0.0"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -1,11 +1,15 @@
 """上下文拼接器测试。"""
 
+import logging
+
 import pytest
 from src.llm.context_builder import (
     _INVENTORY_STATE_LIMIT,
     _KEY_ITEMS_STATE_LIMIT,
     _compact_state_view,
-    _detect_max_chars, _estimate_tokens, _truncate, _format_history, build_context,
+    _context_total_len,
+    _detect_max_chars, _estimate_tokens, _truncate, _format_history,
+    _shrink_section, _shrink_to_window, build_context,
 )
 
 
@@ -112,6 +116,49 @@ class TestFormatHistory:
         assert "Round 1" not in result or "Round 5" in result
 
 
+class TestShrinkSection:
+    def test_truncates_non_history(self):
+        result = _shrink_section("x" * 100, 40, drop_oldest_rounds=False)
+        assert len(result) <= 60
+        assert result.endswith("...")
+
+    def test_history_keeps_latest_rounds_with_structure(self):
+        heading = "【对话历史】"
+        rounds = [f"[Round {i}]\n玩家: 行动{i}\nGM: 回复{i}" for i in range(1, 10)]
+        text = heading + "\n" + "\n\n".join(rounds)
+        result = _shrink_section(text, len(text) // 2, drop_oldest_rounds=True)
+        assert result.startswith(heading)
+        assert "Round 9" in result   # 最新轮保留
+        assert "Round 1" not in result  # 最旧轮被丢
+        assert len(result) <= len(text) // 2 + 1
+        # 每个保留的轮次块都完整（含结尾 GM 行），未被切半
+        body = result.split("\n", 1)[1]
+        for block in body.split("\n\n"):
+            assert "GM:" in block
+
+
+class TestShrinkToWindow:
+    def test_shrinks_low_priority_first(self):
+        hist = "【对话历史】\n" + "\n\n".join(
+            f"[Round {i}]\n玩家: 行动{i}\nGM: 回复{i}" for i in range(1, 40)
+        )
+        parts = [
+            "【游戏状态】\n" + "状态" * 200,
+            "【世界观知识】\n" + "设定" * 200,
+            "【已确认事项】\n" + "事项、" * 200,
+            hist,
+        ]
+        sec_idx = {"state": 0, "lorebook": 1, "confirmed": 2, "history": 3}
+        _shrink_to_window(parts, sec_idx, max_total=1600)
+        assert _context_total_len(parts) <= 1600
+        # 历史（最低优先级）被收缩，最新轮保留
+        assert parts[3].startswith("【对话历史】")
+        assert "Round 39" in parts[3]
+        # 更高优先级的段未被触碰（历史一轮收缩就吸收完溢出）
+        assert parts[0] == "【游戏状态】\n" + "状态" * 200
+        assert parts[2] == "【已确认事项】\n" + "事项、" * 200
+
+
 class DummyInstance:
     game_key = ("web", "dummy", "bot")
     summary = {}
@@ -141,3 +188,35 @@ async def test_build_context_does_not_duplicate_system_prompt():
     assert "【游戏状态】" in context
     assert "【世界观知识】" in context
     assert "【玩家发言】" in context
+
+
+@pytest.mark.asyncio
+async def test_build_context_enforces_window_with_extreme_inputs(caplog, monkeypatch):
+    """极端配置（海量已确认事项/世界书 + 超长玩家消息）下，上下文仍不超窗。"""
+    monkeypatch.setenv("TRPG_MAX_CONTEXT_CHARS", "3000")
+    instance = DummyInstance()
+    instance.confirmed_items = [f"已确认事项{i}" * 20 for i in range(200)]
+    instance.log = [
+        {
+            "round": i,
+            "actions": [{"text": f"行动 {i}：前往村口寻找线索。"}],
+            "gm_response": f"第{i}轮 GM 回复：你沿小路走去，夜色中传来低语。" * 3,
+        }
+        for i in range(1, 31)
+    ]
+    with caplog.at_level(logging.WARNING, logger="trpg"):
+        context = await build_context(
+            instance,
+            gm_prompt_filled="你是测试 GM，负责推动剧情。" * 30,
+            lorebook_entries=[
+                {"type": "location", "name": f"地点{i}", "content": "旧祠深处埋着石碑。" * 20}
+                for i in range(1, 60)
+            ],
+            player_message="我" * 1500,
+            provider_name="deepseek",
+        )
+    assert len(context) <= 3000
+    assert "【玩家发言】" in context
+    assert "【已确认事项】" in context
+    # 收尾收缩确已触发
+    assert "触发收尾收缩" in caplog.text

--- a/tests/test_language_support.py
+++ b/tests/test_language_support.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import src.commands.prompt_composer as prompt_module
 from src.commands.prompt_composer import PromptComposer
 from src.engine.game_instance import GameInstance
-from src.engine.language import gm_language_instruction, normalize_language
+from src.engine.language import gm_language_instruction, localized_field, localized_text, normalize_language
 
 
 def test_language_normalization_accepts_english_aliases():
@@ -47,3 +47,25 @@ def test_language_instruction_keeps_protocol_tags_in_english_mode():
     assert "GOLD" in instruction
     assert "LOOT" in instruction
     assert "SCENE" in instruction
+
+
+def test_localized_text_falls_back_to_english_for_ja_missing():
+    texts = {"zh-CN": "中文", "en": "English"}
+    # ja 缺失时回退 en，而非 zh-CN。
+    assert localized_text("ja", texts) == "English"
+    # en 缺失时回退 zh-CN。
+    assert localized_text("en", {"zh-CN": "中文"}) == "中文"
+    # zh-CN 缺失时回退 fallback。
+    assert localized_text("zh-CN", {"en": "English"}, "兜底") == "English"
+
+
+def test_localized_field_falls_back_to_english_suffix_for_ja():
+    template = {"name": "中文名", "name_en": "English Name"}
+    # ja 缺失 _ja 字段 → 回退 _en 字段。
+    assert localized_field(template, "name", "ja") == "English Name"
+    # zh-CN 用原字段。
+    assert localized_field(template, "name", "zh-CN") == "中文名"
+    # en 用 _en 字段。
+    assert localized_field(template, "name", "en") == "English Name"
+    # 无 _en 时回退原字段。
+    assert localized_field({"name": "中文名"}, "name", "ja") == "中文名"


### PR DESCRIPTION
## 概述
v2.0.0 正式版发布分支。合并后打 `v2.0.0` tag 触发 GitHub Release 与 Docker 发布（tag 授权将单独申请）。

## 改动内容
- **上下文收尾硬上限**：`build_context` 拼接后若总长超过模型窗口，按优先级（历史→已确认→记忆→摘要→世界书→游戏状态）逐段收缩兜底；已确认事项增加 3% 预算上限。修复极端配置下可能把超窗上下文发给模型的问题。
- **ja 语言回退链改 en**：后端 `localized_text`/`localized_field`、检定词表、GM prompt 缺失回退、前端 naive-ui locale / i18n fallback / 规则标签均改为缺失时回退英文。
- **更新弹窗自动下载修复**：`shouldAutoDownloadUpdate` 只拦截真正进行中的任务，避免上次 `staged/done` 残留导致"前往设置"后永远不自动下载。
- **GitHub Actions 升级**：checkout / setup-python / setup-node / upload-artifact / action-gh-release / docker 系列升级到新版本。
- **版本号与 Release Notes**：`2.0.0-beta.4` → `2.0.0`，完整中英双语发布说明。

## 验证
- 后端 pytest：747 passed
- 前端 typecheck / Vitest 109 passed / 生产构建通过
- build_release.py 打包成功，zip 内容检查无内部文件