### PR TITLE
feat(web): integrate peer room dashboard and restore GM access

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ docker pull ghcr.io/diceframe/diceframe:2.3.0-beta.2
 # Docker Hub：docker pull falconku/diceframe:2.3.0-beta.2
 ```
 
-后续更新 Compose 部署：
+如果原先使用 Compose 部署，更新命令必须在存放 `docker-compose.yml` 的部署目录执行：
 
 ```bash
+cd /path/to/diceframe
 docker compose pull
 docker compose up -d
 ```
+
+如果原先使用的是上面的 `docker run` 命令，则不能在任意目录改用 Compose 更新；请按部署说明拉取新镜像并用原端口、卷和环境变量重新创建容器。出现 `no configuration file provided: not found`，表示当前目录没有 Compose 配置文件。
 
 ### 从源码运行
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -95,6 +95,8 @@ See the [standalone WebUI deployment guide](https://diceframe.com/en/docs?doc=st
 
 ## Docker
 
+Run these commands from a cloned repository or extracted source release directory that contains `docker-compose.yml`:
+
 ```bash
 cp .env.example .env
 # edit .env as needed
@@ -122,9 +124,12 @@ See the [Docker deployment guide](https://github.com/diceframe/diceframe-content
 To update a Compose deployment:
 
 ```bash
+cd /path/to/diceframe
 docker compose pull
 docker compose up -d
 ```
+
+If the container was originally started with `docker run`, do not switch to Compose from an arbitrary directory. Recreate it with the original ports, volumes, and environment variables as described in the deployment guide. `no configuration file provided: not found` means the current directory has no Compose file.
 
 ## First Game
 

--- a/docs/en/updates.md
+++ b/docs/en/updates.md
@@ -38,9 +38,12 @@ If you use a Git checkout, continue updating it with `git pull`.
 For a Docker Compose deployment, run:
 
 ```bash
+cd /path/to/diceframe  # Must contain docker-compose.yml
 docker compose pull
 docker compose up -d
 ```
+
+`no configuration file provided: not found` means the current directory has no Compose file. Change to the original deployment directory and retry. If the container was originally started with `docker run`, pull the new image and recreate it with the original ports, volumes, and environment variables instead of applying Compose commands.
 
 NAS users can use the device's container manager to check for updates, pull the latest image, and recreate the container. Make sure `data/` is mounted from the host.
 

--- a/docs/zh/updates.md
+++ b/docs/zh/updates.md
@@ -38,9 +38,12 @@
 使用 Docker Compose 部署时运行：
 
 ```bash
+cd /path/to/diceframe  # 必须是存放 docker-compose.yml 的部署目录
 docker compose pull
 docker compose up -d
 ```
+
+如果提示 `no configuration file provided: not found`，说明当前目录没有 Compose 配置文件。请进入原部署目录后重试；如果最初使用 `docker run` 启动，则应拉取新镜像后按原端口、卷和环境变量重新创建容器，不能直接套用 Compose 更新命令。
 
 NAS 用户可以直接在设备自带的容器管理界面检查更新、拉取最新镜像并重新创建容器。请确认 `data/` 已挂载到宿主机。
 

--- a/frontend-v2/e2e/peer-connect.spec.ts
+++ b/frontend-v2/e2e/peer-connect.spec.ts
@@ -13,7 +13,9 @@ test('two clients establish a direct data channel through Hub signaling', async 
   await host.locator('.peer-direct-consent input').check()
   await host.getByRole('button', { name: '创建临时直连房间' }).click()
   // 批量开房会同时生成已绑定角色与空闲席位的链接；该流程需要空闲席位来创建新角色。
-  const invite = await host.getByLabel('新玩家 1 的一次性链接码').getByRole('textbox').inputValue()
+  const invitePanel = host.locator('.peer-status .peer-invite')
+  await expect(invitePanel).toContainText('玩家邀请码')
+  const invite = await invitePanel.getByLabel('新玩家 1 的一次性链接码').getByRole('textbox').inputValue()
   expect(invite).toMatch(/^DFP2-/)
 
   await guest.goto('/#/peer')
@@ -22,8 +24,13 @@ test('two clients establish a direct data channel through Hub signaling', async 
   await guest.locator('.peer-direct-consent input').check()
   await guest.getByRole('button', { name: '连接房主' }).click()
 
-  await expect(host.getByText('P2P 直连成功', { exact: true })).toBeVisible({ timeout: 20_000 })
-  await expect(guest.getByText('P2P 直连成功', { exact: true })).toBeVisible({ timeout: 20_000 })
+  await expect(host.locator('.peer-status > header .peer-state-connected')).toHaveText('P2P 直连成功', {
+    timeout: 20_000,
+  })
+  await expect(guest.locator('.peer-status > header .peer-state-connected')).toHaveText('P2P 直连成功', {
+    timeout: 20_000,
+  })
+  await expect(host.locator('.peer-invite-peer-state.peer-state-connected')).toHaveCount(1)
   // 通道状态块进入 active 即代表心跳自检通过；不锁具体文案，避免文案调整破坏 e2e。
   await expect(host.locator('.peer-connection-check.active')).toBeVisible()
   await expect(guest.locator('.peer-connection-check.active')).toBeVisible()

--- a/frontend-v2/e2e/shell.spec.ts
+++ b/frontend-v2/e2e/shell.spec.ts
@@ -123,6 +123,7 @@ test('direct share route follows browser locale and exposes a language switch', 
 })
 
 test('solo save asks before conversion and only then creates an online room', async ({ page, request }) => {
+  let gmClaimed = false
   let converted = false
   let roomRequests = 0
   await page.route('**/api/**', async route => {
@@ -143,7 +144,17 @@ test('solo save asks before conversion and only then creates an online room', as
       })
       return
     }
+    if (url.pathname.endsWith('/claim-gm')) {
+      gmClaimed = true
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, user_id: 'gm_owner' }),
+      })
+      return
+    }
     if (url.pathname.endsWith('/mode')) {
+      expect(gmClaimed).toBe(true)
       converted = true
       expect(route.request().postDataJSON()).toEqual({ solo: false })
       await route.fulfill({
@@ -198,9 +209,11 @@ test('solo save asks before conversion and only then creates an online room', as
   await page.locator('.peer-direct-consent input').check()
   await page.getByRole('button', { name: '创建临时直连房间' }).click()
   await expect(page.getByText('转换为多人存档？')).toBeVisible()
+  expect(gmClaimed).toBe(false)
   expect(converted).toBe(false)
   expect(roomRequests).toBe(0)
   await page.getByRole('button', { name: '转换并创建房间' }).click()
+  await expect.poll(() => gmClaimed).toBe(true)
   await expect.poll(() => converted).toBe(true)
   await expect.poll(() => roomRequests).toBe(1)
   await expect(page.locator('.peer-status .peer-invite textarea')).toHaveValue(/^DFP2-/)
@@ -208,6 +221,7 @@ test('solo save asks before conversion and only then creates an online room', as
 })
 
 test('a full save can issue a direct-connect code for an occupied character', async ({ page, request }) => {
+  let gmClaimed = false
   let requestedPeerCount = 0
   await page.route('**/api/**', async route => {
     const url = new URL(route.request().url())
@@ -225,6 +239,15 @@ test('a full save can issue a direct-connect code for an occupied character', as
             max_players: 2,
           }],
         }),
+      })
+      return
+    }
+    if (url.pathname.endsWith('/claim-gm')) {
+      gmClaimed = true
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, user_id: 'gm_owner' }),
       })
       return
     }
@@ -293,6 +316,7 @@ test('a full save can issue a direct-connect code for an occupied character', as
   await page.locator('.peer-direct-consent input').check()
   await page.getByRole('button', { name: '创建临时直连房间' }).click()
 
+  await expect.poll(() => gmClaimed).toBe(true)
   await expect.poll(() => requestedPeerCount).toBe(2)
   await expect(page.locator('.peer-status .peer-invite-meta > strong')).toHaveText('夜莺')
   await expect(page.locator('.peer-status .peer-invite textarea')).toHaveValue(/^DFP2-/)

--- a/frontend-v2/e2e/shell.spec.ts
+++ b/frontend-v2/e2e/shell.spec.ts
@@ -203,7 +203,8 @@ test('solo save asks before conversion and only then creates an online room', as
   await page.getByRole('button', { name: '转换并创建房间' }).click()
   await expect.poll(() => converted).toBe(true)
   await expect.poll(() => roomRequests).toBe(1)
-  await expect(page.locator('.peer-invite textarea')).toHaveValue(/^DFP2-/)
+  await expect(page.locator('.peer-status .peer-invite textarea')).toHaveValue(/^DFP2-/)
+  await expect(page.locator('.peer-setup .peer-invite')).toHaveCount(0)
 })
 
 test('a full save can issue a direct-connect code for an occupied character', async ({ page, request }) => {
@@ -293,6 +294,9 @@ test('a full save can issue a direct-connect code for an occupied character', as
   await page.getByRole('button', { name: '创建临时直连房间' }).click()
 
   await expect.poll(() => requestedPeerCount).toBe(2)
-  await expect(page.locator('.peer-invite-code-wrap > strong')).toHaveText('夜莺')
-  await expect(page.locator('.peer-invite textarea')).toHaveValue(/^DFP2-/)
+  await expect(page.locator('.peer-status .peer-invite-meta > strong')).toHaveText('夜莺')
+  await expect(page.locator('.peer-status .peer-invite textarea')).toHaveValue(/^DFP2-/)
+  await expect(page.locator('.peer-status-room')).toContainText('FULLROOM')
+  await expect(page.locator('.peer-status .peer-invite-peer-state')).toContainText('等待另一客户端')
+  await expect(page.locator('.peer-status .peer-member-states')).toHaveCount(0)
 })

--- a/frontend-v2/src/features/peer/PeerConnectView.vue
+++ b/frontend-v2/src/features/peer/PeerConnectView.vue
@@ -211,7 +211,8 @@ async function createRoom() {
     const game = selectedGame.value
     if (!game) throw new Error(t('peerGameRequired'))
     if (!hasInviteCapacity.value) throw new Error(t('peerNoInviteCapacity'))
-    if (game.solo_mode !== false) {
+    const shouldConvertSoloSave = game.solo_mode !== false
+    if (shouldConvertSoloSave) {
       const accepted = await confirm({
         title: t('peerConvertSoloTitle'),
         content: t('peerConvertSoloContent'),
@@ -219,6 +220,15 @@ async function createRoom() {
         type: 'warning',
       })
       if (!accepted) return
+    }
+    // 与游戏页保持一致：开房前恢复存档绑定的 GM 会话。浏览器 Cookie 更新、
+    // 静态前端换源或换设备后，当前 Web 会话 ID 可能与存档 gm_uid 不同；
+    // 只放宽单个接口会让后续 GM 操作继续失败，因此必须先完成身份恢复。
+    await api(`/games/${encodeURIComponent(selectedGameKey.value)}/claim-gm`, {
+      method: 'POST',
+      body: '{}',
+    })
+    if (shouldConvertSoloSave) {
       const converted = await api<{ ok?: boolean; solo_mode?: boolean; error?: string }>(
         `/games/${encodeURIComponent(selectedGameKey.value)}/mode`,
         { method: 'POST', body: JSON.stringify({ solo: false }) },

--- a/frontend-v2/src/features/peer/PeerConnectView.vue
+++ b/frontend-v2/src/features/peer/PeerConnectView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { NIcon, NInput } from 'naive-ui'
 import { ArrowBackOutline, CopyOutline, LinkOutline } from '@vicons/ionicons5'
@@ -73,6 +73,7 @@ const guestCustomStunUrl = ref('')
 const directConsent = ref(false)
 const inviteCodes = ref<EncodedPeerInvite[]>([])
 const inviteInput = ref('')
+const invitePanel = ref<HTMLElement | null>(null)
 
 const stateLabel = computed(() => t(`peerState_${state.value}`))
 /** 状态详情里的 Hub/协议原始错误码转成人话，正常进度文案原样展示。 */
@@ -254,6 +255,8 @@ async function createRoom() {
       guestActorIds,
       localApi: api,
     })
+    await nextTick()
+    invitePanel.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
   } catch (error) {
     const stunError = stunConfigError(error)
     if (stunError) {
@@ -410,42 +413,6 @@ async function enterGame() {
           <button class="success peer-primary" :disabled="!directConsent || !selectedGameKey || playersLoading || !hasInviteCapacity || busy || sessionActive" @click="createRoom">
             <NIcon :component="LinkOutline" />{{ t('peerCreateRoom') }}
           </button>
-          <div v-if="inviteCodes.length" class="peer-invite">
-            <header class="peer-invite-header">
-              <div class="peer-invite-room">
-                <span>{{ t('peerRoomCode') }}</span><code>{{ roomCode }}</code>
-              </div>
-              <button v-if="inviteCodes.length > 1" class="peer-copy-all" @click="copyAllInvites">
-                <NIcon :component="CopyOutline" />{{ t('peerCopyAllInvites') }}
-              </button>
-            </header>
-            <div
-              v-for="(invite, index) in inviteCodes"
-              :key="invite.peerId"
-              class="peer-invite-item"
-            >
-              <span class="peer-invite-index" aria-hidden="true">{{ index + 1 }}</span>
-              <div class="peer-invite-code-wrap">
-                <strong>{{ invite.actorName || t('peerNewPlayerNumber', { number: index + 1 }) }}</strong>
-                <NInput
-                  class="peer-invite-code"
-                  :value="invite.inviteCode"
-                  type="textarea"
-                  readonly
-                  :autosize="{ minRows: 2, maxRows: 2 }"
-                  :aria-label="t('peerInviteForTarget', { name: invite.actorName || t('peerNewPlayerNumber', { number: index + 1 }) })"
-                />
-              </div>
-              <button
-                class="peer-invite-copy"
-                :aria-label="t('peerCopyInvite')"
-                @click="copyInvite(invite.inviteCode)"
-              >
-                <NIcon :component="CopyOutline" />{{ t('peerCopyInvite') }}
-              </button>
-            </div>
-            <small>{{ t('peerInviteSecurityHint') }}</small>
-          </div>
         </template>
 
         <template v-else>
@@ -490,10 +457,58 @@ async function enterGame() {
             <span>{{ t('peerConnectionStatus') }}</span>
             <strong :class="`peer-state-${state}`"><i />{{ stateLabel }}</strong>
           </div>
-          <code v-if="roomCode">{{ roomCode }}</code>
+          <div v-if="roomCode" class="peer-status-room">
+            <span>{{ t('peerRoomCode') }}</span>
+            <code>{{ roomCode }}</code>
+          </div>
         </header>
         <p v-if="stateDetail" :class="isFailureState ? 'error-banner' : 'peer-status-detail'">{{ displayDetail }}</p>
-        <div v-if="Object.keys(peerStates).length" class="peer-member-states">
+        <section v-if="mode === 'host' && inviteCodes.length" ref="invitePanel" class="peer-invite">
+          <header class="peer-invite-header">
+            <div class="peer-invite-heading">
+              <strong>{{ t('peerInvitesReadyTitle', { count: inviteCodes.length }) }}</strong>
+              <small>{{ t('peerInvitesReadyHint') }}</small>
+            </div>
+            <button v-if="inviteCodes.length > 1" class="peer-copy-all" @click="copyAllInvites">
+              <NIcon :component="CopyOutline" />{{ t('peerCopyAllInvites') }}
+            </button>
+          </header>
+          <div
+            v-for="(invite, index) in inviteCodes"
+            :key="invite.peerId"
+            class="peer-invite-item"
+          >
+            <span class="peer-invite-index" aria-hidden="true">{{ index + 1 }}</span>
+            <div class="peer-invite-code-wrap">
+              <div class="peer-invite-meta">
+                <strong>{{ invite.actorName || t('peerNewPlayerNumber', { number: index + 1 }) }}</strong>
+                <span
+                  class="peer-invite-peer-state"
+                  :class="`peer-state-${peerStates[invite.peerId] || 'waiting'}`"
+                >
+                  <i />{{ t(`peerState_${peerStates[invite.peerId] || 'waiting'}`) }}
+                </span>
+              </div>
+              <NInput
+                class="peer-invite-code"
+                :value="invite.inviteCode"
+                type="textarea"
+                readonly
+                :autosize="{ minRows: 2, maxRows: 2 }"
+                :aria-label="t('peerInviteForTarget', { name: invite.actorName || t('peerNewPlayerNumber', { number: index + 1 }) })"
+              />
+            </div>
+            <button
+              class="peer-invite-copy"
+              :aria-label="t('peerCopyInvite')"
+              @click="copyInvite(invite.inviteCode)"
+            >
+              <NIcon :component="CopyOutline" />{{ t('peerCopyInvite') }}
+            </button>
+          </div>
+          <small>{{ t('peerInviteSecurityHint') }}</small>
+        </section>
+        <div v-if="Object.keys(peerStates).length && !(mode === 'host' && inviteCodes.length)" class="peer-member-states">
           <strong>{{ t('peerConnectedPeers') }}</strong>
           <code v-for="(peerState, peerId) in peerStates" :key="peerId">{{ peerId }} · {{ t(`peerState_${peerState}`) }}</code>
         </div>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -856,7 +856,7 @@ export const en = {
   updateRolledBack: 'The new version failed its health check and was rolled back',
   updateApplyFailed: 'Failed to apply update',
   updateRestartNeeded: 'Files were replaced. Restart DiceFrame to finish the update.',
-  updateDockerHint: 'For Docker, run docker compose pull && docker compose up -d. NAS users can also check for and pull a new image from their device’s container manager.',
+  updateDockerHint: 'Compose deployment: first open the deployment directory containing docker-compose.yml, then run docker compose pull && docker compose up -d. If you originally used docker run, follow the deployment guide to pull the image and recreate the container. NAS users can update it in their container manager.',
   updateSelfUpdateUnsupported: 'Auto-update is not supported in this environment. Please download manually.',
   supportProject: 'Support the Project',
   supportProjectText: 'If DiceFrame helps you, support is welcome to keep the project maintained.',

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -1730,6 +1730,8 @@ export const en = {
   peerInviteTargetRequired: 'Choose an existing character or new-player seat for every link code.',
   peerNoInviteCapacity: 'This save has no other character to invite and no free character seat.',
   peerRoomCode: 'Room code',
+  peerInvitesReadyTitle: 'Player invite codes ({count})',
+  peerInvitesReadyHint: 'Each player uses the code matched to their character. Copy codes individually or copy them all at once.',
   peerInviteCode: 'One-time link code',
   peerInviteNumber: 'One-time link code for player {number}',
   peerInviteForTarget: 'One-time link code for {name}',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -856,7 +856,7 @@ export const ja = {
   updateRolledBack: '新しいバージョンがヘルスチェックに合格しなかったため、自動的にロールバックしました',
   updateApplyFailed: '更新の適用に失敗',
   updateRestartNeeded: 'ファイルを置き換えました。DiceFrame を手動で再起動すると有効になります。',
-  updateDockerHint: 'Docker 環境では docker compose pull && docker compose up -d で更新します。NAS ユーザーはデバイス付属のコンテナ管理画面から新しいイメージを確認・取得することもできます。',
+  updateDockerHint: 'Compose 配置では、まず docker-compose.yml がある配置ディレクトリに移動し、docker compose pull && docker compose up -d を実行します。docker run で起動した場合は、配置ガイドに従ってイメージを取得し、コンテナを再作成してください。NAS ではコンテナ管理画面から更新できます。',
   updateSelfUpdateUnsupported: '現在の環境は自動更新に対応していません。手動でダウンロードしてください。',
   supportProject: 'プロジェクトを支援',
   supportProjectText: 'DiceFrame が役に立ったら、プロジェクトの継続的なメンテナンスへの支援をお願いします。',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -1730,6 +1730,8 @@ export const ja = {
   peerInviteTargetRequired: '各リンクコードに既存キャラクターまたは新規プレイヤー枠を選択してください。',
   peerNoInviteCapacity: '再招待できる別のキャラクターも、新しいキャラクター枠もありません。',
   peerRoomCode: 'ルームコード',
+  peerInvitesReadyTitle: 'プレイヤー招待コード（{count}）',
+  peerInvitesReadyHint: '各プレイヤーは自分のキャラクターに対応するコードを使用します。個別またはまとめてコピーできます。',
   peerInviteCode: 'ワンタイム招待コード',
   peerInviteNumber: 'プレイヤー {number} のワンタイム招待コード',
   peerInviteForTarget: '{name} のワンタイム招待コード',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -856,7 +856,7 @@ export const zhCN = {
   updateRolledBack: '新版本未通过健康检查，已自动回滚',
   updateApplyFailed: '应用更新失败',
   updateRestartNeeded: '文件已替换，请手动重启 DiceFrame 后生效。',
-  updateDockerHint: 'Docker 环境请使用 docker compose pull && docker compose up -d 更新；NAS 用户也可以前往设备自带的容器管理界面检查并拉取新镜像。',
+  updateDockerHint: 'Compose 部署：先进入存放 docker-compose.yml 的部署目录，再运行 docker compose pull && docker compose up -d。若当初使用 docker run 启动，请按部署文档拉取镜像并重新创建容器；NAS 用户也可以在容器管理界面完成更新。',
   updateSelfUpdateUnsupported: '当前环境不支持自动更新，请手动下载。',
   supportProject: '支持项目',
   supportProjectText: '如果 DiceFrame 对你有帮助，欢迎支持项目继续维护。',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -1730,6 +1730,8 @@ export const zhCN = {
   peerInviteTargetRequired: '请为每个链接码选择已有角色或新玩家席位。',
   peerNoInviteCapacity: '该存档没有可重新邀请的其他角色，也没有新的角色席位。',
   peerRoomCode: '房间码',
+  peerInvitesReadyTitle: '玩家邀请码（{count}）',
+  peerInvitesReadyHint: '每名玩家使用与自己角色对应的一码；可以逐条复制，也可以一次复制全部。',
   peerInviteCode: '一次性链接码',
   peerInviteNumber: '玩家 {number} 的一次性链接码',
   peerInviteForTarget: '{name} 的一次性链接码',

--- a/frontend-v2/src/styles/v2/peer.css
+++ b/frontend-v2/src/styles/v2/peer.css
@@ -108,15 +108,26 @@
 .peer-direct-consent a { color: var(--df-accent-strong); }
 .peer-primary { width: 100%; justify-content: center; }
 
-/* 邀请码列表：单行紧凑横排（序号徽章 + 单行码 + 复制），
-   1~6 个码都不拉高页面；完整码靠复制按钮取，输入框横向滚动预览。 */
-.peer-invite { display: grid; gap: 8px; margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--df-border-soft); }
-.peer-invite-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
-.peer-invite-room { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; }
-.peer-invite-room code { color: var(--df-accent-strong); font-size: 16px; letter-spacing: .1em; }
+/* 开房后的邀请操作归入右侧房间控制台，与连接状态保持同一上下文。 */
+.peer-invite {
+  display: grid;
+  gap: 9px;
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--df-accent) 24%, var(--df-border-soft));
+  border-radius: var(--df-radius-md);
+  background: color-mix(in srgb, var(--df-accent-soft) 34%, var(--df-surface-2));
+}
+.peer-invite-header { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+.peer-invite-heading { display: grid; min-width: 0; gap: 4px; }
+.peer-invite-heading > strong { color: var(--df-text); }
+.peer-invite-heading > small { color: var(--df-text-muted); font-size: 12px; line-height: 1.5; }
 .peer-invite-item { display: grid; grid-template-columns: 26px minmax(0, 1fr) auto; align-items: center; gap: 8px; }
 .peer-invite-code-wrap { display: grid; min-width: 0; gap: 4px; }
-.peer-invite-code-wrap > strong { overflow: hidden; color: var(--df-text-secondary); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.peer-invite-meta { display: flex; align-items: center; justify-content: space-between; min-width: 0; gap: 8px; }
+.peer-invite-meta > strong { overflow: hidden; color: var(--df-text-secondary); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.peer-invite-peer-state { display: inline-flex; align-items: center; flex: 0 0 auto; gap: 5px; font-size: 11px; white-space: nowrap; }
+.peer-invite-peer-state i { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 .peer-invite-index {
   display: grid;
   width: 26px;
@@ -140,7 +151,9 @@
 .peer-invite > small { color: var(--df-text-muted); line-height: 1.5; }
 .peer-copy-all { min-height: 30px; padding: 0 10px; white-space: nowrap; font-size: 12px; }
 
-.peer-status > header code { color: var(--df-accent-strong); font-size: 18px; letter-spacing: .12em; }
+.peer-status-room { display: grid; justify-items: end; gap: 4px; }
+.peer-status-room > span { color: var(--df-text-muted); font-size: 11px; }
+.peer-status-room code { color: var(--df-accent-strong); font-size: 18px; letter-spacing: .12em; }
 
 .peer-status > header { display: flex; align-items: start; justify-content: space-between; gap: 16px; }
 .peer-status > header div { display: grid; gap: 8px; }
@@ -192,9 +205,13 @@
   .peer-layout { grid-template-columns: 1fr; grid-template-rows: auto; align-items: start; }
   .peer-card { padding: 16px; }
   .peer-status > header { align-items: start; flex-direction: column; }
+  .peer-status-room { justify-items: start; }
+  .peer-invite-header { align-items: stretch; flex-direction: column; }
+  .peer-copy-all { width: 100%; justify-content: center; }
   /* 窄屏下复制按钮收成图标+短文案，避免挤压码区 */
   .peer-invite-item { grid-template-columns: 22px minmax(0, 1fr) auto; gap: 6px; }
   .peer-invite-index { width: 22px; height: 22px; }
+  .peer-invite-meta { align-items: start; flex-direction: column; gap: 3px; }
   .peer-room-batch li { grid-template-columns: 22px minmax(0, 1fr); }
   .peer-room-batch li > small { grid-column: 2; }
 }

--- a/src/webui/routes/games.py
+++ b/src/webui/routes/games.py
@@ -202,7 +202,11 @@ async def api_set_solo_mode(request: web.Request) -> web.Response:
     inst = request.app["subsystems"].registry.get(api._parse_key(gk))
     if not inst:
         return web.json_response({"ok": False, "error": "not found"}, status=404)
-    if request.get("user_id", "") != inst.gm_uid:
+    if not is_game_gm(
+        inst,
+        request.get("user_id", ""),
+        bool(request.get("owner_authenticated", False)),
+    ):
         return web.json_response({"ok": False, "error": "GM only"}, status=403)
     body = await request.json()
     result = await api.set_solo_mode(gk, bool(body.get("solo")))

--- a/src/webui/services/system.py
+++ b/src/webui/services/system.py
@@ -224,6 +224,6 @@ async def _parse_release_payload(payload: str, include_prerelease: bool) -> dict
 def _install_hint(repo: str) -> dict[str, str]:
     return {
         "windows": "下载新版源码包或 Release 附件，保留 data/ 目录后替换程序文件，再重新运行 web_ui.bat。",
-        "docker": "如果使用镜像部署，拉取新版镜像后重新 docker compose up -d；如果是源码构建镜像，用新版源码重新 build。",
+        "docker": "Compose 部署请先进入存放 docker-compose.yml 的目录，再拉取镜像并重新 docker compose up -d；docker run 部署需重新创建容器，源码镜像需用新版源码重新 build。",
         "source": f"源码用户可从 https://github.com/{repo}/releases 下载新版，升级前先备份 data/。",
     }

--- a/src/webui/services/updater.py
+++ b/src/webui/services/updater.py
@@ -220,8 +220,9 @@ def is_self_update_supported(root: Path) -> dict[str, Any]:
             "mode": "docker",
             "reason": "docker",
             "hint": (
-                "Docker 环境请使用 docker compose pull && docker compose up -d 更新；"
-                "NAS 用户也可以前往设备自带的容器管理界面检查并拉取新镜像"
+                "Compose 部署请先进入存放 docker-compose.yml 的目录，再运行 "
+                "docker compose pull && docker compose up -d；使用 docker run 启动的容器"
+                "需要按部署文档拉取镜像并重新创建，NAS 也可在容器管理界面完成更新"
             ),
         }
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -107,6 +107,8 @@ def test_self_update_unsupported_in_docker(tmp_path, monkeypatch):
     result = updater.is_self_update_supported(tmp_path)
     assert result["supported"] is False
     assert result["reason"] == "docker"
+    assert "docker-compose.yml" in result["hint"]
+    assert "docker run" in result["hint"]
 
 
 def test_self_update_unsupported_when_readonly(tmp_path, monkeypatch):

--- a/tests/test_webui_route_permissions.py
+++ b/tests/test_webui_route_permissions.py
@@ -41,6 +41,10 @@ class FakeAPI:
         self.calls.append(("switch", game_key, world_id))
         return {"ok": True, "world_id": world_id}
 
+    async def set_solo_mode(self, game_key: str, solo: bool) -> dict:
+        self.calls.append(("mode", game_key, solo))
+        return {"ok": True, "solo_mode": solo}
+
     def delete_game(self, game_key: str) -> dict:
         key = self._parse_key(game_key)
         save_dir = self.registry._save_path(key).parent
@@ -204,6 +208,42 @@ async def test_owner_confirmed_delete_can_remove_orphaned_save(tmp_path):
     assert response_json(response)["ok"] is True
     assert not save_dir.exists()
     assert registry.removed == [key]
+
+
+@pytest.mark.asyncio
+async def test_owner_session_can_convert_solo_save_for_online_room(tmp_path):
+    registry = FakeRegistry(tmp_path)
+    registry.items[("web", "room", "bot")] = SimpleNamespace(gm_uid="original_gm_session")
+    req, api = make_request(
+        registry,
+        user_id="current_owner_session",
+        owner_authenticated=True,
+        body={"solo": False},
+    )
+
+    response = await games.api_set_solo_mode(req)
+
+    assert response.status == 200
+    assert response_json(response) == {"ok": True, "solo_mode": False}
+    assert api.calls == [("mode", "web|room|bot", False)]
+
+
+@pytest.mark.asyncio
+async def test_non_owner_session_cannot_convert_foreign_solo_save(tmp_path):
+    registry = FakeRegistry(tmp_path)
+    registry.items[("web", "room", "bot")] = SimpleNamespace(gm_uid="original_gm_session")
+    req, api = make_request(
+        registry,
+        user_id="player_session",
+        owner_authenticated=False,
+        body={"solo": False},
+    )
+
+    response = await games.api_set_solo_mode(req)
+
+    assert response.status == 403
+    assert response_json(response) == {"ok": False, "error": "GM only"}
+    assert api.calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- move all target-specific player invite codes into the room status panel
- show each invited seat's live peer connection state inline and keep guest status behavior unchanged
- restore the saved GM session before converting or hosting a save, with an owner fallback for migrated browser sessions
- clarify Docker Compose update prerequisites in Settings, backend hints, README, and update docs

## Validation

- `python -m pytest tests/test_webui_route_permissions.py tests/test_gm_identity.py tests/test_updater.py -q` (69 passed)
- `npm run typecheck`
- `npm run lint`
- `python ../scripts/run_e2e.py e2e/shell.spec.ts e2e/peer-connect.spec.ts` (12 passed, desktop and mobile; real two-client P2P)
- full backend and frontend suites passed before the final focused regression run
- outgoing diff, identity, ignored runtime paths, and sensitive-pattern scan passed