### PR TITLE
docs: make plugin README copy player-facing

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,11 @@ Bot 会跟随绑定对局的语言显示帮助和主要操作提示；中文与�
 - `@bot 暂离` / `@bot 回来`：临时下线不阻塞回合。
 - `@bot <自然语言行动>`：提交角色行动。
 
-Bot 不直接读写存档，只通过 Web 服务的 HTTP API 工作。插件商店优先从 DiceFrame Hub 读取审核状态、统计与详情，Hub 不可用时自动降级到本地缓存和公开索引镜像；插件包仍直接从作者自己的 GitHub 正式 Release 固定到精确提交下载，Hub 不代理包体。商店检测到插件新版本时会提示，安装与更新均由用户手动确认；进程型或扩权更新始终需要确认。本地和私下分享使用 `.dfplugin`。匿名使用统计默认关闭，可在“设置 → 高级 → DiceFrame Hub 与隐私”中开启、关闭或清除假名化安装身份；游戏、角色、插件列表、模型配置和正文不会作为心跳发送。开发时可用 `DICEFRAME_HUB_URL=http://127.0.0.1:18080` 指向本机 Hub，非本机地址必须使用 HTTPS。插件开发说明见 [插件开发指南](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-development.md)，投稿和审核边界见 [插件索引与审核规则](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-registry.md)。示例插件在 `plugins/examples/`，包括内容包、主题、可调用工具和 Bot Bridge 命令/展示扩展；可用 `python scripts\package_plugin.py plugins\examples\bridge-customizer --overwrite` 打包测试。
+DiceFrame 插件商店可以浏览和安装社区插件。插件由作者通过 GitHub Release 发布；安装和更新都需要用户确认，插件申请运行外部进程或扩大权限时会额外提示风险。本地或私下分享的插件也可以通过 `.dfplugin` 文件安装。
+
+DiceFrame Hub 为插件商店提供审核信息、版本状态和详情。Hub 暂时不可用时，已安装插件和本地游戏不受影响。匿名使用统计默认关闭，可以在“设置 → 高级参数 → DiceFrame Hub 与隐私”中管理。
+
+如果你想开发或发布插件，请阅读[插件开发指南](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-development.md)和[插件索引与审核规则](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-registry.md)。
 
 ## 文档
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -145,7 +145,11 @@ The built-in QQ/NapCat plugin receives its DiceFrame Bot API Token automatically
 
 The Bot follows the bound game's language for help and primary operation messages, with native Chinese and English commands available.
 
-The plugin store indexes author-owned repositories. Installation resolves the latest stable GitHub Release to an exact commit; the store checks for updates and notifies; installing or updating always requires user confirmation, and process or permission-expanding updates require explicit confirmation. Local/private sharing uses `.dfplugin`. Supported capabilities include channel adapters, Bot Bridge command/hook/render extensions, content packs, themes, structured tools, and the location/asset subset of map packs. Import/export and Provider types remain reserved and cannot be installed from the store.
+The DiceFrame plugin store lets you browse and install community plugins published by their authors through GitHub Releases. Installing or updating always requires confirmation, with an additional risk warning when a plugin requests external-process access or expanded permissions. Locally or privately shared plugins can also be installed from `.dfplugin` files.
+
+DiceFrame Hub provides review information, version status, and details for the plugin store. Installed plugins and local games continue to work if Hub is temporarily unavailable. Anonymous usage statistics are disabled by default and can be managed under **Settings → Advanced → DiceFrame Hub and privacy**.
+
+To develop or publish a plugin, see the [plugin development guide](https://github.com/diceframe/diceframe-content/blob/main/docs/en/plugin-development.md) and [plugin registry and review rules](https://github.com/diceframe/diceframe-content/blob/main/docs/en/plugin-registry.md).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- rewrite the Chinese plugin-store paragraph for players instead of maintainers
- remove Hub internals, local-development variables, packaging commands, and implementation-level details from the main README
- keep the player-facing installation, permission, availability, and privacy behavior
- align the English README and link maintainers to the dedicated development and registry documentation

## Validation

- `python -m pytest tests/test_assistant_knowledge.py -q` (6 passed)
- all four linked Chinese/English plugin documentation pages returned HTTP 200
- `git diff --cached --check` passed
- staged secret and personal-path scans passed

## Scope

Documentation only. No code, version, release, Hub, package, or `.dockerignore` changes are included.