### PR TITLE
fix(plugins): 隧道卡片状态与插件宿主环境修复，启动器改 x64

### DIFF
--- a/frontend-v2/src/features/plugins/TunnelCard.vue
+++ b/frontend-v2/src/features/plugins/TunnelCard.vue
@@ -70,7 +70,7 @@ async function onCopyTunnelLink() {
         <NTag v-if="tunnelActive" type="success" size="small">{{ t('tunnelActive') }}</NTag>
         <NTag v-else size="small">{{ t('tunnelIdle') }}</NTag>
         <NTag v-if="p.needs_core_update" type="warning" size="small">{{ t('pluginNeedsCoreUpdate', { version: p.min_app_version || '' }) }}</NTag>
-        <NButton v-if="!tunnelActive" type="primary" size="small" :loading="tunnelStarting" :disabled="!hasAccessPassword" @click="onTunnelEnable(p.plugin_id)">{{ t('tunnelEnable') }}</NButton>
+        <NButton v-if="!tunnelActive" type="primary" size="small" :loading="tunnelStarting" @click="onTunnelEnable(p.plugin_id)">{{ t('tunnelEnable') }}</NButton>
         <NButton v-else size="small" :loading="tunnelStarting" @click="onTunnelStop(p.plugin_id)">{{ t('tunnelStop') }}</NButton>
       </div>
       <p v-if="p.running && !tunnelActive" class="form-hint">{{ t('tunnelPluginRunningHint') }}</p>

--- a/frontend-v2/src/features/plugins/TunnelCard.vue
+++ b/frontend-v2/src/features/plugins/TunnelCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { NAlert, NButton, NInput, NTag, NIcon } from 'naive-ui'
 import { CopyOutline } from '@vicons/ionicons5'
 import { useTunnel } from '@/composables/useTunnel'
@@ -25,6 +25,10 @@ const {
 } = useTunnel()
 
 const hasAccessPassword = computed(() => Boolean(store.config.access_password?.configured))
+
+onMounted(() => {
+  if (!store.config.access_password) void store.load()
+})
 const providers = computed(() => tunnelProviders.value.filter(provider => provider.plugin_id === props.plugin.id))
 const isQuickTunnelPlugin = computed(() => props.plugin.id === 'cloudflare-tunnel')
 

--- a/frontend-v2/src/features/plugins/TunnelCard.vue
+++ b/frontend-v2/src/features/plugins/TunnelCard.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { NAlert, NButton, NInput, NTag, NIcon } from 'naive-ui'
 import { CopyOutline } from '@vicons/ionicons5'
 import { useTunnel } from '@/composables/useTunnel'
+import { pluginApi } from '@/api/plugins'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useLocale } from '@/composables/useLocale'
 import { useToast } from '@/composables/useToast'
@@ -25,11 +26,14 @@ const {
 
 const hasAccessPassword = computed(() => Boolean(store.config.access_password?.configured))
 const providers = computed(() => tunnelProviders.value.filter(provider => provider.plugin_id === props.plugin.id))
-const pluginActive = computed(() => providers.value.some(provider => provider.running))
 const isQuickTunnelPlugin = computed(() => props.plugin.id === 'cloudflare-tunnel')
 
 async function onTunnelEnable(pluginId: string) {
   if (!hasAccessPassword.value) { toast.error(t('tunnelNeedPassword')); return }
+  const provider = providers.value.find(p => p.plugin_id === pluginId)
+  if (!provider?.running) {
+    await pluginApi.setRunning(pluginId, true)
+  }
   await enableTunnel(pluginId)
   if (tunnelError.value) toast.error(tunnelError.value)
 }
@@ -59,17 +63,18 @@ async function onCopyTunnelLink() {
     <div v-for="p in providers" :key="p.plugin_id" class="form-row">
       <label>{{ p.name }}</label>
       <div class="switch-inline">
-        <NTag v-if="p.running" type="success" size="small">{{ t('tunnelActive') }}</NTag>
+        <NTag v-if="tunnelActive" type="success" size="small">{{ t('tunnelActive') }}</NTag>
         <NTag v-else size="small">{{ t('tunnelIdle') }}</NTag>
         <NTag v-if="p.needs_core_update" type="warning" size="small">{{ t('pluginNeedsCoreUpdate', { version: p.min_app_version || '' }) }}</NTag>
-        <NButton v-if="!pluginActive" type="primary" size="small" :loading="tunnelStarting" :disabled="!hasAccessPassword || tunnelActive" @click="onTunnelEnable(p.plugin_id)">{{ t('tunnelEnable') }}</NButton>
+        <NButton v-if="!tunnelActive" type="primary" size="small" :loading="tunnelStarting" :disabled="!hasAccessPassword" @click="onTunnelEnable(p.plugin_id)">{{ t('tunnelEnable') }}</NButton>
         <NButton v-else size="small" :loading="tunnelStarting" @click="onTunnelStop(p.plugin_id)">{{ t('tunnelStop') }}</NButton>
       </div>
+      <p v-if="p.running && !tunnelActive" class="form-hint">{{ t('tunnelPluginRunningHint') }}</p>
     </div>
     <div v-if="tunnelStarting && !tunnelActive" class="form-row">
       <p class="muted">{{ t('tunnelStarting') }}</p>
     </div>
-    <div v-if="pluginActive && tunnelStatus?.url" class="form-row">
+    <div v-if="tunnelActive && tunnelStatus?.url" class="form-row">
       <label>{{ t('tunnelActive') }}</label>
       <NInput :value="tunnelStatus.url" readonly />
       <div class="actions-row">

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -569,6 +569,7 @@ export const en = {
   tunnelStarting: 'Starting tunnel…',
   tunnelActive: 'Active',
   tunnelIdle: 'Idle',
+  tunnelPluginRunningHint: 'Plugin is running, tunnel is not active yet',
   tunnelError: 'Tunnel error',
   tunnelCopyLink: 'Copy invite link',
   tunnelLinkCopied: 'Invite link copied',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -565,6 +565,7 @@ export const ja = {
   tunnelStarting: 'トンネル起動中…',
   tunnelActive: '有効',
   tunnelIdle: '未有効化',
+  tunnelPluginRunningHint: 'プラグインは実行中、トンネルは未起動',
   tunnelError: 'トンネルエラー',
   tunnelCopyLink: '招待リンクをコピー',
   tunnelLinkCopied: '招待リンクをコピーしました',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -569,6 +569,7 @@ export const zhCN = {
   tunnelStarting: '隧道启动中…',
   tunnelActive: '已生效',
   tunnelIdle: '未启用',
+  tunnelPluginRunningHint: '插件已运行，隧道尚未开启',
   tunnelError: '隧道错误',
   tunnelCopyLink: '复制邀请链接',
   tunnelLinkCopied: '已复制邀请链接',

--- a/scripts/build_launcher.py
+++ b/scripts/build_launcher.py
@@ -190,7 +190,7 @@ def build_launcher(output: Path, icon: Path) -> None:
             "/nologo",
             "/optimize+",
             "/target:exe",
-            "/platform:anycpu",
+            "/platform:x64",
             f"/win32icon:{icon}",
             f"/out:{output}",
             str(SOURCE),

--- a/src/plugin_host/host.py
+++ b/src/plugin_host/host.py
@@ -81,6 +81,8 @@ _SAFE_PARENT_ENV = {
     "SYSTEMROOT",
     "TEMP",
     "TMP",
+    "PROCESSOR_ARCHITECTURE",
+    "PROCESSOR_ARCHITEW6432",
     "TZ",
     "WINDIR",
 }


### PR DESCRIPTION
## 背景

Cloudflare 隧道插件页面出现三类问题：

1. 界面把“插件进程在运行”误判为“隧道已生效”，导致停止按钮无效、地址不回传分享链接。
2. 插件宿主启动插件进程时过滤了 PROCESSOR_* 环境变量，Windows 下 platform.machine() 返回空串，插件误报“当前平台不支持 cloudflared”。
3. Windows 便携版启动器以 32 位进程运行（/platform:anycpu），与内置 64 位 Python 不一致。

## 改动

- TunnelCard：状态与按钮改看真实隧道状态（是否拿到 URL），启用时自动拉起插件进程，挂载时自动加载访问密码配置；启用按钮不再因密码状态未加载而被禁用，缺失时点击再提示。
- plugin-host：白名单补充 PROCESSOR_ARCHITECTURE / PROCESSOR_ARCHITEW6432，插件进程可正常做平台判断。
- build_launcher：/platform:anycpu 改为 /platform:x64，启动器编译为 64 位。
- i18n：新增“插件已运行，隧道尚未开启”中/英/日文案。

## 验证

- typecheck、lint、vitest 123/123、生产构建全部通过
- 客户端本机实测：隧道可启动、URL 回传分享链接
- 插件仓库（cloudflare-tunnel v0.2.2 / cloudflare-tunnel-linux v0.1.1）已同步修复并发布，测试 14/14 通过

## 未包含

- docs/MAP_SYSTEM_PLAN_CN.md（无关未跟踪文件，未纳入）