### PR TITLE
fix: recognize provider model configuration during game creation

### DIFF
--- a/frontend-v2/src/features/create/CreateView.vue
+++ b/frontend-v2/src/features/create/CreateView.vue
@@ -19,6 +19,7 @@ import { characterCardNeedsConversion } from '@/utils/characterCards'
 import { ruleSceneUrl } from '@/composables/useBackgroundImages'
 import { resolveSceneImageUrl, revokeSceneImageUrl, sceneImageStyle, uploadSceneImage } from '@/api/sceneImages'
 import { mapBackgroundSelection, uploadMapBackground } from '@/api/mapBackgrounds'
+import { isLlmConfigReady } from '@/utils/modelConfiguration'
 
 interface CreateCharacter extends CharacterSheet { character_name: string }
 type CreateMode = 'template' | 'custom' | 'ai'
@@ -93,11 +94,7 @@ const confirmationWorld = computed(() => {
   if (mode.value === 'custom') return customName.value.trim() || t('modeCustom')
   return t('modeAi')
 })
-const apiReady = computed(() => Boolean(
-  String(settings.config.base_url || '').trim()
-  && String(settings.config.model || '').trim()
-  && settings.config.api_key?.configured,
-))
+const apiReady = computed(() => isLlmConfigReady(settings.config))
 const showApiSetupHint = computed(() => settingsChecked.value && !settings.error && !apiReady.value)
 
 function worldIdOf(w: WorldTemplateSummary | WorldSummary): string { return String(w.world_id || w.id || '') }

--- a/frontend-v2/src/utils/modelConfiguration.ts
+++ b/frontend-v2/src/utils/modelConfiguration.ts
@@ -1,0 +1,23 @@
+import type { AppConfig } from '@/api/types'
+
+/**
+ * The create screen must recognize both the legacy inline model fields and the
+ * provider library introduced for shared model routing.
+ */
+export function isLlmConfigReady(config: Partial<AppConfig>): boolean {
+  const providerRef = String(config.llm_provider_ref || '').trim()
+  if (providerRef) {
+    const provider = (config.ai_providers || []).find(item => item.id === providerRef)
+    return Boolean(
+      provider
+      && String(provider.base_url || '').trim()
+      && String(config.model || '').trim()
+      && provider.api_key?.configured,
+    )
+  }
+  return Boolean(
+    String(config.base_url || '').trim()
+    && String(config.model || '').trim()
+    && config.api_key?.configured,
+  )
+}

--- a/frontend-v2/tests/modelConfiguration.test.ts
+++ b/frontend-v2/tests/modelConfiguration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { isLlmConfigReady } from '../src/utils/modelConfiguration'
+
+describe('isLlmConfigReady', () => {
+  it('accepts a configured legacy inline model', () => {
+    expect(isLlmConfigReady({
+      base_url: 'https://api.example/v1',
+      model: 'chat-model',
+      api_key: { configured: true, masked: '***1234' },
+    })).toBe(true)
+  })
+
+  it('accepts a configured provider-library model', () => {
+    expect(isLlmConfigReady({
+      llm_provider_ref: 'comfy',
+      model: 'comfy-image',
+      ai_providers: [{
+        id: 'comfy',
+        name: 'ComfyUI',
+        base_url: 'https://comfy.example/v1',
+        api_format: 'openai',
+        api_key: { configured: true, masked: '***1234' },
+      }],
+    })).toBe(true)
+  })
+
+  it('rejects a provider reference without a configured provider key', () => {
+    expect(isLlmConfigReady({
+      llm_provider_ref: 'comfy',
+      model: 'comfy-image',
+      ai_providers: [{
+        id: 'comfy',
+        name: 'ComfyUI',
+        base_url: 'https://comfy.example/v1',
+        api_format: 'openai',
+        api_key: { configured: false, masked: '' },
+      }],
+    })).toBe(false)
+  })
+
+  it('does not fall back to inline fields when a provider reference is active', () => {
+    expect(isLlmConfigReady({
+      llm_provider_ref: 'missing',
+      base_url: 'https://api.example/v1',
+      model: 'chat-model',
+      api_key: { configured: true, masked: '***1234' },
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- recognize the shared AI provider library when checking model readiness on the game creation page
- keep the legacy inline model configuration check for older installations
- add regression coverage for provider-backed and legacy model configuration

## Motivation

Issue #140 reported that connection tests passed after configuring the new AI provider library, but game creation still claimed that the model API was not configured. The create screen was checking only the legacy inline fields.

## Verification

- npm run test (221 passed)
- npm run typecheck
- npm run lint
- npm run build

Fixes #140