### PR TITLE
feat: establish Content V2 PR1 foundation

### DIFF
--- a/src/compat/__init__.py
+++ b/src/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility boundaries for legacy persisted and rule data."""

--- a/src/compat/character_cards.py
+++ b/src/compat/character_cards.py
@@ -1,0 +1,14 @@
+"""Compatibility boundary for character-card import/export formats."""
+
+from src.webui.services.character_cards import (
+    export_character_cards,
+    import_character_card,
+    list_character_cards,
+    save_character_card,
+    update_character_card,
+)
+
+__all__ = [
+    "export_character_cards", "import_character_card", "list_character_cards",
+    "save_character_card", "update_character_card",
+]

--- a/src/compat/characters.py
+++ b/src/compat/characters.py
@@ -1,0 +1,14 @@
+"""Compatibility boundary for legacy character-sheet fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.engine.character_utils import migrate_legacy_character_sheet, normalize_character_sheet
+
+__all__ = ["migrate_legacy_character_sheet", "normalize_character_sheet", "normalize_character_payload"]
+
+
+def normalize_character_payload(character: dict[str, Any], rule: object | None = None) -> dict[str, Any]:
+    """Normalize a character without deleting legacy aliases."""
+    return normalize_character_sheet(character, rule)  # type: ignore[arg-type]

--- a/src/compat/rules_v1.py
+++ b/src/compat/rules_v1.py
@@ -1,0 +1,15 @@
+"""Adapter exposing legacy rule templates to the canonical loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.rules.rule_system import _resolve_rule_template
+
+
+def load_v1_template(path: str | Path) -> dict[str, Any]:
+    template = _resolve_rule_template(Path(path))
+    if not str(template.get("rule_id") or "").strip():
+        raise ValueError("V1 rule template requires rule_id")
+    return template

--- a/src/compat/save_paths.py
+++ b/src/compat/save_paths.py
@@ -1,0 +1,16 @@
+"""Stable boundary for legacy save directory naming."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.engine.persistence import _save_path
+
+
+def save_path(registry: object, game_key: tuple) -> Path:
+    return _save_path(registry, game_key)  # type: ignore[arg-type]
+
+
+def legacy_save_paths(registry: object, game_key: tuple) -> tuple[Path, ...]:
+    parts = [str(item) for item in game_key]
+    return tuple(registry.save_dir / separator.join(parts) / "state.json" for separator in (",", "|"))  # type: ignore[attr-defined]

--- a/src/compat/saves.py
+++ b/src/compat/saves.py
@@ -1,0 +1,16 @@
+"""Compatibility helpers for persisted game saves."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_save_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Add a non-destructive schema marker while retaining every legacy field."""
+    result = dict(payload)
+    result.setdefault("save_schema_version", 1)
+    return result
+
+
+def legacy_chatlog_name() -> str:
+    return "chatlog.jsonl"

--- a/src/content/__init__.py
+++ b/src/content/__init__.py
@@ -1,0 +1,10 @@
+"""Content V2 contracts used by core and plugin adapters."""
+
+from .contracts import ContentResource, ResourceRef, canonical_id
+from .locale import LocaleOverlayError, resolve_locale, apply_locale_overlay
+from .snapshot import mechanics_snapshot
+
+__all__ = [
+    "ContentResource", "ResourceRef", "canonical_id", "LocaleOverlayError",
+    "resolve_locale", "apply_locale_overlay", "mechanics_snapshot",
+]

--- a/src/content/contracts.py
+++ b/src/content/contracts.py
@@ -1,0 +1,50 @@
+"""Stable identity and resource contracts for Content V2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+_ID = re.compile(r"^[a-z][a-z0-9_-]{0,95}$")
+
+
+def canonical_id(value: str) -> str:
+    result = str(value or "").strip().lower().replace(" ", "_")
+    if not _ID.fullmatch(result):
+        raise ValueError(f"invalid canonical id: {value!r}")
+    return result
+
+
+@dataclass(frozen=True)
+class ResourceRef:
+    owner: str
+    kind: str
+    local_id: str
+
+    def __post_init__(self) -> None:
+        if not str(self.owner).strip() or not str(self.kind).strip():
+            raise ValueError("resource owner and kind are required")
+        object.__setattr__(self, "owner", str(self.owner).strip())
+        object.__setattr__(self, "kind", canonical_id(self.kind))
+        object.__setattr__(self, "local_id", canonical_id(self.local_id))
+
+    def __str__(self) -> str:
+        return f"{self.owner}:{self.kind}:{self.local_id}"
+
+    @classmethod
+    def parse(cls, value: str) -> "ResourceRef":
+        parts = str(value or "").split(":")
+        if len(parts) < 3:
+            raise ValueError("resource reference must be owner:kind:local_id")
+        return cls(":".join(parts[:-2]), parts[-2], parts[-1])
+
+
+@dataclass(frozen=True)
+class ContentResource:
+    ref: ResourceRef
+    data: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.data, dict):
+            raise TypeError("content resource data must be an object")

--- a/src/content/locale.py
+++ b/src/content/locale.py
@@ -1,0 +1,37 @@
+"""Typed locale overlays; mechanics cannot be changed by translations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_LINGUISTIC = frozenset({"aliases", "keywords", "skill_candidates", "prompt", "prompt_prose"})
+_DISPLAY = frozenset({"name", "title", "description", "label", "hint", "flavor"})
+_ALLOWED = _LINGUISTIC | _DISPLAY
+
+
+class LocaleOverlayError(ValueError):
+    pass
+
+
+def _base_locale(locale: str) -> str:
+    return str(locale or "").replace("_", "-").split("-", 1)[0].lower()
+
+
+def resolve_locale(locales: dict[str, dict[str, Any]], locale: str, default_locale: str = "zh-CN") -> dict[str, Any]:
+    candidates = [str(locale), _base_locale(locale), str(default_locale), _base_locale(default_locale)]
+    for candidate in candidates:
+        value = locales.get(candidate)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def apply_locale_overlay(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(overlay, dict):
+        raise LocaleOverlayError("locale overlay must be an object")
+    forbidden = set(overlay) - _ALLOWED
+    if forbidden:
+        raise LocaleOverlayError(f"locale overlay contains mechanics fields: {sorted(forbidden)}")
+    result = dict(base)
+    result.update(overlay)
+    return result

--- a/src/content/snapshot.py
+++ b/src/content/snapshot.py
@@ -1,0 +1,13 @@
+"""Deterministic mechanics snapshots for locale-invariance checks."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_DISPLAY_FIELDS = frozenset({"name", "title", "description", "label", "hint", "flavor", "aliases", "keywords", "prompt", "prompt_prose"})
+
+
+def mechanics_snapshot(value: dict[str, Any]) -> str:
+    mechanics = {key: item for key, item in value.items() if key not in _DISPLAY_FIELDS}
+    return json.dumps(mechanics, ensure_ascii=False, sort_keys=True, separators=(",", ":"))

--- a/src/lorebook/store.py
+++ b/src/lorebook/store.py
@@ -9,6 +9,8 @@ import threading
 from pathlib import Path
 from typing import Any
 
+from src.migrations.lorebook import migrate as migrate_lorebook
+
 logger = logging.getLogger("trpg")
 
 SCHEMA = """
@@ -58,20 +60,6 @@ CREATE INDEX IF NOT EXISTS idx_lorebook_tier  ON lorebook_entries(world_id, tier
 PRAGMA journal_mode=WAL;
 PRAGMA foreign_keys=ON;
 """
-# 表升级
-_MIGRATE_CONSTANT = "ALTER TABLE lorebook_entries ADD COLUMN is_constant INTEGER DEFAULT 0;"
-_MIGRATE_MATCH_MODE = "ALTER TABLE lorebook_entries ADD COLUMN match_mode TEXT DEFAULT 'any' CHECK(match_mode IN ('any','all','not_any','not_all'));"
-_MIGRATE_STICKY = "ALTER TABLE lorebook_entries ADD COLUMN sticky INTEGER DEFAULT 0;"
-_MIGRATE_COOLDOWN = "ALTER TABLE lorebook_entries ADD COLUMN cooldown INTEGER DEFAULT 0;"
-_MIGRATE_DELAY = "ALTER TABLE lorebook_entries ADD COLUMN delay INTEGER DEFAULT 0;"
-_MIGRATE_ORDER = 'ALTER TABLE lorebook_entries ADD COLUMN "order" INTEGER DEFAULT 100;'
-_MIGRATE_PROBABILITY = "ALTER TABLE lorebook_entries ADD COLUMN probability INTEGER DEFAULT 100;"
-_MIGRATE_GROUP = 'ALTER TABLE lorebook_entries ADD COLUMN "group" TEXT DEFAULT \'\';'
-_MIGRATE_GROUP_WEIGHT = "ALTER TABLE lorebook_entries ADD COLUMN group_weight INTEGER DEFAULT 1;"
-_MIGRATE_CONNECTED = "ALTER TABLE lorebook_entries ADD COLUMN connected_to TEXT DEFAULT '[]';"
-_MIGRATE_WORLD_LANGUAGE = "ALTER TABLE worlds ADD COLUMN language TEXT DEFAULT 'zh-CN';"
-_MIGRATE_SOURCE_PLUGIN = "ALTER TABLE lorebook_entries ADD COLUMN source_plugin TEXT DEFAULT '';"
-
 # 迁移后的 lorebook_entries 目标列（新表结构，顺序即 _drop_legacy_type_check_sql 的建表顺序）
 _LOREBOOK_NEW_COLUMNS = (
     "id", "world_id", "name", "type", "keywords", "content", "unreliable",
@@ -134,16 +122,7 @@ class LorebookStore:
         self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
-        # 运行表升级
-        for mig in (_MIGRATE_CONSTANT, _MIGRATE_MATCH_MODE, _MIGRATE_STICKY,
-                     _MIGRATE_COOLDOWN, _MIGRATE_DELAY, _MIGRATE_ORDER,
-                     _MIGRATE_PROBABILITY, _MIGRATE_GROUP, _MIGRATE_GROUP_WEIGHT,
-                      _MIGRATE_CONNECTED, _MIGRATE_WORLD_LANGUAGE, _MIGRATE_SOURCE_PLUGIN):
-            try:
-                self._conn.execute(mig)
-                self._conn.commit()
-            except sqlite3.OperationalError:
-                pass
+        migrate_lorebook(self._conn)
         self._drop_legacy_type_check()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_lorebook_source ON lorebook_entries(source_plugin)")
         self._conn.commit()

--- a/src/memory/delta.py
+++ b/src/memory/delta.py
@@ -9,6 +9,8 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from src.migrations.memory import migrate as migrate_memory
+
 logger = logging.getLogger("trpg")
 
 SCHEMA = """
@@ -34,12 +36,6 @@ CREATE INDEX IF NOT EXISTS idx_memory_status  ON memory_entries(game_key, status
 PRAGMA journal_mode=WAL;
 """
 
-# 表升级：为没有 embedding 列的老表添加
-_MIGRATE_EMBEDDING = """
-ALTER TABLE memory_entries ADD COLUMN embedding TEXT;
-"""
-
-
 class MemoryStore:
     """长期记忆 SQLite 存储，处理 memory_delta 的冲突消解。"""
 
@@ -57,12 +53,7 @@ class MemoryStore:
         self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
-        # 尝试迁移旧表（添加 embedding 列）
-        try:
-            self._conn.execute(_MIGRATE_EMBEDDING)
-            self._conn.commit()
-        except sqlite3.OperationalError:
-            pass  # 列已存在
+        migrate_memory(self._conn)
         self._conn.commit()
 
     def close(self) -> None:

--- a/src/migrations/__init__.py
+++ b/src/migrations/__init__.py
@@ -1,0 +1,5 @@
+"""Versioned persistence migrations."""
+
+from .sqlite import MigrationError, ensure_column, run_migrations
+
+__all__ = ["MigrationError", "ensure_column", "run_migrations"]

--- a/src/migrations/config.py
+++ b/src/migrations/config.py
@@ -1,0 +1,32 @@
+"""Configuration migrations kept independent from the web bootstrap."""
+
+from __future__ import annotations
+
+DEFAULT_NARRATIVE_MAX_TOKENS = 2048
+GENERATION_DEFAULTS_VERSION = 5
+TOKEN_FIELD_MIGRATIONS = (
+    ("narrative_max_tokens", frozenset({1024, 1536}), DEFAULT_NARRATIVE_MAX_TOKENS),
+    ("analysis_max_tokens", frozenset({512}), 1024),
+    ("summary_max_tokens", frozenset({400}), 1024),
+    ("brief_max_tokens", frozenset({300}), 1024),
+    ("text_gen_max_tokens", frozenset({400}), 1024),
+)
+
+
+def migrate_generation_defaults(config: dict) -> bool:
+    try:
+        version = int(config.get("generation_defaults_version", 0) or 0)
+    except (TypeError, ValueError):
+        version = 0
+    if version >= GENERATION_DEFAULTS_VERSION:
+        return False
+    for field, old_defaults, new_default in TOKEN_FIELD_MIGRATIONS:
+        missing = min(old_defaults)
+        try:
+            current = int(config.get(field, missing) or missing)
+        except (TypeError, ValueError):
+            current = missing
+        if current in old_defaults:
+            config[field] = new_default
+    config["generation_defaults_version"] = GENERATION_DEFAULTS_VERSION
+    return True

--- a/src/migrations/lorebook.py
+++ b/src/migrations/lorebook.py
@@ -1,0 +1,30 @@
+"""Lorebook database schema migrations."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from .sqlite import ensure_column, run_migrations
+
+
+def _v1(conn: sqlite3.Connection) -> None:
+    for name, definition in (
+        ("is_constant", "INTEGER DEFAULT 0"),
+        ("match_mode", "TEXT DEFAULT 'any'"),
+        ("sticky", "INTEGER DEFAULT 0"),
+        ("cooldown", "INTEGER DEFAULT 0"),
+        ("delay", "INTEGER DEFAULT 0"),
+        ("order", "INTEGER DEFAULT 100"),
+        ("probability", "INTEGER DEFAULT 100"),
+        ("group", "TEXT DEFAULT ''"),
+        ("group_weight", "INTEGER DEFAULT 1"),
+        ("connected_to", "TEXT DEFAULT '[]'"),
+    ):
+        ensure_column(conn, "lorebook_entries", name, definition)
+    ensure_column(conn, "worlds", "language", "TEXT DEFAULT 'zh-CN'")
+    ensure_column(conn, "lorebook_entries", "source_plugin", "TEXT DEFAULT ''")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_lorebook_source ON lorebook_entries(source_plugin)")
+
+
+def migrate(conn: sqlite3.Connection) -> int:
+    return run_migrations(conn, ((1, _v1),))

--- a/src/migrations/memory.py
+++ b/src/migrations/memory.py
@@ -1,0 +1,15 @@
+"""Memory database schema migrations."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from .sqlite import ensure_column, run_migrations
+
+
+def _v1(conn: sqlite3.Connection) -> None:
+    ensure_column(conn, "memory_entries", "embedding", "TEXT")
+
+
+def migrate(conn: sqlite3.Connection) -> int:
+    return run_migrations(conn, ((1, _v1),))

--- a/src/migrations/sqlite.py
+++ b/src/migrations/sqlite.py
@@ -1,0 +1,56 @@
+"""Small, transactional SQLite migration primitives.
+
+The database's ``user_version`` is advanced only after every step succeeds.
+Existing databases are intentionally migrated in place; no data is rewritten
+unless a migration explicitly requires it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Iterable
+
+
+class MigrationError(RuntimeError):
+    """Raised when a migration cannot be completed."""
+
+
+Migration = tuple[int, Callable[[sqlite3.Connection], None]]
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+
+
+def ensure_column(conn: sqlite3.Connection, table: str, column: str, definition: str) -> bool:
+    """Add a missing column and report whether the schema changed."""
+    if column in table_columns(conn, table):
+        return False
+    conn.execute(f'ALTER TABLE "{table}" ADD COLUMN "{column}" {definition}')
+    return True
+
+
+def run_migrations(
+    conn: sqlite3.Connection,
+    migrations: Iterable[Migration],
+    *,
+    target_version: int | None = None,
+) -> int:
+    """Run pending migrations atomically and return the resulting version."""
+    steps = sorted(migrations, key=lambda item: item[0])
+    current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    target = target_version if target_version is not None else (steps[-1][0] if steps else current)
+    try:
+        conn.execute("BEGIN")
+        for version, migrate in steps:
+            if version > current:
+                migrate(conn)
+                conn.execute(f"PRAGMA user_version = {int(version)}")
+                current = version
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        raise MigrationError(f"SQLite migration failed at version {current + 1}") from exc
+    if current < target:
+        raise MigrationError(f"No migration registered for target version {target}")
+    return current

--- a/src/plugin_host/host.py
+++ b/src/plugin_host/host.py
@@ -1154,6 +1154,16 @@ class PluginHost:
             raise ValueError("插件 ID 与目录名不一致")
         if int(manifest.get("schema_version", 0)) != 1:
             raise ValueError("不支持的 manifest schema_version")
+        for field in ("content_schema_version", "locale_schema_version"):
+            if field in manifest:
+                try:
+                    version = int(manifest[field])
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(f"{field} 必须是正整数") from exc
+                if version < 1:
+                    raise ValueError(f"{field} 必须是正整数")
+        if "default_locale" in manifest and not str(manifest["default_locale"] or "").strip():
+            raise ValueError("default_locale 不能为空")
         plugin_type = self._plugin_type(manifest)
         if plugin_type not in _PLUGIN_TYPES:
             raise ValueError(f"不支持的 plugin_type：{plugin_type}")

--- a/src/plugin_host/registry.py
+++ b/src/plugin_host/registry.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Any
+
+from src.content.contracts import ResourceRef
 
 from .map_validation import (
     MAP_IMAGE_KINDS,
@@ -34,6 +37,14 @@ class PluginContribution:
     relative_path: str
     title: str = ""
     description: str = ""
+    content_schema_version: int = 1
+
+    @property
+    def ref(self) -> ResourceRef:
+        # Asset paths are legacy local keys; retain the original key while
+        # exposing a canonical identity for the V2 registry.
+        local_id = re.sub(r"[^a-zA-Z0-9_-]", "_", self.key).lower().strip("_") or "asset"
+        return ResourceRef(f"plugin:{self.plugin_id}", self.kind, local_id)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -52,15 +63,18 @@ class ContributionRegistry:
     def __init__(self) -> None:
         self._items: list[PluginContribution] = []
         self._by_kind_key: dict[tuple[str, str], PluginContribution] = {}
+        self._by_ref: dict[ResourceRef, PluginContribution] = {}
 
     def clear(self) -> None:
         self._items.clear()
         self._by_kind_key.clear()
+        self._by_ref.clear()
 
     def clear_plugin(self, plugin_id: str) -> None:
         kept = [item for item in self._items if item.plugin_id != plugin_id]
         self._items = []
         self._by_kind_key = {}
+        self._by_ref = {}
         for item in kept:
             self._add(item)
 
@@ -102,20 +116,24 @@ class ContributionRegistry:
         return [item for item in self._items if item.kind == kind]
 
     def find(self, kind: str, key: str, *, plugin_id: str = "") -> PluginContribution | None:
+        if plugin_id:
+            return self._by_ref.get(ResourceRef(f"plugin:{plugin_id}", kind, key))
         if kind not in _NAMESPACED_KINDS:
             return self._by_kind_key.get((kind, key))
-        if plugin_id:
-            return self._by_kind_key.get((kind, f"{plugin_id}:{key}"))
         matches = [item for item in self._items if item.kind == kind and item.key == key]
         return matches[0] if len(matches) == 1 else None
 
     def _add(self, item: PluginContribution) -> None:
+        ref = item.ref
+        if ref in self._by_ref:
+            raise ValueError(f"插件资源 ID 重复：{ref}")
+        self._by_ref[ref] = item
         lookup_key = f"{item.plugin_id}:{item.key}" if item.kind in _NAMESPACED_KINDS else item.key
         existing = self._by_kind_key.get((item.kind, lookup_key))
         if existing:
             if item.kind in _NAMESPACED_KINDS:
                 raise ValueError(f"插件内资源 ID 重复：{item.kind} {item.key}")
-            if existing.plugin_id != item.plugin_id:
+            if existing.plugin_id != item.plugin_id and item.content_schema_version < 2:
                 raise ValueError(
                     f"插件资源冲突：{item.kind} {item.key} 已由 {existing.plugin_id} 提供"
                 )
@@ -213,6 +231,7 @@ def _contribution_from_path(
         relative_path=path.relative_to(plugin_dir).as_posix(),
         title=title.strip(),
         description=description.strip(),
+        content_schema_version=int(manifest.get("content_schema_version", 1) or 1),
     )
 
 

--- a/src/rules/loader.py
+++ b/src/rules/loader.py
@@ -1,0 +1,25 @@
+"""Unified V1/V2 rule bundle loading entry point."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from src.compat.rules_v1 import load_v1_template
+
+
+class RuleBundleLoader:
+    """Load a V1 JSON rule or a V2 bundle without changing RuleSystem behavior."""
+
+    def load(self, path: str | Path) -> dict[str, Any]:
+        source = Path(path)
+        with source.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+        if not isinstance(raw, dict):
+            raise ValueError("rule bundle must be a JSON object")
+        if int(raw.get("content_schema_version", 1) or 1) >= 2:
+            if not str(raw.get("rule_id") or raw.get("id") or "").strip():
+                raise ValueError("V2 rule bundle requires rule_id")
+            return raw
+        return load_v1_template(source)

--- a/tests/test_content_v2_contracts.py
+++ b/tests/test_content_v2_contracts.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.content import ResourceRef, apply_locale_overlay, mechanics_snapshot, resolve_locale
+
+
+def test_resource_ref_round_trip_supports_namespaced_owner():
+    ref = ResourceRef.parse("plugin:my-pack:item:moon_blade")
+    assert ref.owner == "plugin:my-pack"
+    assert str(ref) == "plugin:my-pack:item:moon_blade"
+
+
+def test_locale_overlay_rejects_mechanics_fields():
+    with pytest.raises(ValueError):
+        apply_locale_overlay({"damage": "1d8"}, {"damage": "2d8"})
+
+
+def test_locale_fallback_and_snapshot_ignore_display_fields():
+    assert resolve_locale({"en": {"name": "Sword"}}, "en-US", "zh-CN")["name"] == "Sword"
+    assert mechanics_snapshot({"damage": "1d8", "name": "A"}) == mechanics_snapshot({"damage": "1d8", "name": "B"})

--- a/tests/test_sqlite_migrations.py
+++ b/tests/test_sqlite_migrations.py
@@ -1,0 +1,23 @@
+import sqlite3
+
+import pytest
+
+from src.migrations.sqlite import MigrationError, run_migrations
+
+
+def test_migration_is_idempotent_and_sets_version():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("create table t (id integer)")
+    calls = []
+    step = lambda db: (calls.append(1), db.execute("alter table t add column value text"))
+    assert run_migrations(conn, ((1, step),)) == 1
+    assert run_migrations(conn, ((1, step),)) == 1
+    assert len(calls) == 1
+
+
+def test_failed_migration_rolls_back_version():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("create table t (id integer)")
+    with pytest.raises(MigrationError):
+        run_migrations(conn, ((1, lambda db: db.execute("alter table missing add column x text")),))
+    assert conn.execute("pragma user_version").fetchone()[0] == 0

--- a/web_server.py
+++ b/web_server.py
@@ -13,6 +13,11 @@ from aiohttp import web
 
 sys.path.insert(0, str(Path(__file__).parent))
 from src.common_factory import TRPGSubsystems, create_trpg_subsystems
+from src.migrations.config import (
+    DEFAULT_NARRATIVE_MAX_TOKENS,
+    GENERATION_DEFAULTS_VERSION,
+    migrate_generation_defaults as _migrate_generation_defaults,
+)
 from src.ai_providers import (
     is_provider_secret_key,
     normalize_ai_providers,
@@ -81,8 +86,6 @@ from src.webui.services import legal as legal_svc
 logger = logging.getLogger("trpg")
 logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
 
-DEFAULT_NARRATIVE_MAX_TOKENS = 2048
-GENERATION_DEFAULTS_VERSION = 5
 
 DATA_DIR = Path(os.getenv("TRPG_DATA_DIR", str(Path(__file__).parent / "data")))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -128,37 +131,6 @@ def _load_json_object(path: Path, label: str) -> dict:
 # 仅在配置值等于某个已知旧默认时提升，保留用户自定义值。
 # 默认值历史上单调递增，缺失字段按最小旧默认补全后同样提升。
 # character_gen_max_tokens 一直是 2048，无旧默认需提升，不在表中。
-_TOKEN_FIELD_MIGRATIONS: tuple[tuple[str, frozenset[int], int], ...] = (
-    ("narrative_max_tokens", frozenset({1024, 1536}), DEFAULT_NARRATIVE_MAX_TOKENS),
-    ("analysis_max_tokens", frozenset({512}), 1024),
-    ("summary_max_tokens", frozenset({400}), 1024),
-    ("brief_max_tokens", frozenset({300}), 1024),
-    ("text_gen_max_tokens", frozenset({400}), 1024),
-)
-
-
-def _migrate_generation_defaults(config: dict) -> bool:
-    """一次性提升旧版默认生成额度，同时保留用户的自定义数值。"""
-    try:
-        version = int(config.get("generation_defaults_version", 0) or 0)
-    except (TypeError, ValueError):
-        version = 0
-    if version >= GENERATION_DEFAULTS_VERSION:
-        return False
-
-    for field, old_defaults, new_default in _TOKEN_FIELD_MIGRATIONS:
-        missing = min(old_defaults)
-        try:
-            current = int(config.get(field, missing) or missing)
-        except (TypeError, ValueError):
-            current = missing
-        if current in old_defaults:
-            config[field] = new_default
-
-    config["generation_defaults_version"] = GENERATION_DEFAULTS_VERSION
-    return True
-
-
 saved = _load_json_object(CONFIG_FILE, "主配置")
 secrets = _load_json_object(SECRETS_FILE, "敏感配置")
 _generation_defaults_migrated = _migrate_generation_defaults(saved)


### PR DESCRIPTION
PR1 foundation: centralize SQLite and config migrations; add persistence compatibility boundaries; add Content V2 contracts and V1 rule loader; extend plugin schema and namespaced registry. Validation: healthcheck, backend pytest 1107 passed, frontend checks. PR2 and PR3 are out of scope.