### PR TITLE
fix: sync runtime locales and localize lorebook NPCs

### DIFF
--- a/src/template_catalog.py
+++ b/src/template_catalog.py
@@ -70,4 +70,22 @@ def sync_template_catalog(
         except OSError:
             stats["failed"] += 1
             logger.exception("模板同步失败: %s -> %s", source, target)
+
+    # Content V2 typed locales live below ``locales/<locale>/``.  Runtime
+    # loaders read from data/templates, so copying only the root core files
+    # silently drops localization in an actual server process even though
+    # direct loader tests against the bundled directory pass.
+    locale_dir = bundled_dir / "locales"
+    if locale_dir.is_dir():
+        for source in sorted(locale_dir.rglob("*.json")):
+            target = runtime_dir / source.relative_to(bundled_dir)
+            try:
+                if target.exists() and source.read_bytes() == target.read_bytes():
+                    continue
+                existed = target.exists()
+                _copy_atomic(source, target)
+                stats["updated" if existed else "copied"] += 1
+            except OSError:
+                stats["failed"] += 1
+                logger.exception("模板 locale 同步失败: %s -> %s", source, target)
     return stats

--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -14,6 +14,8 @@ from src.engine.character_utils import (
     make_default_character,
     normalize_character_sheet,
 )
+from src.content.worlds import localize_lorebook_entries
+from src.engine.language import localized_text
 from src.engine.health import record_health_event
 from src.commands.state_items import grant_classified_item
 
@@ -222,7 +224,16 @@ def list_characters(api: "WebAPI", game_key: str) -> dict[str, Any]:
         name = npc.get("character_name") or npc.get("name") or nid
         npcs_by_name[name] = {"npc_id": nid, **npc, "name": name}
     if api._lore and inst.world_id:
-        for entry in api._lore.list_entries(inst.world_id, "npc"):
+        entries = api._lore.list_entries(inst.world_id, "npc")
+        world_data = api._load_world_template(
+            inst.world_id,
+            str(getattr(inst, "language", "") or ""),
+        )
+        lore_status = localized_text(
+            getattr(inst, "language", ""),
+            {"en": "Lorebook", "zh-CN": "世界书", "ja": "ワールドブック"},
+        )
+        for entry in localize_lorebook_entries(entries, world_data):
             name = entry.get("name", "")
             if not name or name in npcs_by_name:
                 continue
@@ -231,7 +242,7 @@ def list_characters(api: "WebAPI", game_key: str) -> dict[str, Any]:
                 "name": name,
                 "character_name": name,
                 "tier": entry.get("tier", ""),
-                "status": "世界书",
+                "status": lore_status,
                 "relation": entry.get("relation", ""),
                 "content": entry.get("content", ""),
                 "portrait": entry.get("portrait"),
@@ -428,6 +439,11 @@ async def update_npc_portrait(api: "WebAPI", game_key: str, npc_id: str, portrai
     if npc is None and api._lore and inst.world_id:
         entry = api._lore.get_entry(npc_key)
         if entry and entry.get("world_id") == inst.world_id and entry.get("type") == "npc":
+            world_data = api._load_world_template(
+                inst.world_id,
+                str(getattr(inst, "language", "") or ""),
+            )
+            entry = localize_lorebook_entries([entry], world_data)[0]
             name = str(entry.get("name") or npc_key)
             npc = {
                 "name": name,

--- a/tests/test_template_catalog.py
+++ b/tests/test_template_catalog.py
@@ -49,3 +49,23 @@ def test_sync_does_not_replace_user_template_that_collides_with_bundle_name(tmp_
     assert stats["preserved"] == 1
     saved = json.loads((runtime / "base.json").read_text(encoding="utf-8"))
     assert saved["rule_name"] == "用户"
+
+
+def test_sync_copies_and_refreshes_nested_typed_locales(tmp_path):
+    bundled = tmp_path / "bundle" / "rules"
+    runtime = tmp_path / "data" / "templates" / "rules"
+    locale = bundled / "locales" / "en" / "base.json"
+    _write(bundled / "base.json", {"rule_id": "base", "rule_schema_version": 2})
+    _write(locale, {"locale_schema_version": 1, "locale": "en", "fields": {"rule_name": "Base"}})
+
+    first = sync_template_catalog(bundled, runtime, "rules")
+
+    copied = runtime / "locales" / "en" / "base.json"
+    assert first["copied"] == 2
+    assert json.loads(copied.read_text(encoding="utf-8"))["fields"]["rule_name"] == "Base"
+
+    _write(locale, {"locale_schema_version": 1, "locale": "en", "fields": {"rule_name": "Updated"}})
+    second = sync_template_catalog(bundled, runtime, "rules")
+
+    assert second["updated"] == 1
+    assert json.loads(copied.read_text(encoding="utf-8"))["fields"]["rule_name"] == "Updated"

--- a/tests/test_webui_create_flow.py
+++ b/tests/test_webui_create_flow.py
@@ -1552,6 +1552,50 @@ def test_character_api_exposes_generic_rule_meta(web_api):
     assert result["rule_meta"]["identity_schema"][0]["legacy_field"] == "race"
 
 
+def test_character_api_localizes_persisted_lorebook_npcs_for_game_language(web_api):
+    api, lorebook, registry, _fake_llm, worlds_dir = web_api
+    world_id = "localized_character_world"
+    _write_world(worlds_dir, world_id, starter_lorebook=[{
+        "id": "npc_guide", "name": "向导", "type": "npc",
+        "keywords": ["向导"], "content": "中文介绍", "tier": "core",
+    }])
+    core_path = worlds_dir / f"{world_id}.json"
+    core = json.loads(core_path.read_text(encoding="utf-8"))
+    core.update({"world_schema_version": 2, "default_locale": "zh-CN"})
+    core_path.write_text(json.dumps(core, ensure_ascii=False), encoding="utf-8")
+    locale_path = worlds_dir / "locales" / "en" / f"{world_id}.json"
+    locale_path.parent.mkdir(parents=True, exist_ok=True)
+    locale_path.write_text(json.dumps({
+        "locale_schema_version": 1,
+        "locale": "en",
+        "target": {"kind": "world", "id": world_id},
+        "fields": {"world_name": "Localized Character World"},
+        "starter_lorebook": {
+            "npc_guide": {
+                "name": "Old Guide",
+                "keywords": ["guide"],
+                "content": "English introduction",
+            },
+        },
+    }), encoding="utf-8")
+    lorebook.create_world(world_id, "本地化角色世界")
+    lorebook.add_entry({
+        "id": "npc_guide", "world_id": world_id, "name": "向导",
+        "type": "npc", "keywords": ["向导"], "content": "中文介绍",
+        "tier": "core",
+    })
+    instance = registry.get_or_create(("web", "localized-npcs", "bot"))
+    instance.world_id = world_id
+    instance.language = "en"
+
+    result = api.list_characters("web|localized-npcs|bot")
+
+    assert result["npcs"][0]["npc_id"] == "npc_guide"
+    assert result["npcs"][0]["name"] == "Old Guide"
+    assert result["npcs"][0]["content"] == "English introduction"
+    assert result["npcs"][0]["status"] == "Lorebook"
+
+
 @pytest.mark.asyncio
 async def test_game_health_api_marks_event(web_api):
     api, _lorebook, registry, _fake_llm, _worlds_dir = web_api


### PR DESCRIPTION
## Summary
- sync bundled Content V2 typed locale JSON into the runtime template catalog
- localize persisted lorebook NPCs for the current game language, including portrait materialization
- cover nested locale refresh and character API localization with regressions

## Validation
- `python -m pytest` — 1180 passed
- `python -m ruff check src tests`
- `python -m mypy`
- `python scripts/audit_architecture.py`
- `python scripts/audit_rules.py --strict`
- live browser/API acceptance against an isolated real server and OpenAI-compatible HTTP stub