### PR TITLE
docs(plugin): 进程型插件生命周期要求补充宿主世代检测（zh+en）

### DIFF
--- a/docs/en/plugin-development.md
+++ b/docs/en/plugin-development.md
@@ -125,22 +125,34 @@ Process plugins inherit only a small operating-system variable allowlist. A plug
 
 The host creates, restarts, and manages the **plugin process** (exponential backoff restart, reset after stability). Each plugin must handle two things itself to avoid becoming a zombie or leaking child processes:
 
-1. **Watch the parent process**: the host injects `TRPG_PARENT_PID` (the main process PID). When the host exits, the plugin should end itself immediately; otherwise it is left as an orphan. See the independently-distributed `cloudflare-tunnel` plugin (repo [`diceframe/cloudflare-tunnel`](https://github.com/diceframe/cloudflare-tunnel)) for a self-contained `parent_watch.py` reference implementation (cross-platform `pid_exists` + `start_parent_watch`); process plugins can copy it:
+1. **Watch the parent process and the host generation**: the host injects `TRPG_PARENT_PID` (the main process PID) and atomically writes this host process's generation token to `DICEFRAME_PLUGIN_DATA_DIR/.host-generation` before spawning a plugin each time. The plugin should check both, and exit (self-terminate) immediately when either triggers:
+   - **Parent PID disappears**: the host process has exited; otherwise the plugin is left as an orphan.
+   - **Host generation changes or is missing**: the DiceFrame main process restarts via `os.execv` (PID and starttime stay the same), so a pure PID check wrongly thinks the parent is alive, leaving the old plugin process as an orphan that keeps holding single-instance locks and other resources. A changed or missing generation file means the host has restarted; the plugin should exit immediately.
+
+   See the independently-distributed `cloudflare-tunnel` plugin (repo [`diceframe/cloudflare-tunnel`](https://github.com/diceframe/cloudflare-tunnel), generation detection built in since v0.2.0) for a self-contained `parent_watch.py` reference implementation (cross-platform `pid_exists` + `read_generation_file` + `start_parent_watch`); process plugins can copy it and pass the generation file path and current value:
 
    ```python
    # self-contained in the plugin, not an SDK public export
-   from parent_watch import start_parent_watch
+   from pathlib import Path
+   from parent_watch import read_generation_file, start_parent_watch
 
-   start_parent_watch(on_exit=lambda: cleanup_your_subprocess())
+   generation_file = Path(os.environ["DICEFRAME_PLUGIN_DATA_DIR"]) / ".host-generation"
+   start_parent_watch(
+       on_exit=lambda: cleanup_your_subprocess(),
+       generation_file=generation_file,
+       initial_generation=read_generation_file(generation_file),
+   )
    ```
 
-   `on_exit` is the cleanup callback when the host exits (for example, killing subprocesses the plugin spawned).
+   `on_exit` is the cleanup callback when the host exits or restarts (for example, killing subprocesses the plugin spawned). Plugins with a single-instance lock (such as channel adapters) should also release the lock in `on_exit`, and can follow the `qq-napcat` plugin v1.4.0 lock takeover (orphan detection + SIGTERM→SIGKILL then rebuild the lock) so new instances are not rejected by a stale lock.
+
+   Older hosts (< 2.0.2) do not write the generation file: `read_generation_file` returns an empty string, the generation check is skipped, and the plugin degrades to pure PID detection, working on both new and old hosts.
 
 2. **Clean up child processes on exit**: any subprocess the plugin spawns (such as an external binary) must be terminated when the plugin exits, to avoid leftovers. Kill them after the plugin main loop finishes and provide a fallback via `start_parent_watch(on_exit=...)`.
 
 The host's plugin-process restart (`_monitor_process`) and the plugin's own subprocess recovery are separate layers: a crashed plugin process is restarted by the host; a subprocess the plugin spawned and crashed is the plugin's own responsibility (a retry with exponential backoff capped at 60s is suggested).
 
-Boundary of the convention: reconnect strategies and business-specific backoff are plugin-specific and not standardized. Only "watch the parent process + clean up on exit" is the baseline every process plugin should follow.
+Boundary of the convention: reconnect strategies and business-specific backoff are plugin-specific and not standardized. Only "watch the parent process + the host generation + clean up on exit" is the baseline every process plugin should follow.
 
 ## 6.3 config.schema.json
 

--- a/docs/zh/plugin-development.md
+++ b/docs/zh/plugin-development.md
@@ -185,22 +185,34 @@ tool
 
 宿主负责创建、重启和管理**插件进程**（指数退避重启、稳定后复位）。插件自身必须负责两件事，避免成为僵尸或残留子进程：
 
-1. **监控父进程存活**：宿主为插件注入 `TRPG_PARENT_PID`（主进程 PID）。宿主进程退出后，插件应立即结束（自杀），否则会残留为孤儿进程。可参照独立分发的 `cloudflare-tunnel` 插件（仓库 [`diceframe/cloudflare-tunnel`](https://github.com/diceframe/cloudflare-tunnel)）内置的 `parent_watch.py` 参考实现（跨平台 `pid_exists` + `start_parent_watch`），进程型插件可复制：
+1. **监控父进程存活与宿主世代**：宿主为插件注入 `TRPG_PARENT_PID`（主进程 PID），并在每次启动插件进程前，把本宿主进程的世代标识（token）原子写入 `DICEFRAME_PLUGIN_DATA_DIR/.host-generation`。插件须双检，任一触发立即退出（自杀）：
+   - **父进程 PID 消失**：宿主进程退出，插件应立即结束，否则残留为孤儿进程。
+   - **宿主世代变化/缺失**：DiceFrame 主程序重启是 `os.execv` 自替换（PID 与 starttime 都不变），纯 PID 检测会误判父进程存活，宿主换代后旧插件进程残留为孤儿、继续占用单实例锁等资源。世代文件值变化或缺失 = 宿主已换代，插件应立即退出。
+
+   可参照独立分发的 `cloudflare-tunnel` 插件（仓库 [`diceframe/cloudflare-tunnel`](https://github.com/diceframe/cloudflare-tunnel)，v0.2.0 起内置世代检测）的 `parent_watch.py` 参考实现（跨平台 `pid_exists` + `read_generation_file` + `start_parent_watch`），进程型插件可复制，并传入世代文件路径与当前值：
 
    ```python
    # 插件内 self-contained 实现，不依赖 SDK 公共导出
-   from parent_watch import start_parent_watch
+   from pathlib import Path
+   from parent_watch import read_generation_file, start_parent_watch
 
-   start_parent_watch(on_exit=lambda: cleanup_your_subprocess())
+   generation_file = Path(os.environ["DICEFRAME_PLUGIN_DATA_DIR"]) / ".host-generation"
+   start_parent_watch(
+       on_exit=lambda: cleanup_your_subprocess(),
+       generation_file=generation_file,
+       initial_generation=read_generation_file(generation_file),
+   )
    ```
 
-   `on_exit` 是宿主退出时的清理回调（如 kill 插件 spawn 的子进程）。
+   `on_exit` 是宿主退出或换代时的清理回调（如 kill 插件 spawn 的子进程）。带单实例锁的插件（如聊天桥接）还应在 `on_exit` 中释放锁，并可按 `qq-napcat` 插件 v1.4.0 实现锁接管（孤儿检测 + SIGTERM→SIGKILL 后重建锁），避免新实例被残留锁拒绝。
+
+   旧版宿主（< 2.0.2）不写世代文件：`read_generation_file` 读到空串，世代检查自动跳过，退化为纯 PID 检测，插件在新旧宿主上均可用。
 
 2. **退出时清理子进程**：插件 spawn 的任何子进程（如外部二进制），必须在插件退出时终止，防止残留。建议在插件主循环结束后统一 kill，并配合 `start_parent_watch` 的 `on_exit` 兜底。
 
 宿主的插件进程重启（`_monitor_process`）与插件的子进程自愈是两个层面：插件进程崩溃由宿主拉起；插件内部自己 spawn 的子进程崩溃，由插件自己负责（可自行实现重试，指数退避上限建议 60s）。
 
-规范边界：重连策略、业务退避等因插件而异，不强制统一；只有"监控父进程 + 退出清理"是每个进程型插件都应遵守的底线。
+规范边界：重连策略、业务退避等因插件而异，不强制统一；只有"监控父进程 + 宿主世代 + 退出清理"是每个进程型插件都应遵守的底线。
 
 ## 6.3 config.schema.json
 


### PR DESCRIPTION
## 改动
更新 `docs/zh/plugin-development.md` 与 `docs/en/plugin-development.md` 的 6.2 节进程型插件生命周期要求。

## 根因
原指南推荐 `parent_watch.py`（纯 PID 检测）作为进程型插件参考实现。但 DiceFrame
主程序重启是 `os.execv` 自替换（PID 与 starttime 都不变），纯 PID 检测会误判
父进程存活，宿主换代后旧插件进程残留为孤儿、继续占用单实例锁——新插件按旧指南
照抄会踩同样的坑。

## 改动内容
- 生命周期要求从纯 PID 检测升级为"父进程存活 + 宿主世代"双检。
- 写明世代文件协议：宿主每次启动插件前把新 token 原子写入
  `DICEFRAME_PLUGIN_DATA_DIR/.host-generation`；插件轮询比对，值变化/缺失 =
  宿主已换代，立即退出。
- 兼容回退：旧宿主（<2.0.2）不写文件时 `read_generation_file` 读到空串，
  世代检查自动跳过，退化为纯 PID 检测。
- 参考实现更新为 cloudflare-tunnel v0.2.0 的 `parent_watch.py`（已含世代检测）。
- 补充带单实例锁插件参照 qq-napcat v1.4.0 锁接管释放锁的建议。

## 验证
- 两个文件无空字节/无截断，markdown 代码块配对，`git diff --cached --check` 干净。
- 纯文档改动，不影响代码与测试。