### PR TITLE
docs: README 官方网站链接移到头图下方

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center"><a href="https://github.com/diceframe/diceframe/stargazers"><img src="https://img.shields.io/github/stars/diceframe/diceframe?style=flat-square&logo=github&label=Stars" alt="GitHub Stars"></a> <a href="https://github.com/diceframe/diceframe/releases"><img src="https://img.shields.io/github/v/release/diceframe/diceframe?style=flat-square&logo=github&label=Release" alt="GitHub Release"></a> <a href="https://github.com/diceframe/diceframe/blob/main/LICENSE"><img src="https://img.shields.io/github/license/diceframe/diceframe?style=flat-square&logo=github&label=License" alt="License"></a></p>
 
-<p align="center"><a href="https://diceframe.com">官方网站</a></p>
-
 ![DiceFrame WebUI preview](docs/assets/diceframe-readme-hero.jpg)
+
+<p align="center"><a href="https://diceframe.com">官方网站</a></p>
 
 DiceFrame 是一个可以自己部署的 **ai跑团引擎**，支持 **DND/COC/自定义规则**，**多人 WebUI**。
 


### PR DESCRIPTION
## 改动

- 将 `README.md` 中“官方网站”链接（https://diceframe.com）从徽章区下方移到头图（`docs/assets/diceframe-readme-hero.jpg`）之下。

## 原因

- 按用户要求调整 README 头部信息层级：头图作为视觉焦点，官网链接紧贴其下方更合理。

## 影响

- 纯文档调整，无代码、无接口、无行为变化。

## 根因

- 无（非缺陷修复）。

## 验证

- `git diff --cached --check` 通过。
- 公开边界检查：仅 `README.md` 变更，无内部文件。
- 提交身份白名单通过。
- 待 CI（Backend tests / Frontend checks / Browser smoke tests）全绿后合并。
