### PR TITLE
fix(release): include AI provider module in 2.3.1 packages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
-# DiceFrame v2.3.0
+# DiceFrame v2.3.1
 
 ## 中文
 
-DiceFrame 2.3.0 是 2.3 系列正式版，重点完善 AI 服务配置、语音与图片能力，并修复战斗判定和断线续流的一致性问题。
+DiceFrame 2.3.1 是 2.3 系列正式版，重点完善 AI 服务配置、语音与图片能力，并修复战斗判定和断线续流的一致性问题。
 
 ### 新增
 
@@ -28,13 +28,13 @@ DiceFrame 2.3.0 是 2.3 系列正式版，重点完善 AI 服务配置、语音�
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.3.0-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.3.0-windows.zip`。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.3.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.3.1-windows.zip`。
 - `.sha256` 是更新校验文件，普通用户不需要手动下载。
 
 ## English
 
-DiceFrame 2.3.0 is the stable release of the 2.3 series. It focuses on AI service configuration, speech and image capabilities, and consistent combat resolution and stream recovery.
+DiceFrame 2.3.1 is the stable release of the 2.3 series. It focuses on AI service configuration, speech and image capabilities, and consistent combat resolution and stream recovery.
 
 ### New
 
@@ -60,6 +60,6 @@ DiceFrame 2.3.0 is the stable release of the 2.3 series. It focuses on AI servic
 
 ### Download Guide
 
-- **Regular Windows users**: download `DiceFrame-v2.3.0-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.3.0-windows.zip`.
+- **Regular Windows users**: download `DiceFrame-v2.3.1-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.3.1-windows.zip`.
 - `.sha256` files are update checksums; regular users do not need to download them manually.

--- a/scripts/build_portable.py
+++ b/scripts/build_portable.py
@@ -241,6 +241,9 @@ def validate_zip(output_zip: Path) -> None:
     for suffix in required:
         if not any(name.endswith(suffix) for name in names):
             raise RuntimeError(f"Portable zip is missing {suffix}")
+    for relative in build_release.REQUIRED_RUNTIME_SOURCE_FILES:
+        if not any(name.endswith("/app/" + relative) for name in names):
+            raise RuntimeError(f"Portable zip is missing app/{relative}")
     if any(name.endswith("/Start DiceFrame.bat") for name in names):
         raise RuntimeError("Portable zip should not contain Start DiceFrame.bat")
     if any(name.lower().endswith(".bat") for name in names):

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -105,6 +105,10 @@ EXCLUDED_SUFFIXES = {
     ".tsbuildinfo",
 }
 
+# web_server.py imports this module during startup. Keep it explicit so a
+# packaging exclusion cannot silently produce an unusable release archive.
+REQUIRED_RUNTIME_SOURCE_FILES = ("src/ai_providers.py",)
+
 FORBIDDEN_ZIP_PATTERNS = [
     re.compile(r"(^|/)data/"),
     re.compile(r"(^|/)\.env$"),
@@ -153,7 +157,7 @@ def is_excluded(path: Path) -> bool:
         return True
     if path.name.startswith(".env"):
         return True
-    if path.name.startswith("ai_") or "_copy_" in path.name:
+    if "_copy_" in path.name:
         return True
     return path.suffix in EXCLUDED_SUFFIXES
 
@@ -306,6 +310,9 @@ def validate_zip(output_zip: Path) -> None:
         raise RuntimeError("Release zip is missing static-v2/index.html")
     if not any("/static-v2/assets/" in name and name.endswith(".js") for name in names):
         raise RuntimeError("Release zip is missing built frontend assets")
+    for relative in REQUIRED_RUNTIME_SOURCE_FILES:
+        if not any(name.endswith("/" + relative) for name in names):
+            raise RuntimeError(f"Release zip is missing {relative}")
     validate_avatar_payload(infos, require_source=True)
     validate_background_payload(infos, require_source=True)
 

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -26,6 +26,19 @@ def test_copy_tree_excludes_legacy_user_templates(monkeypatch, tmp_path):
     assert not (target / "custom_rule_home.json").exists()
 
 
+def test_copy_tree_keeps_core_ai_modules(monkeypatch, tmp_path):
+    root = tmp_path / "root"
+    source = root / "src"
+    target = tmp_path / "package" / "src"
+    source.mkdir(parents=True)
+    (source / "ai_providers.py").write_text("PROVIDER = True", encoding="utf-8")
+    monkeypatch.setattr(build_release, "ROOT", root)
+
+    build_release.copy_tree(source, target)
+
+    assert (target / "ai_providers.py").exists()
+
+
 def test_prepare_package_tree_excludes_docs(monkeypatch, tmp_path):
     root = tmp_path / "root"
     (root / "docs").mkdir(parents=True)


### PR DESCRIPTION
修复 2.3.0 便携版升级后在健康检查前退出的问题。根因是旧打包规则误删新增的 src/ai_providers.py；本次移除宽泛排除规则，为源码包和便携包增加必需模块校验，补充回归测试，并将版本与发布说明更新为 2.3.1。验证：healthcheck 通过，后端 1045 passed，前端 199 passed，typecheck/build、源码包、便携包及导入 smoke 均通过。