### PR TITLE
chore(release): prepare v2.3.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
-# DiceFrame v2.3.2-beta.1
+# DiceFrame v2.3.2
 
 ## 中文
 
-DiceFrame 2.3.2-beta.1 是下一次补丁版的预览。它重点验证 Content V2 内容架构、规则与世界书的多语言本地化，以及旧数据迁移链路。请先备份现有 `data/` 后再用于重要战役。
+DiceFrame 2.3.2 是 Content V2 架构、规则与世界书多语言本地化、旧数据迁移链路的正式补丁版。重要战役升级前仍建议备份现有 `data/`。
 
 ### 内容与本地化
 
@@ -10,6 +10,7 @@ DiceFrame 2.3.2-beta.1 是下一次补丁版的预览。它重点验证 Content 
 - **规则与世界的 typed locale**：内置规则和世界支持按游戏语言物化的名称、说明、场景与世界书文本；缺失语言会按既定 fallback 回退，不会静默改写 mechanics。
 - **运行时模板同步修复**：启动时会将内置的嵌套 locale JSON 同步到 `data/templates`，确保真实部署与开发加载器一致。
 - **世界书角色本地化**：角色面板和世界书 NPC 的头像物化会使用当前对局语言的只读本地化视图，译文不会写回共享世界书数据库。
+- **模型配置兼容修复**：创建游戏页同时识别旧版内联模型配置和新版 AI 服务商模型配置，连接测试通过后可以正常创建游戏。
 
 ### 规则、迁移与客户端
 
@@ -18,21 +19,21 @@ DiceFrame 2.3.2-beta.1 是下一次补丁版的预览。它重点验证 Content 
 - **战斗与长战役可靠性**：补强检定权威、死亡豁免、状态更新和长战役重算的覆盖，避免重试时重复结算。
 - **实验性移动端客户端**：仓库新增 Expo 移动端客户端与共享 API/流式交互覆盖；本次 Release 附件暂不提供移动端安装包。
 
-### 已知限制
+### 使用提示
 
-- 这是预览版，建议在现有战役和自定义模板上先做副本验证；遇到问题请保留日志和最小复现。
-- 预览版的可下载附件仍为 Windows 源码包和 Windows 便携包；移动端需要从仓库源码自行运行。
+- 建议在现有战役和自定义模板上先做副本验证；遇到问题请保留日志和最小复现。
+- 可下载附件为 Windows 源码包和 Windows 便携包；移动端需要从仓库源码自行运行。
 - 玩家直连仍为实验性功能：对称 NAT 或严格防火墙可能阻止连接，房主必须保持 DiceFrame 和房间在线。
 
 ### 下载指南
 
-- **普通 Windows 用户**：下载 `DiceFrame-v2.3.2-beta.1-windows-portable.zip`。
-- **源码运行用户**：下载 `DiceFrame-v2.3.2-beta.1-windows.zip`。
-- `.sha256` 是更新校验文件；预览版请保留旧版本或数据备份，便于回退。
+- **普通 Windows 用户**：下载 `DiceFrame-v2.3.2-windows-portable.zip`。
+- **源码运行用户**：下载 `DiceFrame-v2.3.2-windows.zip`。
+- `.sha256` 是更新校验文件；升级前建议保留旧版本或数据备份，便于回退。
 
 ## English
 
-DiceFrame 2.3.2-beta.1 previews the next patch release. It focuses on the Content V2 runtime architecture, localized rule and lorebook content, and the legacy-data migration path. Back up your existing `data/` before using it for an important campaign.
+DiceFrame 2.3.2 is the stable patch release for the Content V2 runtime architecture, localized rule and lorebook content, and the legacy-data migration path. Back up your existing `data/` before using it for an important campaign.
 
 ### Content and localization
 
@@ -40,6 +41,7 @@ DiceFrame 2.3.2-beta.1 previews the next patch release. It focuses on the Conten
 - **Typed locales for rules and worlds**: bundled rules and worlds materialize names, descriptions, scenes, and lorebook text for the game language. Missing locales use the documented fallback path without silently changing mechanics.
 - **Runtime template synchronization**: startup now copies nested bundled locale JSON into `data/templates`, aligning a deployed server with the development loader.
 - **Localized lorebook characters**: the character panel and lorebook-NPC portrait materialization use a read-only view for the active game language; translations are never written back into the shared lorebook database.
+- **Model configuration compatibility**: the create screen now recognizes both legacy inline model settings and the newer AI provider model library, so a successful connection test is enough to create a game.
 
 ### Rules, migration, and clients
 
@@ -48,14 +50,14 @@ DiceFrame 2.3.2-beta.1 previews the next patch release. It focuses on the Conten
 - **Reliable combat and long campaigns**: stronger coverage for authoritative checks, death saves, state updates, and long-campaign recomputation helps retries avoid duplicate resolution.
 - **Experimental mobile client**: the repository now includes an Expo mobile client with shared API and streaming coverage. This release does not attach mobile installation packages.
 
-### Known limits
+### Usage notes
 
-- This is a preview release. Test existing campaigns and custom templates on a copy first; retain logs and a minimal reproduction if anything fails.
-- Downloadable assets remain Windows source and Windows portable packages; the mobile client must currently be run from the repository source.
+- Test existing campaigns and custom templates on a copy first; retain logs and a minimal reproduction if anything fails.
+- Downloadable assets are Windows source and Windows portable packages; the mobile client must currently be run from the repository source.
 - Player direct connect remains experimental: symmetric NAT or strict firewalls may prevent connections, and the host must keep DiceFrame and the room online.
 
 ### Download guide
 
-- **Regular Windows users**: download `DiceFrame-v2.3.2-beta.1-windows-portable.zip`.
-- **Source-run users**: download `DiceFrame-v2.3.2-beta.1-windows.zip`.
-- `.sha256` files are update checksums. Keep the previous version or a data backup to make preview rollback easy.
+- **Regular Windows users**: download `DiceFrame-v2.3.2-windows-portable.zip`.
+- **Source-run users**: download `DiceFrame-v2.3.2-windows.zip`.
+- `.sha256` files are update checksums. Keep the previous version or a data backup to make rollback easy.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.3.2-beta.1"
+__version__ = "2.3.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Summary

- prepare DiceFrame v2.3.2 as the stable release
- update release notes from the beta preview to the stable version
- document the Issue140 model configuration compatibility fix

## Release scope

This branch is based on the current remote main after PR143. It contains no local professional D&D 2024 development commit.

## Verification

- pytest -q tests/test_webui_create_flow.py tests/test_release_build.py (78 passed)
- npm run test (221 passed)
- npm run typecheck
- npm run lint
- python scripts/build_release.py
