### PR TITLE
style(plugins): 已安装插件标签增加间距

### DIFF
--- a/frontend-v2/src/styles.css
+++ b/frontend-v2/src/styles.css
@@ -194,6 +194,7 @@ details:not([open])>:not(summary){display:none}
 .plugin-status{padding:5px 8px;border:1px solid var(--df-border-soft);background:var(--df-surface-3);border-radius:4px}
 .plugin-status.running{color:#9ce0a4;border-color:rgba(79,143,88,.38);background:rgba(79,143,88,.16)}
 .plugin-head h3{margin:0;color:var(--df-accent-strong)}
+.plugin-head h3 .n-tag{margin-left:6px}
 .plugin-head p{color:var(--df-text-muted);margin:4px 0 0;font-size:13px}
 .field{margin:10px 0;display:flex;flex-direction:column;gap:4px}
 .field > .switch-label{display:flex;flex-direction:row;align-items:center;gap:8px;font-size:14px;color:var(--df-text-secondary)}


### PR DESCRIPTION
## 改动
- 已安装插件折叠标题中的状态标签（已安装版本 / 有新版本 / 需更新核心）之间增加 6px 间距，避免挤在一起

## 影响
仅插件页样式，无逻辑变化。

## 验证
- typecheck / lint / build / vitest 全部通过（37 files / 123 tests）
- 构建产物已同步便携版 static-v2