### PR TITLE
fix(play): 被踢玩家身份缓存导致无法重新加入 + release v2.1.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,17 @@
-# DiceFrame v2.1.1
+# DiceFrame v2.1.2
 
 ## 中文
 
-DiceFrame 2.1.1 是一次补丁更新，主要修复 Cloudflare 隧道状态与插件架构兼容问题，并优化游玩页技能详情和插件页展示。
+DiceFrame 2.1.2 是一次补丁更新，修复多人游戏中被移出对局的玩家无法重新加入的问题。
 
 ### 修复
 
-- **Cloudflare 隧道状态卡片**：只有隧道真正获得公网地址时才显示“运行中”；进入页面时正确加载访问密码；启停按钮保持可点，密码错误时会给出明确提示。
-- **插件架构兼容**：插件宿主会向插件进程传递处理器架构信息，修复部分环境（如 Linux 云隧道使用的 cloudflared）无法识别正确架构的问题。
-- **启动器架构**：DiceFrame.exe 启动器改为原生 x64 编译。
-
-### 改进
-
-- **技能详情**：游玩页角色技能支持鼠标悬浮查看摘要，并可打开“查看全部详情”弹窗。
-- **插件页排版**：已安装插件的版本标签间距微调，信息更易读。
-- **发布流程**：构建产物先校验再挂载到 Release，避免出现空壳版本。
+- **被踢玩家无法重新加入**：此前玩家被 GM 踢出后，浏览器仍缓存旧身份，再次打开邀请链接会被直接送到游玩页并反复提示「未加入本局」，只能借助隐身窗口恢复。现在加入页与游玩页都会先校验本地身份是否仍是本局成员，失效时自动清理缓存并引导玩家重新创建角色加入；房间密码等加入门槛不受影响。
 
 ## English
 
-DiceFrame 2.1.1 is a patch release that fixes Cloudflare tunnel status and plugin architecture compatibility, and polishes skill details and the plugin page.
+DiceFrame 2.1.2 is a patch release that fixes kicked players being unable to rejoin a multiplayer game.
 
 ### Fixes
 
-- **Cloudflare tunnel card**: shows "running" only when the tunnel actually has a public URL; loads the access password correctly when the page opens; keeps enable/disable clickable and surfaces password errors clearly.
-- **Plugin architecture compatibility**: the plugin host now passes processor-architecture environment variables to plugin processes, fixing cloudflared and similar plugins on environments (such as Linux) that could not detect the right architecture.
-- **Launcher architecture**: DiceFrame.exe is now compiled as a native x64 launcher.
-
-### Improvements
-
-- **Skill details**: hover over a character skill in the play view to preview details, or open the full "View all details" dialog.
-- **Plugin page layout**: slightly more spacing for version tags on installed plugins.
-- **Release pipeline**: build artifacts are verified before being attached to a Release, preventing empty releases.
+- **Kicked players could not rejoin**: after a GM removed a player, the browser kept a stale identity, so reopening the invite link jumped straight to the play view and repeatedly showed "not part of this game" until an incognito window was used. Both the join and play views now verify the cached identity against the current roster; expired identities are cleared automatically and the player is guided back to character creation. Room-password gates are unchanged.

--- a/frontend-v2/src/features/play/PlayView.vue
+++ b/frontend-v2/src/features/play/PlayView.vue
@@ -4,7 +4,9 @@ import { NIcon } from 'naive-ui'
 import { ChevronBack, ChevronForward, MapOutline, StatsChartOutline, TerminalOutline } from '@vicons/ionicons5'
 import { useRoute, useRouter } from 'vue-router'
 import { api, apiBlob, isNotFoundError } from '@/api/client'
-import type { BotBindTokenResponse, CharacterCard, CharacterCardsResponse, CharacterListResponse, CharacterPortrait, CheckResult, CommandResponse, HealthResponse, JsonObject, LuckDecisionResponse, PendingPayment, Player, PlayerContextResponse, PublicAction, RuleMeta, WorldCandidate, WorldListResponse, WorldTemplatesResponse } from '@/api/types'
+import type { BotBindTokenResponse, CharacterCard, CharacterCardsResponse, CharacterListResponse, CharacterPortrait, CheckResult, CommandResponse, GameDetail, HealthResponse, JsonObject, LuckDecisionResponse, PendingPayment, Player, PlayerContextResponse, PublicAction, RuleMeta, WorldCandidate, WorldListResponse, WorldTemplatesResponse } from '@/api/types'
+import { queryString } from '@/stores/gameContext'
+import { isStoredPlayerMember } from '@/utils/joinIdentity'
 import { useGame } from '@/composables/useGame'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
@@ -510,6 +512,22 @@ async function loadPlayContext() {
   if (route.query.share && !route.query.user && !localStorage.getItem('trpg_access_token')) {
     router.replace({ name: 'join', query: { game: game.currentGame.value, share: '1' } })
     return
+  }
+  // 被踢/身份过期的玩家直连 play 链接时，SSE 与私聊接口会持续 403「未加入本局」。
+  // 先独立校验一次成员资格（不依赖 refresh，因其 private-log 403 会中断整组请求），
+  // 失效则清掉本地身份缓存，送回加入页走重新加入（GM 有 access_token，不受影响）。
+  const linkUid = queryString(route.query.user)
+  if (linkUid && !localStorage.getItem('trpg_access_token')) {
+    try {
+      const d = await api<GameDetail>(`/games/${encodeURIComponent(game.currentGame.value)}`)
+      if (!isStoredPlayerMember(d, linkUid)) {
+        localStorage.removeItem('trpg_play_user_' + game.currentGame.value)
+        router.replace({ name: 'join', query: { game: game.currentGame.value, share: '1' } })
+        return
+      }
+    } catch {
+      // 校验请求本身失败（网络抖动/后端重启）：保持旧行为留在本页，下次刷新重试。
+    }
   }
   if (!route.query.user) {
     try {

--- a/frontend-v2/src/features/player/JoinView.vue
+++ b/frontend-v2/src/features/player/JoinView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api, errorMessage } from '@/api/client'
 import type { CharacterCard, CharacterCardsResponse, CharacterListResponse, CharacterPortrait, CharacterSkill, GameDetail, PlayerCreateResponse, RuleAttribute, RuleMeta } from '@/api/types'
 import { rememberCurrentGame } from '@/stores/gameContext'
+import { isStoredPlayerMember } from '@/utils/joinIdentity'
 import { attrDisplayName, suggestedAttributes, skillPointCost } from '@/utils/ruleSchema'
 import { useLocale, type Locale } from '@/composables/useLocale'
 import { useConfirm } from '@/composables/useConfirm'
@@ -86,17 +87,34 @@ function skillToForm(skill: string | CharacterSkill): JoinSkill {
 
 onMounted(async () => {
   const stored = localStorage.getItem('trpg_play_user_' + gameKey.value)
-  if (stored) { rememberCurrentGame(gameKey.value); router.replace({ name: 'play', query: { game: gameKey.value, user: stored, share: '1' } }); return }
-  if (linkUser.value) resumeUser.value = linkUser.value
   try {
     const d = await api<GameDetail>(`/games/${encodeURIComponent(gameKey.value)}`)
     detail.value = d
+    if (stored) {
+      // 校验本地身份是否仍是成员：被踢后缓存过期，不能再盲跳游玩界面。
+      if (isStoredPlayerMember(d, stored)) {
+        rememberCurrentGame(gameKey.value)
+        router.replace({ name: 'play', query: { game: gameKey.value, user: stored, share: '1' } })
+        return
+      }
+      // 被踢/身份过期：清掉本地缓存，走正常重新加入（尊重房间密码等门槛）。
+      localStorage.removeItem('trpg_play_user_' + gameKey.value)
+    }
+    if (linkUser.value) resumeUser.value = linkUser.value
     if (d.has_room_password && !localStorage.getItem('trpg_play_room_' + gameKey.value)) {
       needRoomPassword.value = true
       return
     }
     await afterGate()
-  } catch (e: unknown) { error.value = errorMessage(e) }
+  } catch (e: unknown) {
+    // 详情获取失败：若本地有身份，按旧行为放行进游玩，避免成员被临时故障锁住。
+    if (stored) {
+      rememberCurrentGame(gameKey.value)
+      router.replace({ name: 'play', query: { game: gameKey.value, user: stored, share: '1' } })
+      return
+    }
+    error.value = errorMessage(e)
+  }
 })
 
 async function afterGate() {

--- a/frontend-v2/src/utils/joinIdentity.ts
+++ b/frontend-v2/src/utils/joinIdentity.ts
@@ -1,0 +1,19 @@
+import type { GameDetail } from '@/api/types'
+
+/**
+ * 判断本地缓存的玩家身份 uid 是否仍是该局成员。
+ *
+ * 玩家加入后前端会把 uid 存进 localStorage（`trpg_play_user_<gameKey>`），
+ * JoinView 用它直接跳游玩界面。被 GM 踢出后该 uid 已从对局移除，
+ * 若仍按缓存盲跳，玩家会被卡在「未加入本局」。此函数在跳转前校验成员资格，
+ * 供 JoinView 决定"直接进游玩"还是"清缓存走重新加入"。
+ */
+export function isStoredPlayerMember(detail: GameDetail | Partial<GameDetail>, uid: string): boolean {
+  const m = detail.multiplayer
+  const members = [
+    ...(m?.ready_players ?? []),
+    ...(m?.waiting_players ?? []),
+    ...(m?.away_players ?? []),
+  ]
+  return members.some(player => player.user_id === uid)
+}

--- a/frontend-v2/tests/joinIdentity.test.ts
+++ b/frontend-v2/tests/joinIdentity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import type { GameDetail, Player } from '../src/api/types'
+import { isStoredPlayerMember } from '../src/utils/joinIdentity'
+
+function player(id: string): Player {
+  return { user_id: id, character_name: id }
+}
+
+function detail(fields: GameDetail['multiplayer']): Partial<GameDetail> {
+  return { multiplayer: fields }
+}
+
+describe('isStoredPlayerMember', () => {
+  it('returns true when the uid is among ready players', () => {
+    expect(isStoredPlayerMember(detail({ ready_players: [player('u1')], waiting_players: [], away_players: [] }), 'u1')).toBe(true)
+  })
+
+  it('returns true when the uid is waiting', () => {
+    expect(isStoredPlayerMember(detail({ ready_players: [], waiting_players: [player('u2')], away_players: [] }), 'u2')).toBe(true)
+  })
+
+  it('returns true when the uid is away', () => {
+    expect(isStoredPlayerMember(detail({ ready_players: [], waiting_players: [], away_players: [player('u3')] }), 'u3')).toBe(true)
+  })
+
+  it('returns false for a uid that was kicked', () => {
+    expect(isStoredPlayerMember(detail({ ready_players: [player('u1')], waiting_players: [], away_players: [] }), 'kicked')).toBe(false)
+  })
+
+  it('returns false when no multiplayer info is present', () => {
+    expect(isStoredPlayerMember({}, 'u1')).toBe(false)
+  })
+})

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## 改动内容

- `frontend-v2/src/features/player/JoinView.vue`：加入页挂载时先拉取对局详情，用新的 `isStoredPlayerMember` 校验 localStorage 缓存的玩家 uid 是否仍是本局成员；失效（被踢/身份过期）时清除缓存，走正常重新加入流程（尊重房间密码门槛）。
- `frontend-v2/src/features/play/PlayView.vue`：直连游玩链接（带 `user` 参数）时先独立校验成员资格（不依赖 refresh，因其 private-log 403 会中断整组 Promise.all）；失效则清缓存并重定向回加入页。GM（持 access_token）不受影响。
- 新增 `frontend-v2/src/utils/joinIdentity.ts` 与单测 `frontend-v2/tests/joinIdentity.test.ts`。
- 版本 bump 至 2.1.2，RELEASE_NOTES.md 重写为本版本玩家向说明。

## 原因与根因

GM 踢出玩家后只清了服务端 `inst.players`，浏览器侧 `trpg_play_user_<gameKey>` 缓存与已 rebind 的 session cookie 均残留。旧加入页逻辑只要缓存存在就盲跳游玩页，导致所有请求以失效 uid 命中 403「未加入本局」（private-log / sse-ticket / 提交行动），且游玩页无恢复路径，玩家只能换隐身窗口。

## 影响

被踢玩家可正常通过邀请链接重新加入；正常成员无感知；专属链接恢复身份的行为维持现状。

## 验证

- 前端：vue-tsc typecheck 通过；vitest 128/128 通过（含 joinIdentity 5 例）；生产构建通过。
- 后端：pytest 799 全部通过。
- 打包：`scripts/build_release.py --allow-dirty` 成功，zip 内容黑名单/秘密扫描无命中。