### PR TITLE
fix: close Content V2 PR125 acceptance gaps

### DIFF
--- a/src/content/rule_locale.py
+++ b/src/content/rule_locale.py
@@ -25,7 +25,7 @@ def materialize_rule(core: dict[str, Any], overlay: dict[str, Any]) -> dict[str,
         raise ValueError(f"locale overlay contains mechanics fields: {sorted(forbidden)}")
     result.update({key: value for key, value in rule_fields.items() if key in _DISPLAY_FIELDS})
     result.update({key: value for key, value in fields.items() if key in _DISPLAY_FIELDS})
-    for key, values in (("attributes", overlay.get("attributes")), ("classes", overlay.get("classes")), ("items", overlay.get("items")), ("skills", overlay.get("skills"))):
+    for key, values in (("attributes", overlay.get("attributes")), ("classes", overlay.get("classes")), ("items", overlay.get("items")), ("skills", overlay.get("skills")), ("special_stats", overlay.get("special_stats"))):
         if not isinstance(values, dict):
             continue
         if key == "attributes":

--- a/src/rules/rule_system.py
+++ b/src/rules/rule_system.py
@@ -161,6 +161,10 @@ class RuleSystem:
             if isinstance(item, dict):
                 item.pop("name", None)
                 item.pop("description", None)
+        for item in value.get("special_stats", []):
+            if isinstance(item, dict):
+                item.pop("name", None)
+                item.pop("description", None)
         value.pop("skill_pools", None)
         value.pop("skill_names", None)
         value.pop("difficulty_instructions", None)

--- a/tests/test_builtin_rules_v2.py
+++ b/tests/test_builtin_rules_v2.py
@@ -35,6 +35,25 @@ def test_builtin_rule_locale_base_fallback_and_display_name() -> None:
     assert template["rule_name"] == "Classic Fantasy Freeform"
 
 
+@pytest.mark.parametrize(
+    ("locale", "sanity_name", "luck_name"),
+    (
+        ("zh-CN", "理智值", "幸运值"),
+        ("en", "Sanity", "Luck"),
+        ("ja", "正気度", "幸運"),
+    ),
+)
+def test_coc_special_stats_locale_overlays(locale: str, sanity_name: str, luck_name: str) -> None:
+    loader = RuleBundleLoader()
+    system = RuleSystem(loader.load_rule("templates/rules", "freeform_coc", locale))
+    stats = {str(item["key"]): item for item in system.template["special_stats"]}
+
+    assert stats["sanity"]["name"] == sanity_name
+    assert stats["luck"]["name"] == luck_name
+    assert stats["sanity"]["max"] == 99
+    assert stats["luck"]["max"] == 99
+
+
 def test_legacy_full_copy_rules_remain_loadable() -> None:
     loader = RuleBundleLoader()
 

--- a/tests/test_dnd5e_v2.py
+++ b/tests/test_dnd5e_v2.py
@@ -48,3 +48,17 @@ def test_dnd5e_core_has_canonical_mechanics_and_no_locale_overlay_fields():
     assert core["items"]["arcane_focus"] == {"type": "focus"}
     assert core["items"]["chain_mail"]["ac_base"] == 16
     assert all(item.get("id") for item in core["classes"])
+
+
+def test_dnd5e_v2_starter_items_do_not_depend_on_legacy_damage_tables(monkeypatch):
+    from src.engine import constants
+
+    monkeypatch.setattr(constants, "WEAPON_DAMAGE", {})
+    monkeypatch.setattr(constants, "WEAPON_DAMAGE_DICE", {})
+    rule = RuleSystem(RuleBundleLoader().load_rule(RULES, "dnd5e", "en"))
+
+    equipment, _ = build_starter_items(rule, "Fighter")
+
+    longsword = next(item for item in equipment if item["item_key"] == "longsword")
+    assert longsword["type"] == "weapon"
+    assert longsword["damage_dice"] == "1d8"


### PR DESCRIPTION
## Summary
- Fix special_stats locale materialization for CoC sanity/luck display overlays.
- Keep mechanics snapshots locale-invariant.
- Add regression coverage proving D&D canonical starter items do not depend on legacy damage tables.

## Scope
- No combat, dice, AC, equipment algorithm, RuleSystem redesign, file moves, frontend i18n rewrite, or legacy file deletion.
- Existing V1 rule/save/character compatibility remains unchanged.

## Validation
- Full scripts/healthcheck.py passed.
- Backend: 1126 passed, coverage 68.68%.
- Frontend: lint, typecheck, 202 Vitest tests, production build passed.