### PR TITLE
style(play): move voice input beside action button

### DIFF
--- a/frontend-v2/src/components/ActionComposer.vue
+++ b/frontend-v2/src/components/ActionComposer.vue
@@ -75,16 +75,6 @@ async function submit() {
       <div class="composer-title-row">
         <strong>{{ t('composerTitle') }}</strong>
         <span v-if="hint" class="composer-hint">{{ hint }}</span>
-        <button
-          v-if="micAvailable"
-          type="button"
-          class="dictation-toggle"
-          :class="{ active: recording }"
-          :title="recording ? t('asrStop') : t('asrVoice')"
-          :aria-pressed="recording"
-          :disabled="transcribing || (locked && !recording)"
-          @click="toggleVoice()"
-        >{{ recording ? '⏹' : '🎤' }}</button>
       </div>
     </div>
     <div class="quick-actions" :aria-label="t('quickActions')">
@@ -93,8 +83,19 @@ async function submit() {
     <div v-if="dictationError" class="dictation-status error">{{ dictationError }}</div>
     <div v-else-if="recording" class="dictation-status">{{ t('asrRecording', { seconds: elapsedSeconds }) }}</div>
     <div v-else-if="transcribing" class="dictation-status">{{ t('asrTranscribing') }}</div>
-    <div class="composer-row">
+    <div class="composer-row" :class="{ 'has-dictation': micAvailable }">
       <textarea v-model="text" :disabled="locked" :placeholder="t('actionPlaceholder')" @keydown.ctrl.enter.prevent="submit()" />
+      <button
+        v-if="micAvailable"
+        type="button"
+        class="dictation-toggle"
+        :class="{ active: recording }"
+        :title="recording ? t('asrStop') : t('asrVoice')"
+        :aria-label="recording ? t('asrStop') : t('asrVoice')"
+        :aria-pressed="recording"
+        :disabled="transcribing || (locked && !recording)"
+        @click="toggleVoice()"
+      >{{ recording ? '⏹' : '🎤' }}</button>
       <button class="primary" @click="submit()" :disabled="locked || !text.trim()">{{ busy ? t('processing') : t('action') }}</button>
     </div>
     <div v-if="notice" class="notice">{{ notice }}</div>
@@ -102,16 +103,18 @@ async function submit() {
 </template>
 
 <style scoped>
+.composer-row.has-dictation {
+  grid-template-columns: minmax(0, 1fr) 44px 92px;
+}
+
 .dictation-toggle {
-  flex: 0 0 auto;
-  min-width: 32px;
-  padding: 2px 9px;
+  min-width: 44px;
+  padding: 0;
   border: 1px solid color-mix(in srgb, var(--df-interactive) 38%, var(--df-border-soft));
-  border-radius: 999px;
+  border-radius: var(--df-radius-md);
   color: var(--df-text-secondary);
   background: color-mix(in srgb, var(--df-interactive) 10%, var(--df-control-bg));
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 16px;
 }
 
 .dictation-toggle.active {
@@ -140,5 +143,15 @@ async function submit() {
   border-color: color-mix(in srgb, var(--df-danger) 38%, var(--df-border-soft));
   color: var(--df-danger-strong);
   background: color-mix(in srgb, var(--df-danger) 8%, transparent);
+}
+
+@media (max-width: 800px) {
+  .composer-row.has-dictation {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .composer-row textarea {
+    grid-column: 1 / -1;
+  }
 }
 </style>

--- a/frontend-v2/tests/asr.test.ts
+++ b/frontend-v2/tests/asr.test.ts
@@ -248,6 +248,7 @@ describe('ActionComposer voice input', () => {
     })
 
     expect(wrapper.find('.dictation-toggle').exists()).toBe(false)
+    expect(wrapper.get('.composer-row').classes()).not.toContain('has-dictation')
   })
 
   it('toggles recording from the mic button once the engine is ready', async () => {
@@ -257,6 +258,9 @@ describe('ActionComposer voice input', () => {
       props: { gameKey: 'web|room|bot', userId: 'player-1', detail: detail() },
     })
     await vi.waitFor(() => expect(wrapper.find('.dictation-toggle').exists()).toBe(true))
+    expect(wrapper.find('.composer-head .dictation-toggle').exists()).toBe(false)
+    expect(wrapper.find('.composer-row .dictation-toggle').exists()).toBe(true)
+    expect(wrapper.get('.composer-row').classes()).toContain('has-dictation')
 
     await wrapper.get('.dictation-toggle').trigger('click')
     await vi.waitFor(() => expect(wrapper.get('.dictation-toggle').classes()).toContain('active'))


### PR DESCRIPTION
## Summary
- move the voice dictation toggle from the composer heading beside the action submit button
- preserve the original two-column layout when voice input is unavailable
- keep the textarea full-width on narrow screens and place voice/action controls together below it
- add an accessible label and placement coverage for the conditional layout

## Testing
- `npm test -- tests/ActionComposer.test.ts tests/asr.test.ts`
- `npm run typecheck`
- `npm run lint`