### PR TITLE
fix(sse): resume play streams from stable cursors

### DIFF
--- a/frontend-v2/src/api/client.ts
+++ b/frontend-v2/src/api/client.ts
@@ -162,10 +162,11 @@ export async function checkOwnerAccess(): Promise<OwnerAccessStatus> {
   }
 }
 
-export async function gameEventSource(gameKey: string): Promise<EventSource> {
+export async function gameEventSource(gameKey: string, cursor = ''): Promise<EventSource> {
   const result = await api<{ ticket: string }>(`/games/${encodeURIComponent(gameKey)}/sse-ticket`, { method: 'POST' })
   const q = new URLSearchParams(shareQuery())
   q.set('ticket', result.ticket)
+  if (cursor) q.set('cursor', cursor)
   return new EventSource(`/api/games/${encodeURIComponent(gameKey)}/sse?${q}`)
 }
 

--- a/frontend-v2/src/composables/gameSse.ts
+++ b/frontend-v2/src/composables/gameSse.ts
@@ -1,0 +1,22 @@
+export interface GameSsePayload {
+  type?: string
+  text?: string
+}
+
+export type GameSseEffect = 'baseline' | 'narration-delta' | 'narration-reset' | 'refresh'
+
+/**
+ * SSE baseline 只确认“HTTP 首次快照之后从哪里继续”，不得再触发一次完整刷新。
+ * 其余公开/私有状态事件仍统一走 useGame 的合并刷新，避免各组件解释存档结构。
+ */
+export function gameSseEffect(payload: GameSsePayload | null): GameSseEffect {
+  const type = payload?.type || ''
+  if (type === 'baseline') return 'baseline'
+  if (type === 'narration_delta') return 'narration-delta'
+  if (type === 'narration_reset') return 'narration-reset'
+  return 'refresh'
+}
+
+export function updatedGameSseCursor(current: string, eventId: string): string {
+  return eventId || current
+}

--- a/frontend-v2/src/composables/useGame.ts
+++ b/frontend-v2/src/composables/useGame.ts
@@ -7,6 +7,7 @@ import type { LoreKeywords } from '@/utils/renderer'
 import { clearCurrentGame, gameFromQuery, queryString, readCurrentGame, rememberCurrentGame } from '@/stores/gameContext'
 import { resolveMapBackgroundAsset, revokeMapBackgroundAsset } from '@/api/mapBackgrounds'
 import { activePeerGameClient } from '@/peer/game/bridge'
+import { gameSseEffect, updatedGameSseCursor, type GameSsePayload } from '@/composables/gameSse'
 
 const KEY_MAP:Record<string,keyof LoreKeywords>={npc:'npc',location:'location',item:'item',faction:'faction',event:'event',puzzle:'puzzle',other:'other',lore:'other'}
 function errorMessage(error: unknown): string { return error instanceof Error ? error.message : String(error || 'Load failed') }
@@ -36,6 +37,7 @@ export function useGame(){
   let refreshTimer:number|undefined
   let reconnectTimer:number|undefined
   let connectVersion=0
+  let eventCursor=''
   const signatures:Record<string,string> = { detail:'', players:'', log:'', privateMessages:'', map:'', loreEntries:'', lore:'' }
   // GM 判定与后端 is_game_gm 同口径：已登录 owner（管理员账号多人共用都算）或该局主 GM 会话。
   const isGm = computed(()=>!!detail.value && (hasAccessToken() || (!!userId.value && detail.value.gm_uid===userId.value)))
@@ -43,6 +45,7 @@ export function useGame(){
   const player = computed(()=>players.value.find(p=>p.user_id===actorId.value) || players.value[0])
 
   function rememberGame(key: string) {
+    if (currentGame.value !== key) eventCursor = ''
     currentGame.value = key
     rememberCurrentGame(key, detail.value?.world_name || '')
   }
@@ -177,16 +180,22 @@ export function useGame(){
       return
     }
     try{
-      const next=await gameEventSource(gameKey)
+      const next=await gameEventSource(gameKey, eventCursor)
       if(version!==connectVersion || gameKey!==currentGame.value){next.close();return}
       source=next
+      source.onopen=()=>{
+        if(source!==next)return
+        if(pollTimer){clearInterval(pollTimer);pollTimer=undefined}
+      }
       source.onmessage=(ev:MessageEvent)=>{
         if(pollTimer){clearInterval(pollTimer);pollTimer=undefined}
-        let payload:{type?:string;text?:string}|null=null
+        eventCursor=updatedGameSseCursor(eventCursor, ev.lastEventId)
+        let payload:GameSsePayload|null=null
         try{payload=JSON.parse(ev.data)}catch{payload=null}
-        const type=payload?.type||''
-        if(type==='narration_delta'){liveNarration.value+=String(payload?.text||'');return}
-        if(type==='narration_reset'){liveNarration.value='';return}
+        const effect=gameSseEffect(payload)
+        if(effect==='baseline')return
+        if(effect==='narration-delta'){liveNarration.value+=String(payload?.text||'');return}
+        if(effect==='narration-reset'){liveNarration.value='';return}
         scheduleSilentRefresh()
       }
       source.onerror=()=>{
@@ -200,19 +209,26 @@ export function useGame(){
       if(!reconnectTimer)reconnectTimer=window.setTimeout(()=>{reconnectTimer=undefined;void connect()},5000)
     }
   }
-  function selectGame(key:string){rememberGame(key);refresh();connect()}
+  async function selectGame(key:string){rememberGame(key);await refresh();await connect()}
   if(currentGame.value) rememberCurrentGame(currentGame.value, detail.value?.world_name || '')
-  watch(() => route.query.game, (value) => {
+  watch(() => route.query.game, async (value) => {
     const next = queryString(value)
     if(next && next !== currentGame.value){
       rememberGame(next)
-      refresh()
-      connect()
+      await refresh()
+      await connect()
     } else if(!currentGame.value && readCurrentGame()) {
       rememberGame(readCurrentGame())
     }
   })
-  watch(() => route.query.user, () => { userId.value = routeUser() })
+  watch(() => route.query.user, async () => {
+    const nextUser = routeUser()
+    if (nextUser === userId.value) return
+    userId.value = nextUser
+    eventCursor = ''
+    await refresh(true)
+    await connect()
+  })
   watch(() => log.value.length, (next, prev) => { if ((prev ?? 0) < next) liveNarration.value = '' })
   onBeforeUnmount(()=>{connectVersion++;source?.close();unsubscribePeerEvents?.();revokeMapBackgroundAsset(map.value);clearRefreshTimer();if(pollTimer)clearInterval(pollTimer);if(reconnectTimer)clearTimeout(reconnectTimer)})
   return {currentGame,userId,actorId,detail,players,player,log,privateMessages,map,lore,loreEntries,loading,error,isGm,refresh,connect,selectGame,liveNarration}

--- a/frontend-v2/tests/gameSse.test.ts
+++ b/frontend-v2/tests/gameSse.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { gameSseEffect, updatedGameSseCursor } from '@/composables/gameSse'
+
+describe('game SSE reconnect state', () => {
+  it('records a baseline without scheduling another HTTP refresh', () => {
+    expect(gameSseEffect({ type: 'baseline' })).toBe('baseline')
+  })
+
+  it('keeps the last event cursor across a reconnect until a newer event arrives', () => {
+    const cursor = 'r12.p2.a0123456789.s9876543210'
+    expect(updatedGameSseCursor('', cursor)).toBe(cursor)
+    expect(updatedGameSseCursor(cursor, '')).toBe(cursor)
+  })
+
+  it('continues to refresh for real public and private state events', () => {
+    expect(gameSseEffect({ type: 'public_actions' })).toBe('refresh')
+    expect(gameSseEffect({ type: 'private' })).toBe('refresh')
+    expect(gameSseEffect({ type: 'refresh' })).toBe('refresh')
+  })
+
+  it('keeps streaming narration updates out of the full refresh path', () => {
+    expect(gameSseEffect({ type: 'narration_delta', text: 'new' })).toBe('narration-delta')
+    expect(gameSseEffect({ type: 'narration_reset' })).toBe('narration-reset')
+  })
+})

--- a/src/webui/routes/sse.py
+++ b/src/webui/routes/sse.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import re
 
 from aiohttp import web
 
@@ -15,6 +16,11 @@ from src.webui.connection_pool import ConnectionPool
 from src.webui.routes._common import MAX_ACTION_CHARS, _get_api
 
 logger = logging.getLogger("trpg")
+
+_EVENT_CURSOR_RE = re.compile(
+    r"^r(?P<round>\d{1,10})\.p(?P<private>\d{1,10})\.a(?P<action>0|[0-9a-f]{10})"
+    r"(?:\.s(?P<public>0|[0-9a-f]{10}))?$"
+)
 
 
 async def api_sse_ticket(request: web.Request) -> web.Response:
@@ -158,18 +164,44 @@ async def sse_play(request: web.Request) -> web.StreamResponse:
     await resp.prepare(request)
     pool.add(game_key, user_id, resp)
 
-    cursor = _parse_event_cursor(request.headers.get("Last-Event-ID", ""))
-    last_round = cursor[0]
-    last_private_count = cursor[1]
-    last_action_signature = ""
+    raw_cursor = (
+        request.headers.get("Last-Event-ID", "")
+        or request.query.get("cursor", "")
+    )
+    cursor = _parse_event_cursor(raw_cursor)
+    action_signature = _play_action_signature(inst)
+    public_signature = _play_public_signature(inst, user_id)
+    fresh_connection = cursor is None
+    if fresh_connection:
+        # 页面已先通过 HTTP 获取完整快照。首次 SSE 连接只建立当前基线，
+        # 不把既有回合、行动和私聊误报成新事件，再触发一整组重复 GET。
+        last_round = inst.round_number
+        last_private_count = len(inst.private_log.get(user_id, []))
+        last_action_digest = _signature_digest(action_signature)
+        last_public_digest = _signature_digest(public_signature)
+    else:
+        assert cursor is not None
+        last_round, last_private_count, last_action_digest, last_public_digest = cursor
     last_player_count = len(inst.players)
-    last_public_signature = _play_public_signature(inst, user_id)
     try:
+        if fresh_connection:
+            await _write_play_event(
+                resp,
+                last_round,
+                last_private_count,
+                action_signature,
+                public_signature,
+                {"type": "baseline"},
+            )
         while True:
             current = subsystems.registry.get(api._parse_key(game_key))
             if not current:
                 break
             inst = current
+            action_signature = _play_action_signature(inst)
+            action_digest = _signature_digest(action_signature)
+            public_signature = _play_public_signature(inst, user_id)
+            public_digest = _signature_digest(public_signature)
             public_event_sent = False
             if inst.round_number > last_round:
                 last_round = inst.round_number
@@ -178,7 +210,8 @@ async def sse_play(request: web.Request) -> web.StreamResponse:
                     resp,
                     last_round,
                     last_private_count,
-                    last_action_signature,
+                    action_signature,
+                    public_signature,
                     {
                         "type": "narration",
                         "round": last_round,
@@ -187,40 +220,36 @@ async def sse_play(request: web.Request) -> web.StreamResponse:
                 )
                 # 状态
                 cs = inst.get_character_sheet(user_id)
-                await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'state','hp':cs.get('hp'),'max_hp':cs.get('max_hp'),'gold':cs.get('gold'),'deceased':cs.get('deceased')})
+                await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'state','hp':cs.get('hp'),'max_hp':cs.get('max_hp'),'gold':cs.get('gold'),'deceased':cs.get('deceased')})
                 public_event_sent = True
             elif inst.round_number < last_round:
                 # 回滚后回合号会倒退；同步游标，避免后续重新推进到旧回合号时漏报。
                 last_round = inst.round_number
-                await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'rollback'})
+                await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'rollback'})
                 public_event_sent = True
-            action_signature = json.dumps(
-                [
-                    (a.get("user_id", ""), a.get("text", ""), a.get("timestamp", ""))
-                    for a in inst.action_queue
-                ],
-                ensure_ascii=False,
-            )
-            if action_signature != last_action_signature:
-                last_action_signature = action_signature
-                await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'public_actions'})
+            if action_digest != last_action_digest:
+                last_action_digest = action_digest
+                await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'public_actions'})
                 public_event_sent = True
             if len(inst.players) != last_player_count:
                 last_player_count = len(inst.players)
-                await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'players'})
+                await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'players'})
                 public_event_sent = True
-            public_signature = _play_public_signature(inst, user_id)
-            if public_signature != last_public_signature:
-                last_public_signature = public_signature
+            if public_digest != last_public_digest:
+                last_public_digest = public_digest
                 if not public_event_sent:
                     # 同回合回滚、角色状态恢复等操作不会改变既有 SSE 游标，
                     # 仍需显式唤醒玩家端重新拉取完整公开状态。
-                    await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'refresh'})
+                    await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'refresh'})
             priv = inst.private_log.get(user_id, [])
+            if len(priv) < last_private_count:
+                # 清空私聊等回退操作也要更新游标；客户端通过完整刷新移除旧消息。
+                last_private_count = len(priv)
+                await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'private_reset'})
             if len(priv) > last_private_count:
                 for p in priv[last_private_count:]:
                     last_private_count += 1
-                    await _write_play_event(resp, last_round, last_private_count, last_action_signature, {'type':'private','text':p.get('text','')})
+                    await _write_play_event(resp, last_round, last_private_count, action_signature, public_signature, {'type':'private','text':p.get('text','')})
                 last_private_count = len(priv)
             await asyncio.sleep(0.5)
     except ConnectionResetError:
@@ -254,22 +283,48 @@ def _play_public_signature(inst, user_id: str) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
 
 
-def _event_cursor(round_number: int, private_count: int, action_signature: str) -> str:
-    digest = hashlib.sha1(action_signature.encode("utf-8")).hexdigest()[:10] if action_signature else "0"
-    return f"r{round_number}.p{private_count}.a{digest}"
+def _play_action_signature(inst) -> str:
+    """返回当前公开行动队列的稳定签名原文。"""
+    return json.dumps(
+        [
+            (action.get("user_id", ""), action.get("text", ""), action.get("timestamp", ""))
+            for action in inst.action_queue
+        ],
+        ensure_ascii=False,
+    )
 
 
-def _parse_event_cursor(value: str) -> tuple[int, int]:
-    try:
-        parts = str(value).split(".")
-        return max(0, int(parts[0][1:])), max(0, int(parts[1][1:]))
-    except (IndexError, ValueError):
-        return 0, 0
+def _signature_digest(signature: str) -> str:
+    return hashlib.sha1(signature.encode("utf-8")).hexdigest()[:10] if signature else "0"
+
+
+def _event_cursor(
+    round_number: int,
+    private_count: int,
+    action_signature: str,
+    public_signature: str = "",
+) -> str:
+    action_digest = _signature_digest(action_signature)
+    public_digest = _signature_digest(public_signature)
+    return f"r{round_number}.p{private_count}.a{action_digest}.s{public_digest}"
+
+
+def _parse_event_cursor(value: str) -> tuple[int, int, str, str] | None:
+    match = _EVENT_CURSOR_RE.fullmatch(str(value or ""))
+    if not match:
+        return None
+    return (
+        int(match.group("round")),
+        int(match.group("private")),
+        match.group("action"),
+        match.group("public") or "0",
+    )
 
 
 async def _write_play_event(resp: web.StreamResponse, round_number: int, private_count: int,
-                            action_signature: str, payload: dict) -> None:
-    event_id = _event_cursor(round_number, private_count, action_signature)
+                            action_signature: str, public_signature: str,
+                            payload: dict) -> None:
+    event_id = _event_cursor(round_number, private_count, action_signature, public_signature)
     data = json.dumps(payload, ensure_ascii=False)
     await resp.write(f"id: {event_id}\ndata: {data}\n\n".encode())
 

--- a/tests/test_sse_cursor.py
+++ b/tests/test_sse_cursor.py
@@ -1,11 +1,217 @@
-from src.webui.routes.sse import _event_cursor, _parse_event_cursor
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.engine.game_instance import GameInstance, GameState
+from src.webui.routes import sse as sse_routes
+from src.webui.routes.sse import (
+    _event_cursor,
+    _parse_event_cursor,
+    _play_action_signature,
+    _play_public_signature,
+    _signature_digest,
+)
 
 
-def test_play_event_cursor_round_trip():
-    event_id = _event_cursor(12, 4, '["action"]')
+def _instance() -> GameInstance:
+    inst = GameInstance(
+        game_key=("web", "room", "bot"),
+        state=GameState.ACTIVE_ACTION,
+        round_number=12,
+        scene="旧塔入口",
+    )
+    inst.players = {
+        "p1": {
+            "user_id": "p1",
+            "character_name": "冒险者",
+            "character_sheet": {"hp": 10, "max_hp": 10, "gold": 3},
+        }
+    }
+    inst.private_log["p1"] = [
+        {"round": 11, "text": "你发现墙后的风声。", "source": "gm"},
+    ]
+    inst.action_queue = [
+        {"user_id": "p1", "text": "检查石门", "timestamp": "2026-08-22T10:00:00Z"},
+    ]
+    return inst
+
+
+def _current_cursor(inst: GameInstance) -> str:
+    return _event_cursor(
+        inst.round_number,
+        len(inst.private_log["p1"]),
+        _play_action_signature(inst),
+        _play_public_signature(inst, "p1"),
+    )
+
+
+def test_play_event_cursor_round_trip_includes_action_and_public_digests():
+    event_id = _event_cursor(12, 4, '["action"]', '{"scene":"tower"}')
+    parsed = _parse_event_cursor(event_id)
+
     assert event_id.startswith("r12.p4.a")
-    assert _parse_event_cursor(event_id) == (12, 4)
+    assert parsed == (
+        12,
+        4,
+        _signature_digest('["action"]'),
+        _signature_digest('{"scene":"tower"}'),
+    )
 
 
-def test_invalid_play_event_cursor_starts_from_zero():
-    assert _parse_event_cursor("invalid") == (0, 0)
+def test_legacy_play_event_cursor_remains_parseable():
+    assert _parse_event_cursor("r12.p4.a0123456789") == (12, 4, "0123456789", "0")
+
+
+def test_invalid_play_event_cursor_establishes_a_fresh_baseline():
+    assert _parse_event_cursor("") is None
+    assert _parse_event_cursor("invalid") is None
+    assert _parse_event_cursor("r-1.p0.a0.s0") is None
+    assert _parse_event_cursor(f"r{'1' * 11}.p0.a0.s0") is None
+
+
+def test_same_state_reconnect_cursor_matches_all_server_baselines():
+    inst = _instance()
+    parsed = _parse_event_cursor(_current_cursor(inst))
+
+    assert parsed is not None
+    assert parsed[0] == inst.round_number
+    assert parsed[1] == len(inst.private_log["p1"])
+    assert parsed[2] == _signature_digest(_play_action_signature(inst))
+    assert parsed[3] == _signature_digest(_play_public_signature(inst, "p1"))
+
+
+def test_action_and_other_public_changes_advance_distinct_cursor_digests():
+    inst = _instance()
+    before = _parse_event_cursor(_current_cursor(inst))
+    assert before is not None
+
+    inst.action_queue[0]["text"] = "推开石门"
+    after_action = _parse_event_cursor(_current_cursor(inst))
+    assert after_action is not None
+    assert after_action[2] != before[2]
+    assert after_action[3] != before[3]
+
+    inst.scene = "旧塔大厅"
+    after_scene = _parse_event_cursor(_current_cursor(inst))
+    assert after_scene is not None
+    assert after_scene[2] == after_action[2]
+    assert after_scene[3] != after_action[3]
+
+
+class _FakeStreamResponse:
+    def __init__(self, **_kwargs):
+        self.written: list[bytes] = []
+
+    async def prepare(self, _request):
+        return None
+
+    async def write(self, data: bytes):
+        self.written.append(data)
+
+
+class _FakePool:
+    def __init__(self):
+        self.connections = set()
+
+    def add(self, game_key, user_id, response):
+        self.connections.add((game_key, user_id, response))
+
+    def remove(self, game_key, user_id, response):
+        self.connections.discard((game_key, user_id, response))
+
+
+class _FakeRequest:
+    def __init__(self, inst: GameInstance, cursor: str = ""):
+        self.match_info = {"game_key": "web|room|bot"}
+        self.headers = {}
+        self.query = {"cursor": cursor} if cursor else {}
+        self._identity = {"user_id": "p1"}
+        self.pool = _FakePool()
+        self.app = {
+            "connection_pool": self.pool,
+            "subsystems": SimpleNamespace(
+                registry=SimpleNamespace(get=lambda _key: inst),
+            ),
+        }
+
+    def get(self, key, default=None):
+        return self._identity.get(key, default)
+
+
+def _payloads(response: _FakeStreamResponse) -> list[dict]:
+    payloads = []
+    for raw in response.written:
+        for line in raw.decode().splitlines():
+            if line.startswith("data: "):
+                payloads.append(json.loads(line.removeprefix("data: ")))
+    return payloads
+
+
+async def _stop_stream(_delay):
+    raise ConnectionResetError
+
+
+async def _cancel_stream(_delay):
+    raise sse_routes.asyncio.CancelledError
+
+
+def _patch_stream(monkeypatch, inst: GameInstance) -> None:
+    monkeypatch.setattr(
+        sse_routes,
+        "_get_api",
+        lambda _request: SimpleNamespace(_parse_key=lambda _key: inst.game_key),
+    )
+    monkeypatch.setattr(sse_routes.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(sse_routes.asyncio, "sleep", _stop_stream)
+
+
+@pytest.mark.asyncio
+async def test_fresh_play_stream_sends_baseline_without_refresh(monkeypatch):
+    inst = _instance()
+    request = _FakeRequest(inst)
+    _patch_stream(monkeypatch, inst)
+
+    response = await sse_routes.sse_play(request)
+
+    assert _payloads(response) == [{"type": "baseline"}]
+    assert not request.pool.connections
+
+
+@pytest.mark.asyncio
+async def test_reconnect_without_new_state_sends_no_refresh(monkeypatch):
+    inst = _instance()
+    request = _FakeRequest(inst, _current_cursor(inst))
+    _patch_stream(monkeypatch, inst)
+
+    response = await sse_routes.sse_play(request)
+
+    assert _payloads(response) == []
+    assert not request.pool.connections
+
+
+@pytest.mark.asyncio
+async def test_reconnect_after_real_action_change_requests_refresh(monkeypatch):
+    inst = _instance()
+    cursor = _current_cursor(inst)
+    inst.action_queue[0]["text"] = "推开石门"
+    request = _FakeRequest(inst, cursor)
+    _patch_stream(monkeypatch, inst)
+
+    response = await sse_routes.sse_play(request)
+
+    assert _payloads(response) == [{"type": "public_actions"}]
+    assert not request.pool.connections
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_cancels_play_stream_without_leaking_connection(monkeypatch):
+    inst = _instance()
+    request = _FakeRequest(inst, _current_cursor(inst))
+    _patch_stream(monkeypatch, inst)
+    monkeypatch.setattr(sse_routes.asyncio, "sleep", _cancel_stream)
+
+    with pytest.raises(sse_routes.asyncio.CancelledError):
+        await sse_routes.sse_play(request)
+
+    assert not request.pool.connections


### PR DESCRIPTION
## 根因

游戏 SSE 重连缺少稳定、可恢复的游标语义；网络抖动或页面恢复时可能丢失增量、重复消费事件，或退回不可靠的本地序号。

## 改动

- 服务端为 play stream 提供稳定游标，并按连接游标恢复可用事件。
- 客户端统一解析、保存和提交 SSE cursor。
- useGame 通过独立 composable 管理重连状态，避免整页轮询和输入状态被重置。
- 补齐游标恢复、过期游标、重复事件和客户端解析测试。

## 影响

断线重连会从稳定游标继续；既有无游标客户端仍可建立连接，保持向后兼容。

## 验证

- python scripts/healthcheck.py：974 passed，coverage 67.57%
- 独立分支后端全量：945 passed
- Frontend Vitest：180 passed
- Playwright：desktop 38 passed；mobile 29 passed / 9 desktop-only skipped / 0 failed