### PR TITLE
fix(web): localize character skill suggestions

### DIFF
--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -167,7 +167,14 @@ def _character_schema_for_rule(rule) -> dict[str, Any]:
         "progression_schema": rule.progression_schema,
         "ui_schema": rule.ui_schema,
     }
-    skill_pool = list(rule.template.get("skill_pool") or rule.template.get("skills") or [])
+    explicit_skill_pool = rule.template.get("skill_pool")
+    legacy_skills = rule.template.get("skills")
+    if isinstance(explicit_skill_pool, list):
+        skill_pool = list(explicit_skill_pool)
+    elif isinstance(legacy_skills, list):
+        skill_pool = list(legacy_skills)
+    else:
+        skill_pool = []
     if not skill_pool:
         # Standalone creation has no class selection context yet. Offer the
         # union of class pools so the same rule schema remains useful before a

--- a/tests/test_builtin_rules_v2.py
+++ b/tests/test_builtin_rules_v2.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.rules.loader import RuleBundleLoader
 from src.rules.rule_system import RuleSystem
+from src.webui.services.characters import _character_schema_for_rule
 
 
 RULE_IDS = (
@@ -47,6 +48,28 @@ def test_localized_skill_pools_keep_canonical_mechanics_and_base_values() -> Non
     assert "Spot Hidden" in en.skill_pools["Private Detective"]
     assert en._skill_base_value("Spot Hidden") == 25
     assert zh.mechanics_snapshot() == en.mechanics_snapshot()
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected", "canonical_id"),
+    (
+        ("zh-CN", "重击", "heavy_strike"),
+        ("en", "Heavy Strike", "heavy_strike"),
+        ("ja", "重撃", "heavy_strike"),
+    ),
+)
+def test_character_schema_skill_pool_uses_localized_display_names(
+    locale: str,
+    expected: str,
+    canonical_id: str,
+) -> None:
+    loader = RuleBundleLoader()
+    rule = RuleSystem(loader.load_rule("templates/rules", "freeform_fantasy", locale))
+
+    skill_pool = _character_schema_for_rule(rule)["skill_pool"]
+
+    assert expected in skill_pool
+    assert canonical_id not in skill_pool
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- prevent Content V2 skill mappings from leaking canonical IDs into character creation suggestions
- preserve legacy list-based skill suggestions
- add zh-CN, English, and Japanese regression coverage

## Tests
- `python -m pytest tests/test_builtin_rules_v2.py -q`
- `python -m pytest tests/test_webui_create_flow.py -q -k "character_schema_is_available_without_active_game or character_api_exposes_rule_creation_hints"`