### PR TITLE
build(release): source/portable 包不再内置 cloudflared 二进制

### DIFF
--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -199,8 +199,10 @@ def _sha256_file(path: Path) -> str:
 def download_cloudflared(package_dir: Path) -> None:
     """下载 cloudflared 二进制打进包内，让外网接入插件离线可用。
 
-    按构建平台选择资产：portable/source 包在 Windows 构建 -> windows-amd64；
-    仅 linux-amd64 留给未来 Linux/Docker 构建。失败不阻断打包（插件会运行时下载）。
+    当前 release.yml 仅 Windows 平台构建（ubuntu 跑 windows-zip、windows 跑
+    portable），均不内置——source/portable 包里外网接入插件运行时自行下载。
+    函数保留，供未来 Linux/Docker 构建复用（按构建平台选资产：
+    windows-amd64 / linux-amd64）。失败不阻断打包（插件会运行时下载）。
     """
     target_dir = package_dir / "cloudflared"
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -229,7 +231,13 @@ def download_cloudflared(package_dir: Path) -> None:
         print(f"Warning: cloudflared download failed, plugin will fetch at runtime: {exc}")
 
 
-def prepare_package_tree(package_dir: Path, *, include_cloudflared: bool = True) -> None:
+def prepare_package_tree(package_dir: Path, *, include_cloudflared: bool = False) -> None:
+    """组装发布包目录树。
+
+    include_cloudflared 默认 False：source 与 portable 包都不内置 cloudflared
+    二进制，外网接入插件运行时自行下载（插件 v0.2.0 起带 sha256 校验）。
+    参数保留，供未来 Linux/Docker 构建复用（内置 linux-amd64）。
+    """
     if package_dir.exists():
         shutil.rmtree(package_dir)
     package_dir.mkdir(parents=True)


### PR DESCRIPTION
## 改动

`scripts/build_release.py`：`prepare_package_tree` 默认 `include_cloudflared` 由 `True` 改为 `False`，并同步更新 `download_cloudflared` / `prepare_package_tree` docstring。

## 原因

source zip 此前体积 20 多 M。根因：release.yml 的 `windows-zip` job 在 **ubuntu-latest** 上运行，`download_cloudflared` 按 `os.name` 选中内置 **linux-amd64** cloudflared（约 37.5MB，zip 压缩后约 20MB）——但对 Windows 用户无用（CF 插件按平台找 `cloudflared.exe`）。portable 包早已显式 `include_cloudflared=False`，source 包这次对齐。

## 影响

- source / portable 包均不再内置 cloudflared 二进制，体积回落至 ~8MB。
- CF 隧道插件 v0.2.0 起运行时自行下载并 sha256 校验；离线场景需手动放置二进制才能用外网接入。
- `download_cloudflared` 函数与 `include_cloudflared` 参数保留，供未来 Linux/Docker 构建复用。

## 验证

- `python -m py_compile` 通过
- `pytest tests/test_release_build.py` 2 passed
- 真实打包验证：目标树无 `cloudflared/` 目录，体积 20 多 M → 8.2 MB
- commit 邮箱白名单通过、`git diff --cached --check` 干净