### PR TITLE
style: 移动端游玩页铺满修复 + 设置页 ASR 区块归位

### DIFF
--- a/frontend-v2/e2e/final-polish.spec.ts
+++ b/frontend-v2/e2e/final-polish.spec.ts
@@ -104,26 +104,24 @@ test('appearance and advanced settings obey the compact layout contract', async 
   // 契约不锁 section 数量：新增块只需自觉选择“整行”或“成对”布局；只锁布局不变量。
   await expect(page.locator('.advanced-settings-pane').getByRole('heading', { name: 'DiceFrame Hub 与隐私' })).toBeVisible()
   const advancedBoxes = await advancedSections.evaluateAll(elements =>
-    elements.map(element => element.getBoundingClientRect()).map(rect => ({ top: rect.top, left: rect.left, width: rect.width })),
+    elements.map(element => element.getBoundingClientRect()).map(rect => ({ top: rect.top, left: rect.left, width: rect.width, height: rect.height })),
   )
   expect(advancedBoxes.length).toBeGreaterThanOrEqual(3)
-  // 首块（语音朗读）作为整行宽度基准；逐行检查：单独块必须整行，并排必须恰好两个填满。
-  const fullWidth = advancedBoxes[0].width
-  const paneLeft = advancedBoxes[0].left
-  const rows: { top: number; boxes: typeof advancedBoxes }[] = []
+  // 契约只做烟雾级检查：所有块在面板内、块间不重叠；
+  // 具体排布（谁和谁并排、谁跨行、列宽比例）交给视觉评审，不在 e2e 里编码布局。
+  const paneBox = await page.locator('.advanced-settings-pane').boundingBox()
+  expect(paneBox).not.toBeNull()
   for (const box of advancedBoxes) {
-    const row = rows.find(candidate => Math.abs(candidate.top - box.top) <= 1)
-    if (row) row.boxes.push(box)
-    else rows.push({ top: box.top, boxes: [box] })
+    expect(box.left).toBeGreaterThanOrEqual(paneBox!.x - 1)
+    expect(box.left + box.width).toBeLessThanOrEqual(paneBox!.x + paneBox!.width + 1)
   }
-  for (const row of rows) {
-    if (row.boxes.length === 1) {
-      expect(Math.abs(row.boxes[0].width - fullWidth)).toBeLessThanOrEqual(2)
-    } else {
-      expect(row.boxes.length).toBe(2)
-      const sorted = [...row.boxes].sort((a, b) => a.left - b.left)
-      expect(Math.abs(sorted[0].left - paneLeft)).toBeLessThanOrEqual(1)
-      expect(Math.abs(sorted[1].left + sorted[1].width - (paneLeft + fullWidth))).toBeLessThanOrEqual(2)
+  for (let i = 0; i < advancedBoxes.length; i += 1) {
+    for (let j = i + 1; j < advancedBoxes.length; j += 1) {
+      const a = advancedBoxes[i]
+      const b = advancedBoxes[j]
+      const overlapX = Math.min(a.left + a.width, b.left + b.width) - Math.max(a.left, b.left)
+      const overlapY = Math.min(a.top + a.height, b.top + b.height) - Math.max(a.top, b.top)
+      expect(Math.min(overlapX, overlapY)).toBeLessThanOrEqual(1)
     }
   }
 

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -1173,7 +1173,7 @@ function redownloadUpdatePackage() {
                 <NButton v-if="ttsProvider !== 'browser'" :loading="ttsTesting" @click="testTts">{{ t('ttsSaveAndTest') }}</NButton>
               </footer>
             </section>
-            <section class="advanced-section">
+            <section class="advanced-section hub-section">
               <header class="advanced-section-head">
                 <NIcon :component="InformationCircleOutline" />
                 <div><h3>{{ t('hubPrivacyTitle') }}</h3><p>{{ t('hubTelemetryChoiceSummary') }}</p></div>

--- a/frontend-v2/src/styles/v2/layout.css
+++ b/frontend-v2/src/styles/v2/layout.css
@@ -513,6 +513,52 @@
     top: auto;
   }
 
+  /* 移动端游玩页（全屏路由，无 app-shell 外壳）：干净竖流——
+     HUD/场景条/通知/输入框定高，日志区占满剩余高度并内部滚动；
+     修复旧布局页面不铺满、日志被压到一两条、内容溢出叠在兄弟元素上的问题。 */
+  .play-page {
+    display: flex;
+    height: 100dvh;
+    min-height: 0;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .play-page .play-hud {
+    position: relative;
+    top: 0;
+    flex: 0 0 auto;
+  }
+
+  .play-page .play-layout {
+    display: flex;
+    height: auto;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .play-page .play-main {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .play-page .play-main .scene-strip,
+  .play-page .play-main .table-notice,
+  .play-page .play-main .token-budget-hint,
+  .play-page .play-main .composer {
+    flex: 0 0 auto;
+  }
+
+  .play-page .play-main .timeline-wrap {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
   .play-toolbar {
     max-width: 58vw;
   }

--- a/frontend-v2/src/styles/v2/play-panels.css
+++ b/frontend-v2/src/styles/v2/play-panels.css
@@ -510,6 +510,14 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .advanced-settings-pane > .hub-section,
+  .advanced-settings-pane > .asr-section,
+  .advanced-settings-pane > .generation-section {
+    grid-column: auto;
+    grid-row: auto;
+    align-self: auto;
+  }
+
   .reference-settings-page .settings-pane.about {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/frontend-v2/src/styles/v2/settings-status.css
+++ b/frontend-v2/src/styles/v2/settings-status.css
@@ -185,8 +185,23 @@
   grid-column: 1 / -1;
 }
 
+/* 双列错位布局：左列 Hub 隐私 + 语音识别上下堆叠，
+   右列生成参数跨两行并拉伸到底，与左列底边对齐。 */
+.advanced-settings-pane > .hub-section {
+  grid-column: 1;
+  grid-row: 2;
+}
+
 .advanced-settings-pane > .asr-section {
-  grid-column: 1 / -1;
+  grid-column: 1;
+  grid-row: 3;
+  align-self: start;
+}
+
+.advanced-settings-pane > .generation-section {
+  grid-column: 2;
+  grid-row: 2 / span 2;
+  align-self: stretch;
 }
 
 .advanced-section + .advanced-section {


### PR DESCRIPTION
## 改动
- 移动端游玩页：改为 .play-page 竖流（HUD/场景条/通知/输入框定高，日志区占满剩余高度内部滚动）。
- 设置页：ASR 区块移到 Hub 与隐私下方左列，生成参数右列跨两行底对齐；布局契约 e2e 放宽为烟雾级（不锁排布，只查不溢出/不重叠）。

## 原因
- 游玩页走全屏路由，无 app-shell 外壳；旧移动规则全部以 .app-shell-play 为前缀，从未生效，导致手机分享链接进游玩页不铺满、日志被压到一两条、内容溢出叠层（v2.0.0 起即存在）。
- 设置页 ASR 独占整行视觉占比过大，按反馈归位到左列。

## 验证
- iPhone 12 模拟：页面铺满视口、日志多条可见且内部滚动、无叠层；全量 Playwright 65 过 9 跳过 0 失败。