### PR TITLE
docs: 关于页文档链接指向官网 + 中文版补下载指南

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,12 @@ DiceFrame 2.2.0 为玩家自助成长与 GM 控制补充能力，并修复了浅
 - **内容包世界书条目冗余标签**：内容包导入的世界书条目不再携带「类型：/来源插件：/描述：」前缀——类型与来源插件本就是条目的独立字段，重复拼入内容会挤占生成上下文，英文内容包也会出现中英混杂。主文本改为保真输出。
 - **英文界面下的兜底属性名**：升级加点弹窗在规则属性缺失时的兜底属性，英文界面显示 STR/CON 等英文缩写而非中文。
 
+### 下载指南
+
+- **普通 Windows 用户**：下载 `DiceFrame-v2.2.0-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.2.0-windows.zip`。
+- `.sha256` 是更新校验文件，普通用户不需要手动下载。
+
 ## English
 
 DiceFrame 2.2.0 adds player-driven growth and GM controls, and fixes a batch of issues including light-mode readability, kicked-player rejoin, and redundant lorebook entries.

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -1245,7 +1245,7 @@ function redownloadUpdatePackage() {
               </div>
               <nav class="about-links" :aria-label="t('contact')">
                 <a href="https://diceframe.com" target="_blank" rel="noopener"><span>{{ t('officialWebsite') }}</span><strong>diceframe.com</strong></a>
-                <a href="https://github.com/diceframe/diceframe/tree/main/docs" target="_blank" rel="noopener"><span>{{ t('guideDocs') }}</span><strong>diceframe/diceframe</strong></a>
+                <a href="https://diceframe.com/docs?doc=guide" target="_blank" rel="noopener"><span>{{ t('guideDocs') }}</span><strong>diceframe.com/docs</strong></a>
                 <a href="https://github.com/diceframe/diceframe" target="_blank" rel="noopener"><span>{{ t('projectAddress') }}</span><strong>diceframe/diceframe</strong></a>
                 <a href="https://github.com/diceframe/diceframe/issues" target="_blank" rel="noopener"><span>{{ t('issueFeedback') }}</span><strong>{{ t('submitIssue') }}</strong></a>
                 <a href="/#/legal/terms" target="_blank" rel="noopener"><span>{{ t('legalDocumentLabel') }}</span><strong>{{ t('legalTermsTitle') }}</strong></a>


### PR DESCRIPTION
1. 设置页关于区「说明文档」链接从失效的 GitHub docs 目录改为 diceframe.com/docs?doc=guide（文档已迁至 diceframe-content/官网文档页）\n2. v2.2.0 RELEASE_NOTES 中文版补回下载指南段落（线上 Release 正文已同步）