### PR TITLE
style(settings): flatten TTS panel into generation-param rows

### DIFF
--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -1000,89 +1000,83 @@ function redownloadUpdatePackage() {
                 <NIcon :component="OptionsOutline" />
                 <div><h3>{{ t('ttsSettings') }}</h3><p>{{ t('ttsSettingsHint') }}</p></div>
               </header>
-              <div class="tts-settings-group">
-                <div class="tts-group-heading">
-                  <div><strong>{{ t('ttsEngineConnection') }}</strong><small>{{ t('ttsEngineConnectionHint') }}</small></div>
+              <div class="advanced-row tts-subheading-row">
+                <div><strong>{{ t('ttsEngineConnection') }}</strong><small>{{ t('ttsEngineConnectionHint') }}</small></div>
+              </div>
+              <div class="advanced-row">
+                <div><strong>{{ t('ttsProvider') }}</strong></div>
+                <select :value="store.config.tts_provider ?? 'browser'" @change="setStr('tts_provider', eventValue($event))">
+                  <option value="browser">{{ t('ttsProviderBrowser') }}</option>
+                  <option value="openai-compatible">{{ t('ttsProviderOpenAI') }}</option>
+                  <option value="gpt-sovits">GPT-SoVITS</option>
+                </select>
+              </div>
+              <template v-if="ttsProvider !== 'browser'">
+                <div class="advanced-row">
+                  <div><strong>Base URL</strong></div>
+                  <NInput
+                    :value="store.config.tts_base_url ?? ''"
+                    :placeholder="ttsProvider === 'gpt-sovits' ? 'http://127.0.0.1:9880' : 'https://api.openai.com/v1'"
+                    @update:value="setStr('tts_base_url', $event)"
+                  />
                 </div>
-                <div class="form-row">
-                  <label>{{ t('ttsProvider') }}</label>
-                  <select :value="store.config.tts_provider ?? 'browser'" @change="setStr('tts_provider', eventValue($event))">
-                    <option value="browser">{{ t('ttsProviderBrowser') }}</option>
-                    <option value="openai-compatible">{{ t('ttsProviderOpenAI') }}</option>
-                    <option value="gpt-sovits">GPT-SoVITS</option>
+                <div class="advanced-row">
+                  <div><strong>API Key</strong></div>
+                  <NInput
+                    :value="store.secrets.tts_api_key ?? ''"
+                    type="password"
+                    show-password-on="click"
+                    :placeholder="store.config.tts_api_key?.configured ? t('secretConfiguredPlaceholder', { masked: store.config.tts_api_key.masked }) : t('ttsApiKeyOptional')"
+                    @update:value="setSecret('tts_api_key', $event)"
+                  />
+                </div>
+                <div v-if="ttsProvider === 'openai-compatible'" class="advanced-row">
+                  <div><strong>{{ t('model') }}</strong></div>
+                  <NInput :value="store.config.tts_model ?? 'tts-1'" placeholder="tts-1" @update:value="setStr('tts_model', $event)" />
+                </div>
+                <div class="advanced-row">
+                  <div><strong>{{ t('ttsAudioFormat') }}</strong></div>
+                  <select :value="store.config.tts_audio_format ?? 'mp3'" @change="setStr('tts_audio_format', eventValue($event))">
+                    <option value="mp3">MP3</option><option value="wav">WAV</option><option value="opus">Opus</option><option value="flac">FLAC</option><option value="aac">AAC</option>
                   </select>
                 </div>
-                <template v-if="ttsProvider !== 'browser'">
-                  <div class="form-row">
-                    <label>Base URL</label>
-                    <NInput
-                      :value="store.config.tts_base_url ?? ''"
-                      :placeholder="ttsProvider === 'gpt-sovits' ? 'http://127.0.0.1:9880' : 'https://api.openai.com/v1'"
-                      @update:value="setStr('tts_base_url', $event)"
-                    />
-                  </div>
-                  <div class="form-row">
-                    <label>API Key</label>
-                    <NInput
-                      :value="store.secrets.tts_api_key ?? ''"
-                      type="password"
-                      show-password-on="click"
-                      :placeholder="store.config.tts_api_key?.configured ? t('secretConfiguredPlaceholder', { masked: store.config.tts_api_key.masked }) : t('ttsApiKeyOptional')"
-                      @update:value="setSecret('tts_api_key', $event)"
-                    />
-                  </div>
-                  <div v-if="ttsProvider === 'openai-compatible'" class="form-row">
-                    <label>{{ t('model') }}</label>
-                    <NInput :value="store.config.tts_model ?? 'tts-1'" placeholder="tts-1" @update:value="setStr('tts_model', $event)" />
-                  </div>
-                  <div class="form-row">
-                    <label>{{ t('ttsAudioFormat') }}</label>
-                    <select :value="store.config.tts_audio_format ?? 'mp3'" @change="setStr('tts_audio_format', eventValue($event))">
-                      <option value="mp3">MP3</option><option value="wav">WAV</option><option value="opus">Opus</option><option value="flac">FLAC</option><option value="aac">AAC</option>
-                    </select>
-                  </div>
-                  <div class="form-row">
-                    <label>{{ t('ttsCacheSize') }}</label>
-                    <NInputNumber :value="Number(store.config.tts_cache_mb ?? 256)" :min="16" :max="2048" :step="64" @update:value="setNum('tts_cache_mb', $event)" />
-                  </div>
-                  <TtsVoiceProfiles :provider="ttsProvider" @changed="loadTtsVoices" />
-                </template>
-              </div>
-
-              <div class="tts-settings-group">
-                <div class="tts-group-heading">
-                  <div><strong>{{ t('ttsRoleMapping') }}</strong><small>{{ t('ttsRoleMappingHint') }}</small></div>
+                <div class="advanced-row">
+                  <div><strong>{{ t('ttsCacheSize') }}</strong></div>
+                  <NInputNumber :value="Number(store.config.tts_cache_mb ?? 256)" :min="16" :max="2048" :step="64" @update:value="setNum('tts_cache_mb', $event)" />
                 </div>
-                <template v-if="ttsProvider !== 'browser'">
-                <div class="form-row">
-                  <label>{{ t('ttsDefaultVoice') }}</label>
+                <TtsVoiceProfiles :provider="ttsProvider" @changed="loadTtsVoices" />
+              </template>
+
+              <div class="advanced-row tts-subheading-row">
+                <div><strong>{{ t('ttsRoleMapping') }}</strong><small>{{ t('ttsRoleMappingHint') }}</small></div>
+              </div>
+              <template v-if="ttsProvider !== 'browser'">
+                <div class="advanced-row">
+                  <div><strong>{{ t('ttsDefaultVoice') }}</strong></div>
                   <input :value="store.config.tts_default_voice ?? ''" list="diceframe-tts-voices" @input="setStr('tts_default_voice', eventValue($event))" />
                 </div>
                 <datalist id="diceframe-tts-voices">
                   <option v-for="voice in ttsVoiceOptions" :key="voice.id" :value="voice.id">{{ voice.name }}</option>
                 </datalist>
-                <div class="form-row">
-                  <label>{{ t('ttsGmVoice') }}</label>
+                <div class="advanced-row">
+                  <div><strong>{{ t('ttsGmVoice') }}</strong></div>
                   <input :value="store.config.tts_gm_voice ?? ''" list="diceframe-tts-voices" :placeholder="t('ttsFollowDefault')" @input="setStr('tts_gm_voice', eventValue($event))" />
                 </div>
-                <div class="form-row">
-                  <label>{{ t('ttsPlayerVoice') }}</label>
+                <div class="advanced-row">
+                  <div><strong>{{ t('ttsPlayerVoice') }}</strong></div>
                   <input :value="store.config.tts_player_voice ?? ''" list="diceframe-tts-voices" :placeholder="t('ttsFollowDefault')" @input="setStr('tts_player_voice', eventValue($event))" />
                 </div>
-                  <p v-if="ttsProvider === 'gpt-sovits' && !ttsVoiceOptions.length" class="muted">{{ t('ttsGptVoiceHint') }}</p>
-                </template>
-                <p v-else class="muted">{{ t('ttsBrowserVoiceMappingHint') }}</p>
-              </div>
+                <p v-if="ttsProvider === 'gpt-sovits' && !ttsVoiceOptions.length" class="muted tts-inline-hint">{{ t('ttsGptVoiceHint') }}</p>
+              </template>
+              <p v-else class="muted tts-inline-hint">{{ t('ttsBrowserVoiceMappingHint') }}</p>
 
-              <div class="tts-settings-group">
-                <div class="advanced-row">
-                  <div><strong>{{ t('ttsAutoSpeak') }}</strong><small>{{ t('ttsAutoSpeakHint') }}</small></div>
-                  <div class="switch-inline"><NSwitch :value="autoSpeak" @update:value="setAutoSpeak" /><span>{{ t('enabled') }}</span></div>
-                </div>
-                <div class="advanced-row">
-                  <div><strong>{{ t('ttsRate') }}</strong><small>{{ t('ttsRateHint') }}</small></div>
-                  <NInputNumber class="advanced-number" :value="ttsRateValue" :min="0.5" :max="5" :step="0.1" @update:value="setTtsRateValue" />
-                </div>
+              <div class="advanced-row">
+                <div><strong>{{ t('ttsAutoSpeak') }}</strong><small>{{ t('ttsAutoSpeakHint') }}</small></div>
+                <div class="switch-inline"><NSwitch :value="autoSpeak" @update:value="setAutoSpeak" /><span>{{ t('enabled') }}</span></div>
+              </div>
+              <div class="advanced-row">
+                <div><strong>{{ t('ttsRate') }}</strong><small>{{ t('ttsRateHint') }}</small></div>
+                <NInputNumber class="advanced-number" :value="ttsRateValue" :min="0.5" :max="5" :step="0.1" @update:value="setTtsRateValue" />
               </div>
               <footer class="advanced-save-row">
                 <NButton type="primary" @click="saveTts()">{{ t('saveAction') }}</NButton>

--- a/frontend-v2/src/styles/v2/settings-polish.css
+++ b/frontend-v2/src/styles/v2/settings-polish.css
@@ -35,12 +35,39 @@
   line-height: 1.45;
 }
 
-.reference-settings-page .tts-settings-group > .tts-profile-manager {
-  padding: 12px 0 0;
+.reference-settings-page .tts-section > .tts-profile-manager {
+  padding: 13px 18px 4px;
   border: 0;
-  border-top: 1px solid var(--df-border-soft);
+  border-top: 1px solid color-mix(in srgb, var(--df-border-soft) 74%, transparent);
   border-radius: 0;
   background: transparent;
+}
+
+.reference-settings-page .tts-section .advanced-row {
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 340px);
+}
+
+.reference-settings-page .tts-section .advanced-row > :last-child {
+  min-width: 0;
+  width: 100%;
+}
+
+.reference-settings-page .tts-section .advanced-row .switch-inline {
+  justify-self: start;
+  width: auto;
+}
+
+.reference-settings-page .advanced-row.tts-subheading-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 42px;
+  background: color-mix(in srgb, var(--df-accent) 5%, var(--df-surface-2));
+}
+
+.reference-settings-page .tts-inline-hint {
+  margin: 0;
+  padding: 10px 18px;
+  border-top: 1px solid color-mix(in srgb, var(--df-border-soft) 74%, transparent);
 }
 
 .reference-settings-page .tts-profile-list {
@@ -94,6 +121,12 @@
 
   .reference-settings-page .tts-profile-actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .reference-settings-page .tts-section .advanced-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/frontend-v2/src/styles/v2/settings-status.css
+++ b/frontend-v2/src/styles/v2/settings-status.css
@@ -279,6 +279,7 @@
 .advanced-save-row {
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
   padding: 15px 23px;
   border-top: 1px solid color-mix(in srgb, var(--df-border-soft) 70%, transparent);
   background: color-mix(in srgb, var(--df-surface-2) 54%, transparent);


### PR DESCRIPTION
## 改动

- 设置页 TTS 面板布局调整：把原来分组卡片式（`.tts-settings-group` + `.form-row`）改成与其他生成参数一致的平铺 `advanced-row` 行，小节标题用 `tts-subheading-row`（“引擎连接”与“角色映射”两组）。
- 涉及文件：
  - `frontend-v2/src/features/admin/SettingsView.vue`（±132）
  - `frontend-v2/src/styles/v2/settings-polish.css`（+39）
  - `frontend-v2/src/styles/v2/settings-status.css`（+1）

## 原因

- 统一设置页内 TTS 配置与其余生成参数的行样式，提升视觉一致性。

## 影响

- 纯样式/布局调整，无配置字段、无接口、无行为变化。

## 根因

- 无（非缺陷修复）。

## 验证

- 本地 `typecheck` 通过。
- Vitest：37 个文件 / 123 个测试全部通过。
- 生产构建（`vue-tsc -b && vite build`）通过。
- `git diff --check` 通过；公开边界检查无内部文件。
- 待 CI（Backend tests / Frontend checks / Browser smoke tests）全绿后合并。
