### PR TITLE
feat(play): 角色编辑页技能区展示规则说明与上限提示

### DIFF
--- a/frontend-v2/src/components/admin/SkillEditor.vue
+++ b/frontend-v2/src/components/admin/SkillEditor.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { CharacterSkill, SkillSpec } from '@/api/types'
+import type { CharacterSkill, RuleMeta, SkillSpec } from '@/api/types'
 import { useLocale } from '@/composables/useLocale'
+import { localizedField, skillPointCost } from '@/utils/ruleSchema'
 
-const props = defineProps<{ modelValue: CharacterSkill[]; pool?: Array<string | SkillSpec> }>()
+const props = defineProps<{ modelValue: CharacterSkill[]; pool?: Array<string | SkillSpec>; meta?: RuleMeta | null }>()
 const emit = defineEmits<{ 'update:modelValue': [v: CharacterSkill[]] }>()
 const { t } = useLocale()
 
@@ -30,13 +31,31 @@ function updateVal(i: number, v: number) {
   arr[i] = { ...arr[i], value: v || 0 }
   skills.value = arr
 }
+
+const skillHint = computed(() => localizedField<string>(props.meta, 'skill_hint') || '')
+const maxSkills = computed(() => Number(props.meta?.max_skills || 0))
+const skillPointTotal = computed(() => Number(props.meta?.skill_point_total || 0))
+const maxSkillValue = computed(() => Number(props.meta?.max_skill_value || 0))
+const filledSkills = computed(() => skills.value.filter(s => s.name.trim()))
+const skillSpent = computed(() => filledSkills.value.reduce((sum, skill) => sum + skillPointCost(skill, props.meta), 0))
+const skillOverLimit = computed(() =>
+  Boolean((maxSkills.value && filledSkills.value.length > maxSkills.value)
+    || (skillPointTotal.value && skillSpent.value > skillPointTotal.value)
+    || (maxSkillValue.value && skills.value.some(s => (Number(s.value || 0) || 0) > maxSkillValue.value)))
+)
 </script>
 
 <template>
   <div class="skill-editor">
+    <p v-if="skillHint" class="muted sheet-hint">{{ skillHint }}</p>
+    <p class="muted sheet-hint" :class="{ warn: skillOverLimit }">
+      <span v-if="maxSkills">{{ t('skillCount', { count: filledSkills.length, max: maxSkills }) }}</span>
+      <span v-if="skillPointTotal"> · {{ t('skillPointsSpent', { spent: skillSpent, total: skillPointTotal }) }}</span>
+      <span v-if="maxSkillValue"> · {{ t('maxSingleSkill', { max: maxSkillValue }) }}</span>
+    </p>
     <div v-for="(s, i) in skills" :key="i" class="skill-row">
       <input :value="s.name" :placeholder="t('skillName')" @input="updateName(i, ($event.target as HTMLInputElement).value)">
-      <input type="number" :value="s.value" min="0" @input="updateVal(i, Number(($event.target as HTMLInputElement).value))">
+      <input type="number" :value="s.value" min="0" :class="{ warn: maxSkillValue && (Number(s.value || 0) || 0) > maxSkillValue }" @input="updateVal(i, Number(($event.target as HTMLInputElement).value))">
       <button class="modal-x" :title="t('delete')" @click="remove(i)">×</button>
     </div>
     <button class="chip" @click="add()">+ {{ t('addSkill') }}</button>

--- a/frontend-v2/src/features/admin/CharactersView.vue
+++ b/frontend-v2/src/features/admin/CharactersView.vue
@@ -703,7 +703,7 @@ async function onWizardSubmit(c: CharacterSheet & { character_name: string }) {
         </div>
       </div>
       <label>{{ t('skills') }}</label>
-      <SkillEditor v-model="edit.skills" :pool="skillPool" />
+      <SkillEditor v-model="edit.skills" :pool="skillPool" :meta="ruleMeta" />
       <label>{{ t('backgroundStory') }}<textarea rows="3" v-model="edit.background"></textarea></label>
       <ItemEditor v-model:equipment="edit.equipment" v-model:inventory="edit.inventory" />
       <label>{{ t('keyItemsLineHelp') }}<textarea rows="3" v-model="edit.keyText"></textarea></label>
@@ -729,7 +729,7 @@ async function onWizardSubmit(c: CharacterSheet & { character_name: string }) {
       <label>{{ t('originIdentity') }}<input v-model="editCard.race"></label>
       <label>{{ t('classRole') }}<input v-model="editCard.class"></label>
       <label>{{ t('skills') }}</label>
-      <SkillEditor v-model="editCard.skills" :pool="skillPool" />
+      <SkillEditor v-model="editCard.skills" :pool="skillPool" :meta="ruleMeta" />
       <label>{{ t('background') }}<textarea rows="4" v-model="editCard.background"></textarea></label>
       <label>{{ t('initialMoney') }}<input type="number" v-model.number="editCard.gold"></label>
       <template #actions>


### PR DESCRIPTION
## 改动
- SkillEditor 新增 meta prop：展示规则的 skill_hint（CoC d100 阈值说明 / DnD 熟练项说明等）+ 技能数/上限、技能点/总量、单技能上限，超出标红（单技能输入框同步标红）
- CharactersView 两处 SkillEditor 传入 ruleMeta
- 仅提示不拦截，与建卡页（JoinView）行为一致；数值全部来自规则模板，各规则自适应显示

## 验证
typecheck / vitest 128 通过 / 生产构建通过