### PR TITLE
fix(web): restore voice input microphone access

### DIFF
--- a/src/webui/routes/pages.py
+++ b/src/webui/routes/pages.py
@@ -19,7 +19,7 @@ async def add_response_security_headers(
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "no-referrer"
-    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(self), geolocation=()"
 
 
 async def index(request: web.Request) -> web.FileResponse:

--- a/tests/test_search_engine_blocking.py
+++ b/tests/test_search_engine_blocking.py
@@ -41,7 +41,7 @@ async def test_security_headers_are_added_to_success_error_and_stream_responses(
         assert response.headers["X-Content-Type-Options"] == "nosniff"
         assert response.headers["X-Frame-Options"] == "DENY"
         assert response.headers["Referrer-Policy"] == "no-referrer"
-        assert response.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=()"
+        assert response.headers["Permissions-Policy"] == "camera=(), microphone=(self), geolocation=()"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow same-origin microphone access in the global `Permissions-Policy`
- keep camera and geolocation disabled
- update the security-header regression test

## Root cause
The WebUI voice-input code was present and ASR could be configured, but every response sent `microphone=()`. Browsers therefore rejected microphone access at the document policy layer.

## Validation
- `python -m pytest -q tests/test_search_engine_blocking.py tests/test_asr_routes.py tests/test_asr.py` (22 passed)
- frontend ASR tests, typecheck, lint, and production build were also verified locally before isolating the PR branch