### PR TITLE
release: v2.0.1-beta.1——移动端对局页沉浸化 + 高度兜底

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,77 +1,29 @@
-# DiceFrame v2.0.0
+# DiceFrame v2.0.1-beta.1
 
 ## 中文
 
-这是 DiceFrame 2.0 正式版，自 v1.9.11 以来重构了插件生态、新增官方公告，并做了大量游玩体验与稳定性修复。正式版频道现在可以更新体验。
+这是 2.0 系列的预览版，专注手机端对局体验。预览版频道现在可以更新体验。
 
-### 新功能
+### 移动端对局体验
 
-- **插件商店与内容商店**：插件页拆分为"插件商店 / 内容商店"两个选项卡——内容商店专注展示内容包类资源，插件商店聚焦机器人接入、工具、主题等插件，查找更直接。
-- **插件商店生态**：工具型插件可渲染专用操作卡片（如外网接入卡）；商店条目显示所需 DiceFrame 最低版本并提示升级；支持更大插件包为二进制进程插件铺路。
-- **一键外网接入**：新增官方 **Cloudflare 快速隧道**插件，一键生成公网 HTTPS 地址并自动写入分享链接，朋友和群聊 Bot 无需公网 IP 或域名即可加入你的对局；在"插件 → 工具"页的外网接入卡片操作。
-- **主题与皮肤**：新增 4 套内置配色皮肤——星海秘典、王廷鎏金、翡翠远境、绯红余烬，在"设置 → 主题"页卡片式一键切换，并可与明暗模式叠加；也可继续安装插件主题深度定制。
-- **插件规则词库定制**：插件作者可扩展检定意图词表（extends 继承），自定义规则体系的检定匹配更贴合。
-- **公告系统**：新增官方公告拉取与展示（内容经 Hub 网络获取）。
+- **沉浸式对局页**：手机上进入对局后，应用顶栏与底部导航自动隐藏，把整块屏幕让给对局内容，对话窗口显著变大。
+- **精简顶栏与场景条**：对局页顶栏与场景条压缩为单行，只保留关键信息，对话与输入区获得更多空间。
+- **对话区自适应高度**：浏览器或 App 壳的工具栏收起/展开时，对话区会自动拉长或收缩，不再出现"底部栏下去了、对话框却没跟着变"的错位。
 
-### 体验与玩法
+### 说明
 
-- **世界书 / 游戏日志页**：未进入存档或未选择世界时显示整洁的单列空态引导，不再出现"只有一边一排"的错乱布局。
-- **剧情提示**：推进回合后不再用顶部气泡重复弹出剧情全文，剧情只在时间线展示。
-- **GM 指令目标解析**：角色真名（如"冒险者"）优先于泛指词匹配，修复"复活冒险者"被误判为歧义而拒绝的问题。
-- **骰子 / 规则修复**：SAN 检定大成功不再按失败结算；CoC 自定义技能基础值兜底防超模建卡；物理破坏/撬/砸/拆解类行动明确提示应进行检定。
-- **幸运机制**：多人幸运改判改为每玩家独立超时（默认 60 秒可配），不再一人挂机全桌等待。
-- **难度机制**：硬核难度禁止复活（角色可永久死亡），落实难度差异。
-- **Hub 访问**：请求超时从 3 秒/6 秒放宽到 30 秒，减少 Hub 站缓慢时误触发熔断、插件详情打不开。
-- **默认模型**：默认模型调整为 `deepseek-v4-flash`，更快更省。
-- **设置页"支持项目"与 GitHub Star**：并排一行展示、文字左对齐。
-
-### 修复与体验
-
-- **支付流程**：创建角色余额不足时，不再反复弹出支付窗口——自动取消未完成的支付订单，避免弹窗循环打扰。
-- **幸运选择**："保留失败"按钮改为与"消耗幸运点"一致的红色 pill 样式，两个选项一眼可辨。
-- **商店目录刷新**：目录缓存从 30 天缩短为 1 天，上架与更新能更快看到；目录过期时来源旁会出现刷新按钮。
-- **地图包调整**：地图包（map-pack）暂不支持在线安装，相关条目不再出现在商店可安装列表中，避免误导。
-
-### 下载指南
-
-- **普通 Windows 用户**：下载 `DiceFrame-v2.0.0-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.0.0-windows.zip`。
-- `.sha256` 是更新校验文件，普通用户不需要手动下载。
+预览版仅供预览频道体验，正式版频道暂不推送。发现问题欢迎反馈。
 
 ## English
 
-This is the DiceFrame 2.0 stable release — a major update since v1.9.11 with a rebuilt plugin ecosystem, official announcements, and a large batch of play-experience and stability fixes. Stable-channel users can update and enjoy it.
+This is a preview release of the 2.0 series focused on the mobile play experience. Preview-channel users can update and try it.
 
-### New Features
+### Mobile Play Experience
 
-- **Plugin Store / Content Store**: the Plugins page now has "Plugin Store / Content Store" tabs — Content Store focuses on content-pack resources, while Plugin Store focuses on bot adapters, tools, themes and other plugins, making discovery more direct.
-- **Plugin ecosystem**: tool plugins render dedicated operation cards (e.g. an external-access card); store entries show the minimum DiceFrame version and prompt upgrades; larger packages are supported, paving the way for binary process plugins.
-- **One-click external access**: a new official **Cloudflare quick tunnel** plugin generates a public HTTPS address with one click and writes it into the share link, so friends and chat bots can join your table without a public IP or domain; operate it from the external-access card on Plugins → Tools.
-- **Themes & skins**: four new built-in color skins — Star Sea Codex, Golden Court, Jade Frontier, and Crimson Ember — switchable from one-card taps on the Settings → Themes page and stackable with light/dark mode; plugin themes are still available for deeper customization.
-- **Custom rule lexicons for plugins**: plugin authors can extend the check-intent lexicon (extends inheritance), so custom rule systems match their checks more closely.
-- **Announcements**: official announcements are fetched from the Hub and shown in-app.
+- **Immersive table**: the app header and bottom navigation are hidden on mobile during play, giving the whole screen to the table — the conversation window is much larger.
+- **Compact HUD & scene strip**: the play HUD and scene strip collapse to a single row, keeping only the essentials and freeing more space for dialogue and input.
+- **Adaptive conversation height**: when the browser or app-shell toolbar hides or expands, the conversation area stretches or shrinks automatically instead of leaving a mismatch.
 
-### Play & Experience
+### Note
 
-- **Lorebook / game log pages**: clean single-column empty states when no save or world is selected, fixing the misaligned "only one side" layout.
-- **Narration toast**: advancing a round no longer re-pops the full narration in a top toast; it is shown only in the timeline.
-- **GM command target resolution**: exact character names (e.g. "Adventurer") now take priority over generic terms, fixing "revive Adventurer" being wrongly rejected as ambiguous.
-- **Dice & rules fixes**: SAN critical success no longer resolves as failure; CoC custom-skill base fallback prevents over-powered sheets; physical actions (prying / breaking / dismantling) now clearly warrant a check.
-- **Luck**: multiplayer luck decisions get a per-player timeout (default 60 s, configurable) instead of blocking the whole table for one player.
-- **Difficulty**: hardcore difficulty disables revival (characters can permanently die), making difficulty levels meaningful.
-- **Hub access**: request timeouts widened from 3 s/6 s to 30 s, reducing false circuit-breaking when the Hub site is slow and plugin details fail to open.
-- **Default model**: the default model is now `deepseek-v4-flash`, faster and cheaper.
-- **Support Project + GitHub Star buttons**: shown side by side in Settings, text left-aligned.
-
-### Fixes & Experience
-
-- **Payment flow**: when balance is insufficient while creating a character, the pending payment order is now cancelled automatically instead of repeatedly popping up the payment dialog.
-- **Luck selection**: the "Keep failure" button now uses the same red pill style as "Spend luck point", so the two options are easy to tell apart.
-- **Catalog refresh**: store catalog cache shortened from 30 days to 1 day so listings and updates appear faster; a refresh button appears next to the source when the catalog is stale.
-- **Map pack**: map-pack is reserved for a future map editor and no longer appears as installable in the store.
-
-### Download Guide
-
-- **Regular Windows users**: download `DiceFrame-v2.0.0-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.0.0-windows.zip`.
-- `.sha256` files are update checksums; regular users do not need to download them manually.
+This preview is for the preview channel only; the stable channel is not updated yet. Feedback is welcome.

--- a/frontend-v2/e2e/responsive.spec.ts
+++ b/frontend-v2/e2e/responsive.spec.ts
@@ -121,7 +121,7 @@ test('equipment details modal stays above the open phone character drawer', asyn
   expect(layers.modal).toBeGreaterThan(layers.drawer)
 })
 
-test('phone play keeps scene metadata compact and actions above bottom navigation', async ({ page }) => {
+test('phone play keeps scene metadata compact and actions anchored to the viewport bottom', async ({ page }) => {
   const token = accessToken()
   await page.addInitScript(value => localStorage.setItem('trpg_access_token', value), token)
   await page.setViewportSize({ width: 390, height: 844 })
@@ -132,15 +132,22 @@ test('phone play keeps scene metadata compact and actions above bottom navigatio
   const layout = await page.evaluate(() => {
     const scene = document.querySelector<HTMLElement>('.scene-strip')!
     const composer = document.querySelector<HTMLElement>('.composer')!
+    const header = document.querySelector<HTMLElement>('.app-header')!
     const nav = document.querySelector<HTMLElement>('.mobile-bottom-nav')!
     return {
       sceneHeight: scene.getBoundingClientRect().height,
       composerBottom: composer.getBoundingClientRect().bottom,
-      navTop: nav.getBoundingClientRect().top,
+      viewportHeight: window.innerHeight,
+      headerHidden: getComputedStyle(header).display === 'none',
+      navHidden: getComputedStyle(nav).display === 'none',
     }
   })
+  // 沉浸式对局页：顶栏/底导隐藏，输入区贴到视口底边，不再受底部导航遮挡
+  expect(layout.headerHidden).toBe(true)
+  expect(layout.navHidden).toBe(true)
   expect(layout.sceneHeight).toBeLessThanOrEqual(82)
-  expect(layout.composerBottom).toBeLessThanOrEqual(layout.navTop)
+  expect(layout.composerBottom).toBeGreaterThanOrEqual(layout.viewportHeight - 12)
+  expect(layout.composerBottom).toBeLessThanOrEqual(layout.viewportHeight + 1)
 })
 
 test('phone play has no spacer bands around the game workspace', async ({ page }) => {
@@ -151,21 +158,26 @@ test('phone play has no spacer bands around the game workspace', async ({ page }
   await expect(page.locator('.composer')).toBeVisible()
 
   const geometry = await page.evaluate(() => {
-    const header = document.querySelector<HTMLElement>('.app-header')!.getBoundingClientRect()
+    const header = document.querySelector<HTMLElement>('.app-header')!
     const workspace = document.querySelector<HTMLElement>('.app-workspace')!.getBoundingClientRect()
     const pageView = document.querySelector<HTMLElement>('.play-page')!.getBoundingClientRect()
     const hud = document.querySelector<HTMLElement>('.play-hud')!.getBoundingClientRect()
     const main = document.querySelector<HTMLElement>('.play-main')!.getBoundingClientRect()
-    const nav = document.querySelector<HTMLElement>('.mobile-bottom-nav')!.getBoundingClientRect()
+    const nav = document.querySelector<HTMLElement>('.mobile-bottom-nav')!
     return {
-      headerGap: workspace.top - header.bottom,
+      headerHidden: getComputedStyle(header).display === 'none',
+      navHidden: getComputedStyle(nav).display === 'none',
+      workspaceTop: workspace.top,
       hudGap: hud.top - pageView.top,
-      pageBottomGap: nav.top - pageView.bottom,
+      pageBottomGap: window.innerHeight - pageView.bottom,
       mainBottomGap: pageView.bottom - main.bottom,
     }
   })
 
-  expect(Math.abs(geometry.headerGap)).toBeLessThanOrEqual(1)
+  // 沉浸式对局页：顶栏/底导隐藏，对局内容从视口顶铺满到底，无 spacer band
+  expect(geometry.headerHidden).toBe(true)
+  expect(geometry.navHidden).toBe(true)
+  expect(Math.abs(geometry.workspaceTop)).toBeLessThanOrEqual(1)
   expect(Math.abs(geometry.hudGap)).toBeLessThanOrEqual(1)
   expect(Math.abs(geometry.pageBottomGap)).toBeLessThanOrEqual(1)
   expect(Math.abs(geometry.mainBottomGap)).toBeLessThanOrEqual(1)

--- a/frontend-v2/src/main.ts
+++ b/frontend-v2/src/main.ts
@@ -7,6 +7,17 @@ import './styles/tokens.css'
 import './styles.css'
 import './styles/v2.css'
 
+// 视口高度兜底：部分 App 壳（如 Eagle）的工具栏显示/隐藏不会更新动态视口单位
+// （100dvh 只跟浏览器原生地址栏联动），导致 fixed 元素随视口下移而对局页不跟随。
+// 把真实可视区高度写入 --app-h CSS 变量，布局层用它计算高度，任何 resize 都会触发。
+function syncViewportHeight() {
+  const h = window.visualViewport?.height || window.innerHeight
+  document.documentElement.style.setProperty('--app-h', `${h}px`)
+}
+syncViewportHeight()
+window.addEventListener('resize', syncViewportHeight)
+window.visualViewport?.addEventListener('resize', syncViewportHeight)
+
 const app = createApp(App).use(createPinia()).use(router).use(i18n)
 
 // Hash history resolves asynchronously on a direct deep link. Mounting before

--- a/frontend-v2/src/styles/v2/layout.css
+++ b/frontend-v2/src/styles/v2/layout.css
@@ -271,10 +271,10 @@
   }
 
   .app-shell-play {
-    grid-template-rows: max-content minmax(0, 1fr);
-    height: 100dvh;
+    grid-template-rows: minmax(0, 1fr);
+    height: var(--app-h, 100dvh);
     min-height: 0;
-    padding-bottom: calc(58px + env(safe-area-inset-bottom));
+    padding-bottom: 0;
     overflow: hidden;
   }
 
@@ -341,6 +341,90 @@
     padding-bottom: 0;
     overflow: hidden;
     scroll-padding-bottom: 0;
+  }
+
+  /* 对局页沉浸：手机上隐藏应用顶栏与底部导航，把全部高度让给对局内容。
+     顶栏/底导在对局页均无功能（返回靠 play-hud 返回键，抽屉靠浮动按钮），
+     省下 ~116px 直接还给对话时间线。 */
+  .app-shell-play .app-header,
+  .app-shell-play .mobile-bottom-nav {
+    display: none;
+  }
+
+  .app-shell-play .game-sidebar,
+  .app-shell-play .play-control-rail,
+  .app-shell-play .game-sidebar.collapsed,
+  .app-shell-play .play-control-rail.collapsed {
+    top: 0;
+    bottom: 0;
+  }
+
+  .app-shell-play .play-drawer-backdrop {
+    inset: 0;
+  }
+
+  /* 压缩对局页顶栏与场景条：一行 title + tools，统计行与场景副标让位 */
+  .app-shell-play .play-hud {
+    position: relative;
+    top: auto;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "title tools";
+    min-height: 0;
+    padding: 5px 10px;
+    gap: 8px;
+  }
+
+  .app-shell-play .play-hud-stats {
+    display: none;
+  }
+
+  .app-shell-play .play-titleblock h1 {
+    font-size: 16px;
+  }
+
+  .app-shell-play .play-main {
+    padding-bottom: calc(6px + env(safe-area-inset-bottom));
+  }
+
+  .app-shell-play .scene-strip {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    min-height: 0;
+    padding: 6px 10px;
+  }
+
+  .app-shell-play .scene-strip::after {
+    display: none;
+  }
+
+  .app-shell-play .scene-title {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .app-shell-play .scene-title p {
+    display: none;
+  }
+
+  .app-shell-play .scene-strip h2 {
+    margin: 0;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .app-shell-play .scene-chips {
+    max-width: none;
+  }
+
+  .app-shell-play .scene-chips span {
+    padding: 2px 6px;
+    font-size: 11px;
   }
 
   .mobile-bottom-nav::before {

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.0.0"
+__version__ = "2.0.1-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## 中文

2.0 系列预览版，专注手机端对局体验。预览版频道可更新体验。

### 移动端对局体验

- **沉浸式对局页**：手机上进入对局后，应用顶栏与底部导航自动隐藏，整块屏幕让给对局内容，对话窗口显著变大。
- **精简顶栏与场景条**：对局页顶栏与场景条压缩为单行，只保留关键信息，对话与输入区获得更多空间。
- **对话区自适应高度**：浏览器或 App 壳的工具栏收起/展开时，对话区自动拉长或收缩，不再出现"底部栏下去了、对话框却没跟着变"的错位。

### 说明

预览版仅供预览频道体验，正式版频道暂不推送。

## English

A preview release of the 2.0 series focused on the mobile play experience.

### Mobile Play Experience

- **Immersive table**: app header and bottom nav are hidden on mobile during play, giving the whole screen to the table.
- **Compact HUD & scene strip**: the play HUD and scene strip collapse to a single row, keeping only the essentials.
- **Adaptive conversation height**: the conversation area stretches/shrinks as browser or app-shell toolbars show or hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)