### PR TITLE
chore(release): v2.3.0-beta.1 预览版

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,47 +1,49 @@
-# DiceFrame v2.2.1
+# DiceFrame v2.3.0-beta.1
 
 ## 中文
 
-DiceFrame 2.2.1 为规则作者补充资源结算能力，修复思考模式模型的检定规划问题，并优化 DF 助手。
+DiceFrame 2.3.0-beta.1 为预览版：新增「联机冒险」玩家直连能力（实验性），并强化多人局的安全与公平性。
 
 ### 新增
 
-- **规则资源标签与阈值触发器**：GM 可用 `STAT:玩家ID:资源key:变化量` 标签在结算时直接增减规则特殊属性（KPI、谜团进度、倒计时等），服务端自动钳制上下限；`special_stats` 可声明阈值触发器（at/direction/notify），资源到达阈值时向 GM 注入系统提示推进剧情。GM 数值指令别名同步支持从规则资源动态推导。
-
-### 修复
-
-- **思考模式模型检定规划失败**：使用 DeepSeek 等带思考模式的模型时，AI 检定规划偶发失败并回退到简化检定；现在自动切换兼容调用方式并在输出截断时自动放大重试。
-- **规则特殊属性初始值**：freeform_wuxia 内力改为显式满值起步，避免依赖引擎默认值（规则作者侧修复）。
+- **玩家直连（实验性）**：无需自建服务器，房主创建临时直连房间，为每位玩家生成独立的一次性链接码；朋友粘贴链接码即可加入同一场冒险。连接信息仅用于短暂握手，直连成功后游戏数据在参与者之间直接传输。
+- **联机冒险入口**：总览页新增「联机冒险」按钮，在同一窗口内完成创建房间或粘贴链接码加入。
 
 ### 改进
 
-- **DF 助手优化**：接入完整官方文档（用户手册/部署/插件开发等），回答更准，文档更新自动同步。
+- **多人公平性保护**：系统明确玩家与 GM 的权限边界——单个玩家的叙述不能改写世界事实、NPC 或其他玩家的角色状态，多人同局体验更可靠。
+- **联机体验**：邀请码列表更紧凑，支持一键复制全部链接码；连接失败提示改为可读文案；房主离开后房间自动废弃，避免朋友拿着失效链接码空等。
+
+### 已知限制
+
+- 直连为实验性功能：对称 NAT、严格防火墙等网络环境可能无法连通；链接码 5 分钟有效且一次性使用。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.2.1-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.2.1-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.3.0-beta.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.3.0-beta.1-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-DiceFrame 2.2.1 adds resource-adjudication tools for rule authors, fixes AI check planning with reasoning models, and improves the DF Assistant.
+DiceFrame 2.3.0-beta.1 is a preview release: it introduces the experimental "Multiplayer Adventure" player-to-player direct connect, and hardens fairness and safety for multiplayer sessions.
 
 ### New
 
-- **Rule resource tags and threshold triggers**: GMs can use `STAT:player_id:resource_key:delta` tags to adjust rule-defined special stats (KPI, puzzle progress, countdowns, etc.) directly during resolution, with server-side clamping to min/max; `special_stats` may declare threshold triggers (at/direction/notify) that inject a system prompt to the GM when a resource crosses a threshold. GM numeric command aliases are now derived from rule resources dynamically.
-
-### Fixes
-
-- **Check planning failed with reasoning models**: when using reasoning models such as DeepSeek's thinking mode, AI check planning could intermittently fail and fall back to simplified checks; the client now switches to a compatible calling convention automatically and retries with a larger token budget on truncation.
-- **Rule special-stat initial values**: freeform_wuxia's qi now starts explicitly at full value instead of relying on engine defaults (rule-author-side fix).
+- **Player-to-player direct connect (experimental)**: no self-hosted server needed — the host creates a temporary room and issues an independent one-time link code per player; friends paste a code to join the same adventure. Connection details are exchanged only for the brief handshake; once connected, game data travels directly between participants.
+- **Multiplayer Adventure entry**: the overview page gains a "Multiplayer Adventure" button that handles room creation and code-based joining in one window.
 
 ### Improvements
 
-- **DF Assistant**: now grounded in the full official docs (user guide, deployment, plugin development, etc.) for more accurate answers, with doc updates synced automatically.
+- **Multiplayer fairness protection**: the system enforces the authority boundary between players and the GM — one player's narration can no longer rewrite world facts, NPCs, or other players' character states.
+- **Connect UX**: a more compact invite-code list with copy-all, readable failure messages, and rooms that expire once the host leaves so friends never wait on a dead code.
+
+### Known limits
+
+- Direct connect is experimental: symmetric NAT or strict firewalls may prevent a connection; link codes are one-time and expire after five minutes.
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v2.2.1-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.2.1-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v2.3.0-beta.1-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.3.0-beta.1-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.2.1"
+__version__ = "2.3.0-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## 改动
- src/version.py 升至 2.3.0-beta.1。
- RELEASE_NOTES.md 重写为面向玩家的预览版说明（中/英），保留下载指南段落。

## 原因
合入 #97（玩家直连多人原型）与 #98（多人权限边界保护）后发布预览版。

## 影响
仅版本号与更新说明；tag v2.3.0-beta.1 将触发 GitHub Pre-release（含 - 的 tag 不发布 Docker）。

## 验证
- #97/#98 的 Backend tests / Frontend checks / Browser smoke tests 均已在 main 合并前全绿。