### PR TITLE
fix(updater): skip private IP check for update downloads in Docker/virtual NIC environments

### DIFF
--- a/src/plugin_host/mirrors.py
+++ b/src/plugin_host/mirrors.py
@@ -212,8 +212,9 @@ class MirrorManager:
         mirror_id: str = "",
         binary: bool = False,
         max_bytes: int | None = None,
+        resolve: bool = True,
     ) -> FetchResult:
-        normalized_url = validate_public_http_url(url)
+        normalized_url = validate_public_http_url(url, resolve=resolve)
         mirrors = [self._require(mirror_id)] if mirror_id else self.enabled()
         if not mirrors:
             return await self._fetch(
@@ -262,14 +263,17 @@ class MirrorManager:
         mirror_id: str = "",
         max_bytes: int | None = None,
         on_progress: Callable[[int, int], Any] | None = None,
+        resolve: bool = True,
     ) -> FetchResult:
         """流式下载大文件到 target_path（经多镜像降级），支持进度回调。
 
         与 fetch_github_url 不同，本方法逐 chunk 写盘而非全部读入内存，
         适合 release zip 等大文件。on_progress(downloaded, total) 在每个 chunk
         后调用（total 为 0 表示未知长度），可为同步或异步回调。
+        resolve=False 时跳过 DNS 解析与私网地址校验，适用于 Docker/虚拟网卡
+        环境下公网域名可能解析到内网地址的场景。
         """
-        normalized_url = validate_public_http_url(url)
+        normalized_url = validate_public_http_url(url, resolve=resolve)
         mirrors = [self._require(mirror_id)] if mirror_id else self.enabled()
         if not mirrors:
             return await self._download_to_file(

--- a/src/webui/services/updater.py
+++ b/src/webui/services/updater.py
@@ -374,7 +374,7 @@ class UpdaterService:
             if sha_asset:
                 sha_url = str(sha_asset.get("download_url", ""))
                 sha_result = await self._mirrors.fetch_github_url(
-                    sha_url, binary=False, max_bytes=4096
+                    sha_url, binary=False, max_bytes=4096, resolve=False,
                 )
                 if sha_result.ok and sha_result.data:
                     expected_sha = parse_sha256_file(
@@ -396,6 +396,7 @@ class UpdaterService:
                 target,
                 max_bytes=MAX_APP_UPDATE_BYTES,
                 on_progress=on_progress,
+                resolve=False,
             )
             if not result.ok:
                 self._state.update(state="failed", error=result.error or "下载失败")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -175,10 +175,10 @@ async def test_download_update_respects_channel_and_accepts_prerelease_latest(tm
     digest = hashlib.sha256(content).hexdigest()
     mirrors = SimpleNamespace()
 
-    async def fake_fetch(url, *, binary=False, max_bytes=None):
+    async def fake_fetch(url, *, binary=False, max_bytes=None, resolve=True):
         return FetchResult(ok=True, data=f"{digest}  {ZIP_NAME}", mirror_name="m")
 
-    async def fake_download(url, target, *, max_bytes=None, on_progress=None):
+    async def fake_download(url, target, *, max_bytes=None, on_progress=None, resolve=True):
         target.write_bytes(content)
         return FetchResult(ok=True, mirror_name="m")
 
@@ -213,10 +213,10 @@ async def test_download_update_success_flow(tmp_path):
     digest = hashlib.sha256(content).hexdigest()
     mirrors = SimpleNamespace()
 
-    async def fake_fetch(url, *, binary=False, max_bytes=None):
+    async def fake_fetch(url, *, binary=False, max_bytes=None, resolve=True):
         return FetchResult(ok=True, data=f"{digest}  {ZIP_NAME}", mirror_name="测试镜像")
 
-    async def fake_download(url, target, *, max_bytes=None, on_progress=None):
+    async def fake_download(url, target, *, max_bytes=None, on_progress=None, resolve=True):
         target.write_bytes(content)
         if on_progress:
             on_progress(len(content), len(content))
@@ -251,10 +251,10 @@ async def test_download_update_progress_updates_bytes(tmp_path):
     content = b"x" * 1024
     mirrors = SimpleNamespace()
 
-    async def fake_fetch(url, *, binary=False, max_bytes=None):
+    async def fake_fetch(url, *, binary=False, max_bytes=None, resolve=True):
         return FetchResult(ok=True, data="a" * 64)
 
-    async def fake_download(url, target, *, max_bytes=None, on_progress=None):
+    async def fake_download(url, target, *, max_bytes=None, on_progress=None, resolve=True):
         # 分两块写，触发两次进度回调
         target.write_bytes(content)
         if on_progress:
@@ -345,8 +345,8 @@ async def test_download_update_rejects_source_package_for_portable_install(
 async def test_download_update_sha_mismatch_marks_failed(tmp_path):
     content = b"real content"
     mirrors = SimpleNamespace()
-    mirrors.fetch_github_url = lambda url, *, binary=False, max_bytes=None: _async_fetch("0" * 64)
-    mirrors.download_to_file = lambda url, target, *, max_bytes=None, on_progress=None: _async_download(target, content)
+    mirrors.fetch_github_url = lambda url, *, binary=False, max_bytes=None, resolve=True: _async_fetch("0" * 64)
+    mirrors.download_to_file = lambda url, target, *, max_bytes=None, on_progress=None, resolve=True: _async_download(target, content)
     latest = {"version": "1.6.0", "assets": [_asset(ZIP_NAME), _asset(ZIP_NAME + ".sha256")]}
 
     svc = _make_service(tmp_path, mirrors)
@@ -364,10 +364,10 @@ async def test_download_update_sha_mismatch_marks_failed(tmp_path):
 async def test_download_update_download_failure_marks_failed(tmp_path):
     mirrors = SimpleNamespace()
 
-    async def fake_fetch(url, *, binary=False, max_bytes=None):
+    async def fake_fetch(url, *, binary=False, max_bytes=None, resolve=True):
         return FetchResult(ok=True, data="a" * 64)
 
-    async def fake_download(url, target, *, max_bytes=None, on_progress=None):
+    async def fake_download(url, target, *, max_bytes=None, on_progress=None, resolve=True):
         return FetchResult(ok=False, error="镜像源均失败")
 
     mirrors.fetch_github_url = fake_fetch
@@ -390,11 +390,11 @@ async def test_download_update_sha_sidecar_missing_skips_verify(tmp_path):
     content = b"no sidecar"
     mirrors = SimpleNamespace()
 
-    async def fake_download(url, target, *, max_bytes=None, on_progress=None):
+    async def fake_download(url, target, *, max_bytes=None, on_progress=None, resolve=True):
         target.write_bytes(content)
         return FetchResult(ok=True, mirror_name="m")
 
-    mirrors.fetch_github_url = lambda url, *, binary=False, max_bytes=None: _async_fetch(None)
+    mirrors.fetch_github_url = lambda url, *, binary=False, max_bytes=None, resolve=True: _async_fetch(None)
     mirrors.download_to_file = fake_download
     # 无 .sha256 asset
     latest = {"version": "1.6.0", "assets": [_asset(ZIP_NAME)]}


### PR DESCRIPTION
## Summary
- When running in Docker or with virtual network interfaces, DNS resolution of public hostnames (e.g. github.com) may return private IPs
- The updater URL validation rejected these with "URL 不允许访问非公网地址", blocking updates
- Since update download URLs come from trusted GitHub API responses, skip the DNS resolution/private IP check for update downloads
- SSRF protection remains intact for other scenarios (e.g. plugin marketplace)

## Changes
- `src/plugin_host/mirrors.py`: Add `resolve` parameter to `fetch_github_url` and `download_to_file`
- `src/webui/services/updater.py`: Pass `resolve=False` when downloading updates