### PR TITLE
fix(web): 按最新回合清除流式思考气泡

### DIFF
--- a/frontend-v2/src/composables/useGame.ts
+++ b/frontend-v2/src/composables/useGame.ts
@@ -229,7 +229,9 @@ export function useGame(){
     await refresh(true)
     await connect()
   })
-  watch(() => log.value.length, (next, prev) => { if ((prev ?? 0) < next) liveNarration.value = '' })
+  // 新回合写入 log 时清掉流式气泡。第一页满员后长度不再增长（旧条目被挤到下一页），
+  // 须按最新条目的 round 判断，否则“GM 思考中”在正式输出落地后残留。
+  watch(() => log.value[log.value.length - 1]?.round, (next, prev) => { if (next !== prev) liveNarration.value = '' })
   onBeforeUnmount(()=>{connectVersion++;source?.close();unsubscribePeerEvents?.();revokeMapBackgroundAsset(map.value);clearRefreshTimer();if(pollTimer)clearInterval(pollTimer);if(reconnectTimer)clearTimeout(reconnectTimer)})
   return {currentGame,userId,actorId,detail,players,player,log,privateMessages,map,lore,loreEntries,loading,error,isGm,refresh,connect,selectGame,liveNarration}
 }


### PR DESCRIPTION
## 问题

GM 正常完成回合后，正式叙事已写入时间线，但“GM 思考中”流式气泡仍残留在正式输出下方。

## 根因

- `narration_reset` SSE 事件只在截断/骰子矛盾**重试**时广播，正常完成不发；
- 客户端只能靠 `watch(log.length)` 增长来清空 `liveNarration`；
- log 第一页固定 50 条，**满员后**新回合写入会把旧条目挤到下一页，数组长度不再增长 → 清除条件永远不成立。

游戏前期（<50 条）一切正常，饱和后才复现，表现为时好时坏。

## 修复

`useGame.ts` 中把 watch 目标从 `log.length` 改为最新条目的 `round` 变化。移动端（React Native 客户端）同构逻辑已同步修复。

## 验证

- `vue-tsc` 类型检查通过
- 既有 207 个测试全部通过