### PR TITLE
feat: allow manual model capability overrides

### DIFF
--- a/frontend-v2/src/api/types.ts
+++ b/frontend-v2/src/api/types.ts
@@ -1104,6 +1104,7 @@ export interface AiProvider {
   base_url: string
   api_format: 'openai' | 'anthropic' | string
   models?: string[]
+  model_capabilities?: Record<string, 'chat' | 'image' | 'embedding' | 'tts' | 'asr'>
   api_key?: SecretField
 }
 

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -331,6 +331,7 @@ interface ProviderDraft {
   base_url: string
   api_format: string
   models: string[]
+  model_capabilities: Record<string, ModelCapability>
   configuredMasked: string
 }
 const providerDrafts = ref<ProviderDraft[]>([])
@@ -377,7 +378,7 @@ const providerCatalogFilteredModels = computed(() => {
   return providerCatalogSourceModels.value.filter(model => {
     const matchesQuery = !query || model.toLowerCase().includes(query)
     const matchesCapability = providerCatalogFilter.value === 'all'
-      || modelCapability(model) === providerCatalogFilter.value
+      || draftModelCapability(activeCatalogProvider.value, model) === providerCatalogFilter.value
     return matchesQuery && matchesCapability
   })
 })
@@ -386,11 +387,11 @@ const providerCatalogFilters = computed(() => {
   const models = providerCatalogSourceModels.value
   const filters: { id: ModelCatalogFilter; label: string; count: number }[] = [
     { id: 'all', label: t('modelPickerAll'), count: models.length },
-    { id: 'chat', label: t('modelCapabilityChat'), count: models.filter(model => modelCapability(model) === 'chat').length },
-    { id: 'image', label: t('modelCapabilityImage'), count: models.filter(model => modelCapability(model) === 'image').length },
-    { id: 'embedding', label: t('modelCapabilityEmbedding'), count: models.filter(model => modelCapability(model) === 'embedding').length },
-    { id: 'tts', label: t('modelCapabilityTts'), count: models.filter(model => modelCapability(model) === 'tts').length },
-    { id: 'asr', label: t('modelCapabilityAsr'), count: models.filter(model => modelCapability(model) === 'asr').length },
+    { id: 'chat', label: t('modelCapabilityChat'), count: models.filter(model => draftModelCapability(activeCatalogProvider.value, model) === 'chat').length },
+    { id: 'image', label: t('modelCapabilityImage'), count: models.filter(model => draftModelCapability(activeCatalogProvider.value, model) === 'image').length },
+    { id: 'embedding', label: t('modelCapabilityEmbedding'), count: models.filter(model => draftModelCapability(activeCatalogProvider.value, model) === 'embedding').length },
+    { id: 'tts', label: t('modelCapabilityTts'), count: models.filter(model => draftModelCapability(activeCatalogProvider.value, model) === 'tts').length },
+    { id: 'asr', label: t('modelCapabilityAsr'), count: models.filter(model => draftModelCapability(activeCatalogProvider.value, model) === 'asr').length },
   ]
   return filters
 })
@@ -402,6 +403,7 @@ function syncProviderDrafts(list: AppConfig['ai_providers']) {
     base_url: p.base_url,
     api_format: String(p.api_format || 'openai'),
     models: [...new Set((p.models || []).map(model => String(model).trim()).filter(Boolean))],
+    model_capabilities: { ...(p.model_capabilities || {}) },
     configuredMasked: p.api_key?.configured ? p.api_key.masked : '',
   }))
   if (!providerDrafts.value.some(provider => provider.id === activeProviderId.value)) {
@@ -417,7 +419,7 @@ function addProviderDraft() {
   }
   const provider = {
     id: `p${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
-    name: '', base_url: '', api_format: 'openai', models: [], configuredMasked: '',
+    name: '', base_url: '', api_format: 'openai', models: [], model_capabilities: {}, configuredMasked: '',
   }
   providerDrafts.value.push(provider)
   activeProviderId.value = provider.id
@@ -442,6 +444,7 @@ async function saveProvidersList() {
     await store.saveProviders(
       providerDrafts.value.map(d => ({
         id: d.id, name: d.name, base_url: d.base_url, api_format: d.api_format, models: d.models,
+        model_capabilities: d.model_capabilities,
       })),
     )
     toast.success(t('settingsSaved'))
@@ -456,7 +459,11 @@ async function testProviderDraft(draft: ProviderDraft, testModel: string) {
   providerTestingId.value = draft.id
   providerTestResult.value = null
   const model = testModel.trim() || String(store.config.model || 'gpt-4o-mini')
-  const kind = providerTestKind(model, providerTestModes.value[draft.id] || 'auto')
+  const kind = providerTestKind(
+    model,
+    providerTestModes.value[draft.id] || 'auto',
+    draft.model_capabilities[model],
+  )
   if (!kind) {
     providerTestedId.value = draft.id
     providerTestedKind.value = 'model'
@@ -551,6 +558,16 @@ function isCatalogModelSelected(model: string): boolean {
 
 function removeProviderModel(draft: ProviderDraft, model: string) {
   draft.models = draft.models.filter(item => item !== model)
+  delete draft.model_capabilities[model]
+}
+
+function draftModelCapability(draft: ProviderDraft | null, model: string): ModelCapability {
+  return modelCapability(model, draft?.model_capabilities[model])
+}
+
+function setDraftModelCapability(draft: ProviderDraft, model: string, capability: string) {
+  if (!['chat', 'image', 'embedding', 'tts', 'asr'].includes(capability)) return
+  draft.model_capabilities[model] = capability as ModelCapability
 }
 
 function providerHasKey(draft: ProviderDraft): boolean {
@@ -585,8 +602,8 @@ function providerStyle(providerId: string) {
   return { '--provider-hue': String(Math.abs(hash) % 360) }
 }
 
-function modelCapabilityLabels(model: string): string[] {
-  const capability = modelCapability(model)
+function modelCapabilityLabels(model: string, override?: string): string[] {
+  const capability = modelCapability(model, override)
   if (capability === 'image') return [t('modelCapabilityImage')]
   if (capability === 'embedding') return [t('modelCapabilityEmbedding')]
   if (capability === 'tts') return [t('modelCapabilityTts')]
@@ -617,8 +634,11 @@ function providerById(id: string) {
 }
 
 function savedProviderModels(providerId: string, capability?: ModelCapability): string[] {
-  const models = providerById(providerId)?.models || []
-  return capability ? models.filter(model => modelCapability(model) === capability) : models
+  const provider = providerById(providerId)
+  const models = provider?.models || []
+  return capability
+    ? models.filter(model => modelCapability(model, provider?.model_capabilities?.[model]) === capability)
+    : models
 }
 
 function modelBindingSummary(providerId: unknown, model: unknown): string {
@@ -1365,8 +1385,21 @@ function redownloadUpdatePackage() {
                           <span class="provider-model-orbit"><i /><i /></span>
                           <div class="provider-model-copy">
                             <strong>{{ modelName }}</strong>
-                            <small>{{ modelCapabilityLabels(modelName).join(' · ') }}</small>
+                            <small>{{ modelCapabilityLabels(modelName, activeProvider.model_capabilities[modelName]).join(' · ') }}</small>
                           </div>
+                          <label class="provider-model-capability">
+                            <span>{{ t('modelCapabilityManual') }}</span>
+                            <select
+                              :value="draftModelCapability(activeProvider, modelName)"
+                              @change="setDraftModelCapability(activeProvider, modelName, eventValue($event))"
+                            >
+                              <option value="chat">{{ t('modelCapabilityChat') }}</option>
+                              <option value="image">{{ t('modelCapabilityImage') }}</option>
+                              <option value="embedding">{{ t('modelCapabilityEmbedding') }}</option>
+                              <option value="tts">{{ t('modelCapabilityTts') }}</option>
+                              <option value="asr">{{ t('modelCapabilityAsr') }}</option>
+                            </select>
+                          </label>
                           <button
                             type="button"
                             class="provider-model-remove"
@@ -1478,7 +1511,7 @@ function redownloadUpdatePackage() {
                   <span class="provider-model-orbit"><i /><i /></span>
                   <span class="provider-catalog-copy">
                     <strong>{{ modelName }}</strong>
-                    <small>{{ modelCapabilityLabels(modelName).join(' · ') }}</small>
+                    <small>{{ modelCapabilityLabels(modelName, activeCatalogProvider?.model_capabilities[modelName]).join(' · ') }}</small>
                   </span>
                   <span class="provider-catalog-toggle">{{ isCatalogModelSelected(modelName) ? '−' : '+' }}</span>
                 </button>

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -441,13 +441,14 @@ async function saveProvidersList() {
   }
   providerSaving.value = true
   try {
-    await store.saveProviders(
+    const warnings = await store.saveProviders(
       providerDrafts.value.map(d => ({
         id: d.id, name: d.name, base_url: d.base_url, api_format: d.api_format, models: d.models,
         model_capabilities: d.model_capabilities,
       })),
     )
     toast.success(t('settingsSaved'))
+    warnings.forEach(warning => toast.warning(warning))
   } catch (e: unknown) {
     toast.error(errorMessage(e))
   } finally {
@@ -565,7 +566,15 @@ function draftModelCapability(draft: ProviderDraft | null, model: string): Model
   return modelCapability(model, draft?.model_capabilities[model])
 }
 
+function draftModelCapabilitySelection(draft: ProviderDraft | null, model: string): ModelCapability | 'auto' {
+  return draft?.model_capabilities[model] || 'auto'
+}
+
 function setDraftModelCapability(draft: ProviderDraft, model: string, capability: string) {
+  if (capability === 'auto') {
+    delete draft.model_capabilities[model]
+    return
+  }
   if (!['chat', 'image', 'embedding', 'tts', 'asr'].includes(capability)) return
   draft.model_capabilities[model] = capability as ModelCapability
 }
@@ -604,12 +613,13 @@ function providerStyle(providerId: string) {
 
 function modelCapabilityLabels(model: string, override?: string): string[] {
   const capability = modelCapability(model, override)
-  if (capability === 'image') return [t('modelCapabilityImage')]
-  if (capability === 'embedding') return [t('modelCapabilityEmbedding')]
-  if (capability === 'tts') return [t('modelCapabilityTts')]
-  if (capability === 'asr') return [t('modelCapabilityAsr')]
+  const labels = [override ? t('modelCapabilityManualOverride') : t('modelCapabilityAuto')]
+  if (capability === 'image') return [...labels, t('modelCapabilityImage')]
+  if (capability === 'embedding') return [...labels, t('modelCapabilityEmbedding')]
+  if (capability === 'tts') return [...labels, t('modelCapabilityTts')]
+  if (capability === 'asr') return [...labels, t('modelCapabilityAsr')]
 
-  const labels = [t('modelCapabilityChat')]
+  labels.push(t('modelCapabilityChat'))
   const value = model.toLowerCase()
   if (/(reason|thinking|deepseek-r|(^|[-_.])r1|(^|[-_.])o[134])/.test(value)) {
     labels.push(t('modelCapabilityReasoning'))
@@ -678,9 +688,10 @@ async function saveModelRouting() {
   }
   modelRoutingSaving.value = true
   try {
-    await store.saveSection(MODEL_ROUTING_CONFIG_KEYS)
+    const warnings = await store.saveSection(MODEL_ROUTING_CONFIG_KEYS)
     await Promise.all([initializeTts(true), initializeAsr(true), loadTtsVoices()])
     toast.success(t('modelRoutingSaved'))
+    warnings.forEach(warning => toast.warning(warning))
   } catch (error: unknown) {
     toast.error(errorMessage(error))
   } finally {
@@ -1390,9 +1401,10 @@ function redownloadUpdatePackage() {
                           <label class="provider-model-capability">
                             <span>{{ t('modelCapabilityManual') }}</span>
                             <select
-                              :value="draftModelCapability(activeProvider, modelName)"
+                              :value="draftModelCapabilitySelection(activeProvider, modelName)"
                               @change="setDraftModelCapability(activeProvider, modelName, eventValue($event))"
                             >
+                              <option value="auto">{{ t('modelCapabilityAuto') }}</option>
                               <option value="chat">{{ t('modelCapabilityChat') }}</option>
                               <option value="image">{{ t('modelCapabilityImage') }}</option>
                               <option value="embedding">{{ t('modelCapabilityEmbedding') }}</option>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -578,6 +578,8 @@ export const en = {
   pluginProviderModelsEmpty: 'This provider has no saved models; update its model catalog in Model Settings',
   modelCapabilityChat: 'Chat',
   modelCapabilityManual: 'Manual type',
+  modelCapabilityAuto: 'Auto-detected',
+  modelCapabilityManualOverride: 'Manual',
   modelCapabilityReasoning: 'Reasoning',
   modelCapabilityImage: 'Image',
   modelCapabilityEmbedding: 'Embedding',

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -577,6 +577,7 @@ export const en = {
   pluginAiProviderSelectFirst: 'Select an AI provider first',
   pluginProviderModelsEmpty: 'This provider has no saved models; update its model catalog in Model Settings',
   modelCapabilityChat: 'Chat',
+  modelCapabilityManual: 'Manual type',
   modelCapabilityReasoning: 'Reasoning',
   modelCapabilityImage: 'Image',
   modelCapabilityEmbedding: 'Embedding',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -577,6 +577,7 @@ export const ja = {
   pluginAiProviderSelectFirst: '先に AI プロバイダーを選択してください',
   pluginProviderModelsEmpty: '保存済みモデルがありません。モデル設定でモデル一覧を更新してください',
   modelCapabilityChat: 'チャット',
+  modelCapabilityManual: '手動タイプ',
   modelCapabilityReasoning: '推論',
   modelCapabilityImage: '画像',
   modelCapabilityEmbedding: 'ベクトル',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -578,6 +578,8 @@ export const ja = {
   pluginProviderModelsEmpty: '保存済みモデルがありません。モデル設定でモデル一覧を更新してください',
   modelCapabilityChat: 'チャット',
   modelCapabilityManual: '手動タイプ',
+  modelCapabilityAuto: '自動判定',
+  modelCapabilityManualOverride: '手動',
   modelCapabilityReasoning: '推論',
   modelCapabilityImage: '画像',
   modelCapabilityEmbedding: 'ベクトル',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -577,6 +577,7 @@ export const zhCN = {
   pluginAiProviderSelectFirst: '请先选择 AI 服务商',
   pluginProviderModelsEmpty: '该服务商没有已保存模型，请先在“模型接口”维护模型目录',
   modelCapabilityChat: '对话',
+  modelCapabilityManual: '手动类型',
   modelCapabilityReasoning: '推理',
   modelCapabilityImage: '图片',
   modelCapabilityEmbedding: '向量',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -578,6 +578,8 @@ export const zhCN = {
   pluginProviderModelsEmpty: '该服务商没有已保存模型，请先在“模型接口”维护模型目录',
   modelCapabilityChat: '对话',
   modelCapabilityManual: '手动类型',
+  modelCapabilityAuto: '自动识别',
+  modelCapabilityManualOverride: '手动',
   modelCapabilityReasoning: '推理',
   modelCapabilityImage: '图片',
   modelCapabilityEmbedding: '向量',

--- a/frontend-v2/src/stores/useSettingsStore.ts
+++ b/frontend-v2/src/stores/useSettingsStore.ts
@@ -15,6 +15,7 @@ export interface AiProviderInput {
   base_url: string
   api_format: string
   models?: string[]
+  model_capabilities?: Record<string, 'chat' | 'image' | 'embedding' | 'tts' | 'asr'>
 }
 
 export interface ProviderModelsResponse {
@@ -78,6 +79,7 @@ export const useSettingsStore = defineStore('settings', () => {
       ai_providers: providers.map((p) => ({
         id: p.id, name: p.name, base_url: p.base_url, api_format: p.api_format,
         models: p.models || [],
+        ...(Object.keys(p.model_capabilities || {}).length ? { model_capabilities: p.model_capabilities } : {}),
       })),
     }
     for (const p of providers) {
@@ -92,7 +94,10 @@ export const useSettingsStore = defineStore('settings', () => {
       if (!saved) return false
       const expectedModels = provider.models || []
       const actualModels = saved.models || []
+      const expectedCapabilities = provider.model_capabilities || {}
+      const actualCapabilities = saved.model_capabilities || {}
       return expectedModels.every(model => actualModels.includes(model))
+        && Object.entries(expectedCapabilities).every(([model, capability]) => actualCapabilities[model] === capability)
     })
     if (!persisted) {
       throw new ApiError(

--- a/frontend-v2/src/stores/useSettingsStore.ts
+++ b/frontend-v2/src/stores/useSettingsStore.ts
@@ -69,9 +69,10 @@ export const useSettingsStore = defineStore('settings', () => {
     const payload: Record<string, unknown> = {}
     for (const k of keys) if (k in config.value) payload[k] = getConfigField(k as keyof AppConfig)
     Object.assign(payload, collectSecrets(secretKeys))
-    await api('/config', { method: 'POST', body: JSON.stringify(payload) })
+    const result = await api<{ warnings?: string[] }>('/config', { method: 'POST', body: JSON.stringify(payload) })
     for (const k of secretKeys) secrets.value[k] = ''
     await load()
+    return result.warnings || []
   }
 
   async function saveProviders(providers: AiProviderInput[]) {
@@ -86,7 +87,7 @@ export const useSettingsStore = defineStore('settings', () => {
       const v = secrets.value[providerSecretKey(p.id)]?.trim()
       if (v) payload[providerSecretKey(p.id)] = v
     }
-    await api('/config', { method: 'POST', body: JSON.stringify(payload) })
+    const result = await api<{ warnings?: string[] }>('/config', { method: 'POST', body: JSON.stringify(payload) })
     const refreshed = await api<AppConfig>('/config')
     const savedProviders = Array.isArray(refreshed.ai_providers) ? refreshed.ai_providers : null
     const persisted = savedProviders && providers.every(provider => {
@@ -108,6 +109,7 @@ export const useSettingsStore = defineStore('settings', () => {
     }
     config.value = refreshed
     for (const p of providers) secrets.value[providerSecretKey(p.id)] = ''
+    return result.warnings || []
   }
 
   async function saveAccessPassword(password: string) {

--- a/frontend-v2/src/styles/v2/settings-ai-management.css
+++ b/frontend-v2/src/styles/v2/settings-ai-management.css
@@ -330,7 +330,7 @@
 .provider-model-row {
   position: relative;
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 32px;
+  grid-template-columns: 34px minmax(0, 1fr) minmax(112px, 150px) 32px;
   align-items: center;
   gap: 9px;
   min-height: 53px;
@@ -389,6 +389,28 @@
 .provider-model-copy small {
   color: var(--df-text-muted);
   font-size: 9px;
+}
+
+.provider-model-capability {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.provider-model-capability > span {
+  color: var(--df-text-muted);
+  font-size: 9px;
+}
+
+.provider-model-capability select {
+  width: 100%;
+  min-height: 29px;
+  padding: 3px 24px 3px 8px;
+  border: 1px solid var(--df-border-soft);
+  border-radius: 7px;
+  color: var(--df-text-primary);
+  background: var(--df-control-bg);
+  font-size: 11px;
 }
 
 .provider-model-remove {
@@ -1197,6 +1219,15 @@
 
   .provider-model-row {
     grid-template-columns: 30px minmax(0, 1fr) 30px;
+  }
+
+  .provider-model-capability {
+    grid-column: 2 / 3;
+  }
+
+  .provider-model-remove {
+    grid-column: 3;
+    grid-row: 1;
   }
 
   .model-routing-header,

--- a/frontend-v2/src/utils/providerModels.ts
+++ b/frontend-v2/src/utils/providerModels.ts
@@ -2,7 +2,10 @@ export type ModelCapability = 'chat' | 'image' | 'embedding' | 'tts' | 'asr'
 export type ProviderTestMode = 'auto' | 'model' | 'embedding'
 export type ProviderTestKind = Exclude<ProviderTestMode, 'auto'>
 
-export function modelCapability(model: string): ModelCapability {
+export function modelCapability(model: string, override?: string): ModelCapability {
+  if (override && ['chat', 'image', 'embedding', 'tts', 'asr'].includes(override)) {
+    return override as ModelCapability
+  }
   const value = model.toLowerCase()
   if (/(image|dall-e|flux|stable[-_. ]?diffusion|(^|[-_.])sd3|kolors|qwen[-_. ]?image|ideogram|imagen)/.test(value)) {
     return 'image'
@@ -13,11 +16,15 @@ export function modelCapability(model: string): ModelCapability {
   return 'chat'
 }
 
-export function providerTestKind(model: string, mode: ProviderTestMode = 'auto'): ProviderTestKind | null {
+export function providerTestKind(
+  model: string,
+  mode: ProviderTestMode = 'auto',
+  capabilityOverride?: string,
+): ProviderTestKind | null {
   if (mode !== 'auto') return mode
   const value = model.trim().toLowerCase()
   if (!value || /rerank/.test(value)) return null
-  const capability = modelCapability(value)
+  const capability = modelCapability(value, capabilityOverride)
   if (capability === 'embedding') return 'embedding'
   if (capability === 'chat') return 'model'
   return null

--- a/frontend-v2/tests/AiProviders.test.ts
+++ b/frontend-v2/tests/AiProviders.test.ts
@@ -163,6 +163,24 @@ describe('AI provider library settings store', () => {
     expect(payload.ai_providers[0].model_capabilities).toEqual({ 'custom-painter': 'image' })
   })
 
+  it('omits capability overrides when a model is restored to automatic detection', async () => {
+    const store = useSettingsStore()
+    mockedApi.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({
+      ai_providers: [{
+        id: 'custom', name: 'Custom', base_url: 'https://example.test/v1', api_format: 'openai',
+        models: ['custom-painter'],
+      }],
+    })
+
+    await store.saveProviders([{
+      id: 'custom', name: 'Custom', base_url: 'https://example.test/v1', api_format: 'openai',
+      models: ['custom-painter'], model_capabilities: {},
+    }])
+
+    const payload = JSON.parse(mockedApi.mock.calls[0][1]!.body as string)
+    expect(payload.ai_providers[0].model_capabilities).toBeUndefined()
+  })
+
   it('requests a model catalog with saved provider credentials by id', async () => {
     const store = useSettingsStore()
     mockedApi.mockResolvedValue({ ok: true, models: ['model-b', 'model-a'], count: 2 })

--- a/frontend-v2/tests/AiProviders.test.ts
+++ b/frontend-v2/tests/AiProviders.test.ts
@@ -10,7 +10,7 @@ vi.mock('../src/api/client', () => {
 
 import { ApiError, api } from '../src/api/client'
 import { providerSecretKey, useSettingsStore } from '../src/stores/useSettingsStore'
-import { providerTestKind } from '../src/utils/providerModels'
+import { modelCapability, providerTestKind } from '../src/utils/providerModels'
 
 const mockedApi = vi.mocked(api)
 
@@ -139,6 +139,28 @@ describe('AI provider library settings store', () => {
     expect(providerTestKind('BAAI/bge-reranker-v2-m3')).toBeNull()
     expect(providerTestKind('Qwen/Qwen-Image')).toBeNull()
     expect(providerTestKind('custom-vector-model', 'embedding')).toBe('embedding')
+  })
+
+  it('uses and persists a manual capability when automatic detection is wrong', async () => {
+    expect(modelCapability('custom-painter')).toBe('chat')
+    expect(modelCapability('custom-painter', 'image')).toBe('image')
+    expect(providerTestKind('custom-painter', 'auto', 'image')).toBeNull()
+
+    const store = useSettingsStore()
+    mockedApi.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({
+      ai_providers: [{
+        id: 'custom', name: 'Custom', base_url: 'https://example.test/v1', api_format: 'openai',
+        models: ['custom-painter'], model_capabilities: { 'custom-painter': 'image' },
+      }],
+    })
+
+    await store.saveProviders([{
+      id: 'custom', name: 'Custom', base_url: 'https://example.test/v1', api_format: 'openai',
+      models: ['custom-painter'], model_capabilities: { 'custom-painter': 'image' },
+    }])
+
+    const payload = JSON.parse(mockedApi.mock.calls[0][1]!.body as string)
+    expect(payload.ai_providers[0].model_capabilities).toEqual({ 'custom-painter': 'image' })
   })
 
   it('requests a model catalog with saved provider credentials by id', async () => {

--- a/src/ai_providers.py
+++ b/src/ai_providers.py
@@ -21,6 +21,18 @@ PROVIDER_REF_KEYS = frozenset({
     "embedding_provider_ref", "tts_provider_ref", "asr_provider_ref", "imagegen_provider_ref",
 })
 
+# 路由键 -> 该路由要求的模型能力。只对明确的手动覆盖做协调，
+# 启发式识别可能误判，不能因为它改变就悄悄清空用户已有配置。
+MODEL_CAPABILITY_ROUTES = (
+    ("llm_provider_ref", "model", "chat", "主模型"),
+    ("fallback1_provider_ref", "fallback1_model", "chat", "备用模型 1"),
+    ("fallback2_provider_ref", "fallback2_model", "chat", "备用模型 2"),
+    ("embedding_provider_ref", "embedding_model", "embedding", "向量模型"),
+    ("tts_provider_ref", "tts_model", "tts", "语音合成模型"),
+    ("asr_provider_ref", "asr_model", "asr", "语音识别模型"),
+    ("imagegen_provider_ref", "imagegen_model", "image", "图像生成模型"),
+)
+
 
 def is_valid_provider_id(provider_id: str) -> bool:
     return bool(_PROVIDER_ID_PATTERN.match(provider_id or ""))
@@ -123,3 +135,35 @@ def strip_dangling_provider_refs(candidate: dict[str, Any]) -> None:
         ref = str(candidate.get(key) or "").strip()
         if ref and ref not in known:
             candidate[key] = ""
+
+
+def reconcile_model_capability_routes(candidate: dict[str, Any]) -> list[str]:
+    """清理显式能力覆盖与路由用途不一致的旧绑定。
+
+    仅检查 provider 目录中存在的模型和显式 ``model_capabilities``，因此普通
+    的自动识别结果不会改变既有配置。返回被解除的路由名称供 API 提示用户。
+    """
+    providers = {
+        str(entry.get("id") or ""): entry
+        for entry in candidate.get("ai_providers") or []
+        if isinstance(entry, dict) and str(entry.get("id") or "")
+    }
+    cleared: list[str] = []
+    for ref_key, model_key, required, label in MODEL_CAPABILITY_ROUTES:
+        ref = str(candidate.get(ref_key) or "").strip()
+        model = str(candidate.get(model_key) or "").strip()
+        provider = providers.get(ref)
+        if not ref or not model or not provider:
+            continue
+        models = provider.get("models")
+        if not isinstance(models, list) or model not in models:
+            continue
+        capabilities = provider.get("model_capabilities")
+        override = capabilities.get(model) if isinstance(capabilities, dict) else None
+        if not override or override == required:
+            continue
+        # A matching override is valid. Any other explicit override is stale.
+        candidate[ref_key] = ""
+        candidate[model_key] = ""
+        cleared.append(label)
+    return cleared

--- a/src/ai_providers.py
+++ b/src/ai_providers.py
@@ -13,6 +13,7 @@ from typing import Any
 
 PROVIDER_SECRET_KEY_PREFIX = "ai_provider_key_"
 _PROVIDER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_MODEL_CAPABILITIES = frozenset({"chat", "image", "embedding", "tts", "asr"})
 
 # 引用键 → 能力侧的运行时重建分组（与 config_update 的两个 frozenset 对应）
 PROVIDER_REF_KEYS = frozenset({
@@ -72,6 +73,17 @@ def normalize_ai_providers(raw: Any) -> list[dict[str, Any]]:
         models = _normalize_models(item.get("models"))
         if models:
             entry["models"] = models
+        raw_capabilities = item.get("model_capabilities")
+        if isinstance(raw_capabilities, dict) and models:
+            model_names = set(models)
+            capabilities = {
+                str(model): str(capability).strip().lower()
+                for model, capability in raw_capabilities.items()
+                if str(model) in model_names
+                and str(capability).strip().lower() in _MODEL_CAPABILITIES
+            }
+            if capabilities:
+                entry["model_capabilities"] = capabilities
         entries.append(entry)
     return entries
 

--- a/src/webui/config_update.py
+++ b/src/webui/config_update.py
@@ -14,6 +14,7 @@ from src.ai_providers import (
     PROVIDER_REF_KEYS,
     is_provider_secret_key,
     normalize_ai_providers,
+    reconcile_model_capability_routes,
     strip_dangling_provider_refs,
     strip_orphan_provider_secrets,
 )
@@ -144,6 +145,7 @@ class PreparedConfigUpdate:
     changed_keys: frozenset[str]
     access_password_changed: bool
     error: str = ""
+    warnings: tuple[str, ...] = ()
 
 
 def clean_text_value(value: Any) -> str:
@@ -286,6 +288,7 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
     strip_orphan_provider_secrets(candidate)
     strip_dangling_provider_refs(candidate)
     _degrade_speech_engines_lost_provider(candidate, refs_before)
+    cleared_model_routes = reconcile_model_capability_routes(candidate)
 
     imagegen_ref = str(candidate.get("imagegen_provider_ref") or "").strip()
     if imagegen_ref:
@@ -308,7 +311,15 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
         return PreparedConfigUpdate(candidate, changed_keys, access_password_changed, "代理地址仅支持 http:// 或 https://")
     if float(candidate.get("napcat_reply_delay_max_sec", 0)) < float(candidate.get("napcat_reply_delay_min_sec", 0)):
         return PreparedConfigUpdate(candidate, changed_keys, access_password_changed, "NapCat 回复延迟上限不能小于下限")
-    return PreparedConfigUpdate(candidate, changed_keys, access_password_changed)
+    return PreparedConfigUpdate(
+        candidate,
+        changed_keys,
+        access_password_changed,
+        warnings=tuple(
+            f"{label}已解除：所选模型的手动能力不是该用途所需类型"
+            for label in cleared_model_routes
+        ),
+    )
 
 
 def bot_plugin_changes(body: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_ai_providers.py
+++ b/tests/test_ai_providers.py
@@ -68,6 +68,24 @@ def test_normalize_ai_providers_keeps_unique_model_catalog():
     assert out[0]["models"] == ["model-b", "model-a"]
 
 
+def test_normalize_ai_providers_keeps_valid_manual_model_capabilities():
+    out = normalize_ai_providers([{
+        "id": "a",
+        "models": ["chat-looking-image", "real-chat"],
+        "model_capabilities": {
+            "chat-looking-image": "image",
+            "real-chat": "CHAT",
+            "missing-model": "tts",
+            "bad": "unknown",
+        },
+    }])
+
+    assert out[0]["model_capabilities"] == {
+        "chat-looking-image": "image",
+        "real-chat": "chat",
+    }
+
+
 def test_provider_secret_key_roundtrip():
     assert provider_secret_key("sf") == "ai_provider_key_sf"
     assert is_provider_secret_key("ai_provider_key_sf")

--- a/tests/test_ai_providers.py
+++ b/tests/test_ai_providers.py
@@ -9,6 +9,7 @@ from src.ai_providers import (
     is_provider_secret_key,
     normalize_ai_providers,
     provider_secret_key,
+    reconcile_model_capability_routes,
     resolve_provider,
     strip_dangling_provider_refs,
     strip_orphan_provider_secrets,
@@ -26,8 +27,19 @@ class _ConfigRequest:
         return self._body
 
 
-def _provider(provider_id="sf", base_url="https://api.siliconflow.cn/v1", api_format="openai"):
-    return {"id": provider_id, "name": provider_id, "base_url": base_url, "api_format": api_format}
+def _provider(
+    provider_id="sf",
+    base_url="https://api.siliconflow.cn/v1",
+    api_format="openai",
+    models=None,
+    model_capabilities=None,
+):
+    entry = {"id": provider_id, "name": provider_id, "base_url": base_url, "api_format": api_format}
+    if models is not None:
+        entry["models"] = models
+    if model_capabilities is not None:
+        entry["model_capabilities"] = model_capabilities
+    return entry
 
 
 def _state(**overrides):
@@ -121,6 +133,30 @@ def test_strip_orphan_secrets_and_dangling_refs():
     assert config["tts_provider_ref"] == "a"
 
 
+def test_reconcile_model_capability_routes_clears_only_incompatible_manual_bindings():
+    config = _state(
+        ai_providers=[_provider(
+            models=["comfy-image", "heuristic-image"],
+            model_capabilities={"comfy-image": "image"},
+        )],
+        llm_provider_ref="sf", model="comfy-image",
+        imagegen_provider_ref="sf", imagegen_model="comfy-image",
+        imagegen_enabled=True,
+        embedding_provider_ref="sf", embedding_model="heuristic-image",
+    )
+
+    cleared = reconcile_model_capability_routes(config)
+
+    assert cleared == ["主模型"]
+    assert config["llm_provider_ref"] == ""
+    assert config["model"] == ""
+    assert config["imagegen_provider_ref"] == "sf"
+    assert config["imagegen_model"] == "comfy-image"
+    # 没有显式覆盖的模型不因启发式结果而被清理。
+    assert config["embedding_provider_ref"] == "sf"
+    assert config["embedding_model"] == "heuristic-image"
+
+
 # ---------- 配置更新 ----------
 
 def test_config_update_accepts_provider_library_and_refs():
@@ -162,6 +198,22 @@ def test_config_update_deleting_provider_cleans_orphan_secret_and_ref():
     assert prepared.state[provider_secret_key("a")] == "k1"
     assert provider_secret_key("b") not in prepared.state
     assert prepared.state["llm_provider_ref"] == ""
+
+
+def test_config_update_reconciles_routes_after_manual_capability_change():
+    current = _state(
+        ai_providers=[_provider(models=["comfy-model"], model_capabilities={"comfy-model": "chat"})],
+        llm_provider_ref="sf", model="comfy-model",
+    )
+
+    prepared = prepare_config_update(current, {
+        "ai_providers": [_provider(models=["comfy-model"], model_capabilities={"comfy-model": "image"})],
+    })
+
+    assert prepared.error == ""
+    assert prepared.state["llm_provider_ref"] == ""
+    assert prepared.state["model"] == ""
+    assert prepared.warnings == ("主模型已解除：所选模型的手动能力不是该用途所需类型",)
 
 
 def test_config_update_degrades_speech_engines_when_provider_deleted():

--- a/web_server.py
+++ b/web_server.py
@@ -1076,6 +1076,8 @@ async def _apply_config_update(request: web.Request, body: dict) -> web.Response
         except Exception:
             logger.warning("配置更新后 embedding 补齐失败", exc_info=True)
     payload = {"ok": True, "access_password_changed": access_password_changed}
+    if prepared.warnings:
+        payload["warnings"] = list(prepared.warnings)
     if plugin_warning:
         payload["warning"] = plugin_warning
     return web.json_response(payload)


### PR DESCRIPTION
## Summary

- add persistent per-model capability overrides to AI provider configuration
- let administrators manually classify models as chat, image, embedding, TTS, or ASR
- apply overrides consistently to catalog filters, routing selectors, labels, and automatic provider tests
- validate and discard invalid or orphaned overrides on the backend
- reconcile stale model routing when a manual capability override changes, with a user-visible warning
- restore automatic detection as an explicit model capability choice

## Motivation

Model capability detection currently relies on model-name heuristics. Some image or specialized models use ambiguous names and can be misclassified as chat models, with no way for administrators to correct the result.

## Verification

- `pytest -q tests/test_ai_providers.py tests/test_config_runtime_reload.py tests/test_web_server_bot_auth.py` (53 passed)
- `npm run test -- --run tests/AiProviders.test.ts` (9 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Fixes #141