### PR TITLE
fix(build): 助手知识模块 aiohttp 延迟导入 + 找回 v2.2.1 发布内容

### DIFF
--- a/src/webui/assistant_knowledge.py
+++ b/src/webui/assistant_knowledge.py
@@ -24,8 +24,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import aiohttp
-
 logger = logging.getLogger("trpg")
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -238,11 +236,17 @@ async def _fetch_remote_docs(lang_key: str) -> dict[str, str] | None:
     """从 diceframe-content 仓库拉取 docs/{lang}/*.md；全部失败返回 None。
 
     单个文件 404（文档被上游删除）不影响其他文件，按实际拉到的集合替换。
+    aiohttp 延迟到函数内导入：本模块被 scripts/build_assistant_knowledge.py
+    在无依赖的构建环境加载，顶层 import 会让发布打包直接崩（CI 不装 aiohttp）。
     """
     if not _DOCS_BASE_URLS:
         return None
     paths = _CONTENT_DOC_PATHS.get(lang_key) or ()
     if not paths:
+        return None
+    try:
+        import aiohttp
+    except ImportError:
         return None
 
     async def fetch_one(session: aiohttp.ClientSession, base: str, path: str) -> str | None:


### PR DESCRIPTION
## 概要

- **构建修复**：`assistant_knowledge.py` 顶层 `import aiohttp` 导致 CI 的 zip 发布构建崩溃（`build_assistant_knowledge.py` 在无 aiohttp 的打包环境加载该模块）；改为函数内延迟导入，运行时/容器不受影响（运行依赖含 aiohttp）。
- **找回 v2.2.1 发布内容**：此前 `v2.2.1` tag 指向的 main 缺少版本号与 README 群号准备提交（54bb607 未随 PR #95 合并），本次一并带入 main：`version.py` → 2.2.1、`RELEASE_NOTES.md` → v2.2.1、`README.md` 找回 QQ 交流群 1060613588。

## 影响

- 修复 CI 发布构建失败，使 v2.2.1 的 zip Release 可以正常生成；Docker 会随重新打 tag 重建并覆盖 2.2.1/latest 镜像（旧镜像内部 version.py 是 2.2.0，需重建对齐）。
- 无运行时行为变化（aiohttp 延迟导入对 web 服务透明）。

## 验证

- 后端 pytest 全量 814 passed
- 模块在无 aiohttp 环境可加载（模拟 CI 构建路径）
- `git diff --check` 通过；无秘密/内部文件