### PR TITLE
chore(release): prepare v2.3.2-beta.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,65 +1,61 @@
-# DiceFrame v2.3.1
+# DiceFrame v2.3.2-beta.1
 
 ## 中文
 
-DiceFrame 2.3.1 是 2.3 系列正式版，重点完善 AI 服务配置、语音与图片能力，并修复战斗判定和断线续流的一致性问题。
+DiceFrame 2.3.2-beta.1 是下一次补丁版的预览。它重点验证 Content V2 内容架构、规则与世界书的多语言本地化，以及旧数据迁移链路。请先备份现有 `data/` 后再用于重要战役。
 
-### 新增
+### 内容与本地化
 
-- **统一 AI 服务商与模型配置**：集中维护服务商、Base URL、API Key 和模型目录，并在独立页面为主模型、向量模型、TTS、语音识别与图片生成分配模型。旧版内联配置继续兼容，无需强制迁移。
-- **内置图片生成**：可通过 OpenAI 兼容接口生成场景图、头像、物品图和地图背景；生成结果会保存为游戏素材，未配置时不影响现有玩法。
-- **云端语音识别**：支持 OpenAI 兼容的音频转写接口，玩家可在行动输入框旁录音并将识别文本直接填入输入框。
-- **免费 Edge TTS**：新增微软 Edge 在线音色，无需 API Key 或 Base URL，可直接用于 GM 和角色朗读。
+- **Content V2 正式进入运行时**：规则、世界、职业、物品、法术和 NPC 使用稳定的 canonical ID；中文、英文和日文只覆盖显示文本，切换语言不会改变存档、规则或世界书 identity。
+- **规则与世界的 typed locale**：内置规则和世界支持按游戏语言物化的名称、说明、场景与世界书文本；缺失语言会按既定 fallback 回退，不会静默改写 mechanics。
+- **运行时模板同步修复**：启动时会将内置的嵌套 locale JSON 同步到 `data/templates`，确保真实部署与开发加载器一致。
+- **世界书角色本地化**：角色面板和世界书 NPC 的头像物化会使用当前对局语言的只读本地化视图，译文不会写回共享世界书数据库。
 
-### 改进与修复
+### 规则、迁移与客户端
 
-- **AI 配置帮助与连接测试**：恢复服务商和模型配置帮助，以 DeepSeek 为示例；连接测试超时可在高级设置中配置为 5–300 秒。
-- **战斗检定一致性**：战斗命中与暴击统一以服务端 `CheckResult` 为准，不再二次掷命中骰；重试不会重复掷骰或重复扣血，异常缺少检定结果时会安全停止结算。
-- **断线续流**：游戏事件流使用稳定游标恢复，网络抖动或页面恢复时减少事件丢失和重复展示，同时保持旧客户端兼容。
-- **多人和移动端体验**：直连邀请码与玩家身份绑定；房主和玩家视图共用布局规则，修复移动端日志区、卡片遮挡和输入区排列问题。
-- **规则与骰子可靠性**：统一 D&D、CoC 等规则的检定入口与奖惩骰行为，并加强长期战役和多人权限边界校验。
-- **设置页布局**：高级设置新增项目后仍能稳定排列；顶部状态卡保持单排，可横向查看完整信息。
+- **D&D 5e Lite Content V2**：D&D 轻规则的职业、装备、伤害和角色创建数据迁入 canonical 内容模型，同时保持 generic d20 与 D&D 专属逻辑的边界。
+- **旧数据兼容与迁移**：旧规则、世界书、角色和存档会先经过明确的 compatibility/migration 边界再进入当前模型，减少升级后 legacy 字段与索引不一致的问题。
+- **战斗与长战役可靠性**：补强检定权威、死亡豁免、状态更新和长战役重算的覆盖，避免重试时重复结算。
+- **实验性移动端客户端**：仓库新增 Expo 移动端客户端与共享 API/流式交互覆盖；本次 Release 附件暂不提供移动端安装包。
 
 ### 已知限制
 
+- 这是预览版，建议在现有战役和自定义模板上先做副本验证；遇到问题请保留日志和最小复现。
+- 预览版的可下载附件仍为 Windows 源码包和 Windows 便携包；移动端需要从仓库源码自行运行。
 - 玩家直连仍为实验性功能：对称 NAT 或严格防火墙可能阻止连接，房主必须保持 DiceFrame 和房间在线。
-- Edge TTS 使用微软在线朗读接口，服务协议变化时可能需要升级依赖。
-- 图片生成和云端语音识别需要用户自行配置兼容服务；P2P 直连模式不传输录音音频。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.3.1-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.3.1-windows.zip`。
-- `.sha256` 是更新校验文件，普通用户不需要手动下载。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.3.2-beta.1-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.3.2-beta.1-windows.zip`。
+- `.sha256` 是更新校验文件；预览版请保留旧版本或数据备份，便于回退。
 
 ## English
 
-DiceFrame 2.3.1 is the stable release of the 2.3 series. It focuses on AI service configuration, speech and image capabilities, and consistent combat resolution and stream recovery.
+DiceFrame 2.3.2-beta.1 previews the next patch release. It focuses on the Content V2 runtime architecture, localized rule and lorebook content, and the legacy-data migration path. Back up your existing `data/` before using it for an important campaign.
 
-### New
+### Content and localization
 
-- **Unified AI providers and model routing**: manage providers, base URLs, API keys, and model catalogs in one place, then assign models for chat, embeddings, TTS, transcription, and image generation on a dedicated page. Legacy inline settings remain compatible and do not require forced migration.
-- **Built-in image generation**: generate scene art, portraits, item images, and map backgrounds through OpenAI-compatible APIs. Generated assets persist with the game, while unconfigured installations continue to work normally.
-- **Cloud speech recognition**: use OpenAI-compatible audio transcription endpoints to record beside the action input and insert recognized text directly into the editor.
-- **Free Edge TTS**: Microsoft Edge online voices are available without an API key or base URL for GM and character narration.
+- **Content V2 is active at runtime**: rules, worlds, classes, items, spells, and NPCs use stable canonical IDs. Chinese, English, and Japanese overlays change display text only, never save, rule, or lorebook identity.
+- **Typed locales for rules and worlds**: bundled rules and worlds materialize names, descriptions, scenes, and lorebook text for the game language. Missing locales use the documented fallback path without silently changing mechanics.
+- **Runtime template synchronization**: startup now copies nested bundled locale JSON into `data/templates`, aligning a deployed server with the development loader.
+- **Localized lorebook characters**: the character panel and lorebook-NPC portrait materialization use a read-only view for the active game language; translations are never written back into the shared lorebook database.
 
-### Improvements and Fixes
+### Rules, migration, and clients
 
-- **AI setup help and connection tests**: provider and model help is restored with DeepSeek as the example. Connection-test timeout is configurable from 5 to 300 seconds in advanced settings.
-- **Consistent combat checks**: combat hits and criticals now use the server `CheckResult` as the sole authority, without a second attack roll. Retries do not reroll or apply damage twice, and missing check results fail safely.
-- **Stream recovery**: game event streams resume from stable cursors after network interruptions or page recovery, reducing missing or duplicated events while remaining compatible with older clients.
-- **Multiplayer and mobile UX**: direct-connect invitations are bound to player identities; host and player views share layout rules, with fixes for mobile logs, overlapping cards, and action controls.
-- **Reliable rules and dice**: D&D, CoC, and other bundled rules share consistent check planning and bonus/penalty behavior, with stronger long-campaign and multiplayer authority validation.
-- **Stable settings layout**: advanced settings remain aligned as options are added, and the top status cards stay on one horizontally scrollable row without truncating their content.
+- **D&D 5e Lite Content V2**: D&D Lite classes, equipment, damage, and character-creation data now use the canonical content model while keeping generic d20 behavior separate from D&D-specific logic.
+- **Legacy compatibility and migration**: older rules, lorebooks, characters, and saves cross explicit compatibility and migration boundaries before entering the current model, reducing inconsistent legacy fields and indexes after upgrade.
+- **Reliable combat and long campaigns**: stronger coverage for authoritative checks, death saves, state updates, and long-campaign recomputation helps retries avoid duplicate resolution.
+- **Experimental mobile client**: the repository now includes an Expo mobile client with shared API and streaming coverage. This release does not attach mobile installation packages.
 
-### Known Limits
+### Known limits
 
-- Player-to-player direct connect remains experimental: symmetric NAT or strict firewalls may prevent connections, and the host must keep DiceFrame and the room online.
-- Edge TTS relies on Microsoft's online read-aloud interface and may require dependency updates if that service changes.
-- Image generation and cloud transcription require a user-configured compatible service. P2P direct mode does not transport recorded audio.
+- This is a preview release. Test existing campaigns and custom templates on a copy first; retain logs and a minimal reproduction if anything fails.
+- Downloadable assets remain Windows source and Windows portable packages; the mobile client must currently be run from the repository source.
+- Player direct connect remains experimental: symmetric NAT or strict firewalls may prevent connections, and the host must keep DiceFrame and the room online.
 
-### Download Guide
+### Download guide
 
-- **Regular Windows users**: download `DiceFrame-v2.3.1-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.3.1-windows.zip`.
-- `.sha256` files are update checksums; regular users do not need to download them manually.
+- **Regular Windows users**: download `DiceFrame-v2.3.2-beta.1-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.3.2-beta.1-windows.zip`.
+- `.sha256` files are update checksums. Keep the previous version or a data backup to make preview rollback easy.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.3.1"
+__version__ = "2.3.2-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Release scope
- bump DiceFrame to `2.3.2-beta.1`
- publish bilingual preview release notes for the Content V2 runtime and migration validation

## Validation
- `python -m pytest -q` — 1180 passed
- `python -m ruff check src tests`
- `python -m mypy`
- `python scripts/audit_architecture.py`
- `python scripts/audit_rules.py --strict`
- `python scripts/build_release.py --version 2.3.2-beta.1 --allow-dirty`
- independently verified the generated source ZIP excludes private/runtime/test/cache paths and contains required runtime files

The tag workflow marks this version as a prerelease and produces Windows source/portable archives plus SHA-256 sidecars.