### PR TITLE
style(peer): 精简联机进入按钮文案

### DIFF
--- a/frontend-v2/e2e/peer-connect.spec.ts
+++ b/frontend-v2/e2e/peer-connect.spec.ts
@@ -29,7 +29,7 @@ test('two clients establish a direct data channel through Hub signaling', async 
   await expect(host.locator('.peer-message-form')).toHaveCount(0)
   await expect(guest.locator('.peer-message-form')).toHaveCount(0)
 
-  await guest.getByRole('button', { name: '进入直连冒险' }).click()
+  await guest.getByRole('button', { name: '进入冒险' }).click()
   await expect(guest.getByRole('heading', { name: '创建你的角色' })).toBeVisible()
   await guest.getByLabel('角色名').fill('Peer E2E Player')
   await guest.getByRole('button', { name: '创建角色并进入' }).click()

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -1571,7 +1571,7 @@ export const en = {
   peerConnectionStatus: 'Connection status',
   peerConnectedPeers: 'Member links',
   peerDisconnect: 'Disconnect this client',
-  peerEnterGame: 'Enter direct-connect game',
+  peerEnterGame: 'Enter the adventure',
   peerBoundary: 'The game channel accepts only allowlisted player reads, character creation, actions, luck and payment decisions, away status, and edits to the player\'s own character. It never proxies arbitrary HTTP endpoints. Model calls still run only on the host.',
   peerConnectionCheckTitle: 'Channel status',
   peerConnectionCheckHint: 'Once connected, both sides automatically keep the channel alive and check that it works.',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -1571,7 +1571,7 @@ export const ja = {
   peerConnectionStatus: '接続状態',
   peerConnectedPeers: 'メンバーのリンク',
   peerDisconnect: 'この端末の直接接続を切断',
-  peerEnterGame: '直接接続の冒険に入る',
+  peerEnterGame: '冒険に入る',
   peerBoundary: 'ゲームチャネルは、ホワイトリストに明示されたプレイヤー情報の読み取り、キャラクター作成、行動、幸運と支払いの判定、離席状態、本人のキャラクターカード操作のみを受け付けます。任意の HTTP インターフェースのプロキシは行いません。モデル呼び出しは引き続きホストの端末でのみ実行されます。',
   peerConnectionCheckTitle: 'チャネル状態',
   peerConnectionCheckHint: '接続後、双方がチャネルを自動で維持し、正常に動くかを確認します。',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -1571,7 +1571,7 @@ export const zhCN = {
   peerConnectionStatus: '连接状态',
   peerConnectedPeers: '成员链路',
   peerDisconnect: '断开本机直连',
-  peerEnterGame: '进入直连冒险',
+  peerEnterGame: '进入冒险',
   peerBoundary: '游戏通道只接受明确列入白名单的玩家读取、建卡、行动、幸运、支付、离开状态和本人角色卡操作；不会代理任意 HTTP 接口。模型调用仍只在房主本机执行。',
   peerConnectionCheckTitle: '通道状态',
   peerConnectionCheckHint: '连上后双方会自动保持通道，并检查它是否工作正常。',


### PR DESCRIPTION
## 改动
- 连接成功后的进入按钮由「进入直连冒险」改为「进入冒险」，en/ja 对应精简，e2e 断言同步。

## 原因
- 按钮文案精简，与其余入口按钮的口吻保持一致。

## 验证
- 本地 typecheck 与相关 Vitest 绿；CI 补跑 Playwright。