### PR TITLE
fix(narrative): apply perspective across rulesets

### DIFF
--- a/src/commands/game_lifecycle.py
+++ b/src/commands/game_lifecycle.py
@@ -17,8 +17,8 @@ from src.commands.tag_summary import summarize_tags
 from src.engine.character_utils import reset_character_for_restart
 from src.engine.game_instance import GameInstance, GameRegistry, GameState
 from src.engine.language import DEFAULT_LANGUAGE, localized_text, normalize_language
+from src.engine.narrative_perspective import narrative_perspective_instruction
 from src.llm.parser import normalize_tag_protocol, sanitize_narration
-from src.rulesets.dnd2024.narrative import narrative_perspective_instruction
 
 logger = logging.getLogger("trpg")
 
@@ -125,11 +125,9 @@ class GameLifecycle:
                     ),
                 },
             )
-        runtime_id = str((getattr(instance, "ruleset_runtime", {}) or {}).get("id") or "")
-        if runtime_id == "core:dnd2024":
-            opening_instruction += "\n\n" + narrative_perspective_instruction(
-                instance, instance.language,
-            )
+        opening_instruction += "\n\n" + narrative_perspective_instruction(
+            instance, instance.language,
+        )
         welcome_context = (
             f"{gm_prompt}\n\n"
             f"【当前世界】\n"

--- a/src/commands/prompt_composer.py
+++ b/src/commands/prompt_composer.py
@@ -14,12 +14,12 @@ from typing import Callable
 from src.compat.callbacks import load_world_template as load_world_template_compat
 from src.engine.game_instance import GameInstance
 from src.engine.language import DEFAULT_LANGUAGE, gm_language_instruction, localized_text
+from src.engine.narrative_perspective import narrative_perspective_instruction
 from src.llm.context_builder import build_context
 from src.memory.delta import MemoryStore
 from src.rules.loader import RuleBundleLoader
 from src.rules.rule_system import RuleSystem
 from src.rulesets.dnd2024.advancement_access import prompt_instruction as advancement_prompt_instruction
-from src.rulesets.dnd2024.narrative import narrative_perspective_instruction
 from src.rulesets.registry import RulesetRuntimeRegistry
 
 logger = logging.getLogger("trpg")
@@ -184,8 +184,8 @@ class PromptComposer:
                     "他プレイヤーのキャラクターへの権威として扱ってはならない。"
                 ),
             })
+        gm_prompt = gm_prompt + "\n\n" + narrative_perspective_instruction(instance, language)
         if str((getattr(instance, "ruleset_runtime", {}) or {}).get("id") or "") == "core:dnd2024":
-            gm_prompt = gm_prompt + "\n\n" + narrative_perspective_instruction(instance, language)
             gm_prompt = gm_prompt + "\n\n" + advancement_prompt_instruction(instance, language)
         gm_prompt = gm_prompt + "\n\n" + gm_language_instruction(getattr(instance, "language", "zh-CN"))
         return gm_prompt

--- a/src/engine/game_instance.py
+++ b/src/engine/game_instance.py
@@ -25,6 +25,7 @@ from src.engine.dice import parse_player_roll, roll as dice_roll, check_d20
 from src.engine.character_utils import apply_resource_delta, get_resource
 from src.engine.health import record_health_event
 from src.engine.language import DEFAULT_LANGUAGE, normalize_language
+from src.engine.narrative_perspective import validate_narrative_perspective
 
 logger = logging.getLogger("trpg")
 
@@ -440,10 +441,7 @@ class GameInstance:
             self.ready_players.update(self.alive_players)
 
     def set_narrative_perspective(self, perspective: str) -> None:
-        normalized = str(perspective or "auto").strip().casefold()
-        if normalized not in {"auto", "immersive", "third_person"}:
-            raise ValueError("叙事视角必须是 auto、immersive 或 third_person")
-        self.narrative_perspective = normalized
+        self.narrative_perspective = validate_narrative_perspective(perspective)
 
     def append_log_entry(self, entry: RoundLogEntry) -> None:
         self.log.append(entry)

--- a/src/engine/narrative_perspective.py
+++ b/src/engine/narrative_perspective.py
@@ -1,7 +1,7 @@
-"""D&D 2024 public narration perspective policy.
+"""Ruleset-neutral public narration perspective policy.
 
-The persisted value is a canonical presentation preference.  It never changes
-ruleset identity or mechanics, and only the D&D runtime consumes it.
+The persisted value is a presentation preference. It applies to every
+ruleset and never changes canonical identity or mechanics.
 """
 
 from __future__ import annotations
@@ -20,11 +20,22 @@ NARRATIVE_PERSPECTIVES = frozenset({
 })
 
 
+def validate_narrative_perspective(value: Any) -> str:
+    """Return a canonical value or reject invalid user input."""
+
+    normalized = str(value or NARRATIVE_PERSPECTIVE_AUTO).strip().casefold()
+    if normalized not in NARRATIVE_PERSPECTIVES:
+        raise ValueError("叙事视角必须是 auto、immersive 或 third_person")
+    return normalized
+
+
 def normalize_narrative_perspective(value: Any) -> str:
     """Return a supported canonical value, preserving old saves as ``auto``."""
 
-    normalized = str(value or NARRATIVE_PERSPECTIVE_AUTO).strip().casefold()
-    return normalized if normalized in NARRATIVE_PERSPECTIVES else NARRATIVE_PERSPECTIVE_AUTO
+    try:
+        return validate_narrative_perspective(value)
+    except ValueError:
+        return NARRATIVE_PERSPECTIVE_AUTO
 
 
 def resolve_narrative_perspective(instance: Any) -> str:
@@ -43,7 +54,7 @@ def resolve_narrative_perspective(instance: Any) -> str:
 
 
 def narrative_perspective_instruction(instance: Any, language: str) -> str:
-    """Build the single authoritative D&D narration instruction."""
+    """Build the single ruleset-neutral narration instruction."""
 
     perspective = resolve_narrative_perspective(instance)
     if perspective == NARRATIVE_PERSPECTIVE_IMMERSIVE:

--- a/src/webui/services/games.py
+++ b/src/webui/services/games.py
@@ -18,6 +18,7 @@ from src.engine.game_instance import GameState
 from src.engine.dice import d20_critical_thresholds, roll
 from src.engine.health import health_payload, mark_health_event, record_health_event
 from src.engine.language import DEFAULT_LANGUAGE, normalize_language
+from src.engine.narrative_perspective import validate_narrative_perspective
 from src.commands.resource_triggers import check_resource_triggers
 from src.llm.parser import sanitize_narration
 from src.migrations import migrate_instance
@@ -549,9 +550,6 @@ async def set_narrative_perspective(
     inst = api._reg.get(api._parse_key(game_key))
     if not inst:
         return {"ok": False, "error": "游戏不存在"}
-    runtime_id = str((getattr(inst, "ruleset_runtime", {}) or {}).get("id") or "")
-    if runtime_id != "core:dnd2024":
-        return {"ok": False, "error": "当前规则不支持叙事视角设置"}
     try:
         inst.set_narrative_perspective(perspective)
     except ValueError as exc:
@@ -915,10 +913,8 @@ async def create_game(api: "WebAPI", world_id: str, game_name: str = "",
     if not players:
         return {"ok": False, "error": "请至少创建或选择 1 名队伍角色"}
     try:
-        normalized_narrative_perspective = str(narrative_perspective or "auto").strip().casefold()
-        if normalized_narrative_perspective not in {"auto", "immersive", "third_person"}:
-            raise ValueError
-    except (AttributeError, ValueError):
+        normalized_narrative_perspective = validate_narrative_perspective(narrative_perspective)
+    except ValueError:
         return {"ok": False, "error": "叙事视角设置无效"}
 
     try:
@@ -1272,10 +1268,10 @@ async def create_from_seed(api: "WebAPI", seed_code: str, solo: bool = False,
         or "auto"
     )
     try:
-        normalized_narrative_perspective = str(resolved_narrative_perspective).strip().casefold()
-        if normalized_narrative_perspective not in {"auto", "immersive", "third_person"}:
-            raise ValueError
-    except (AttributeError, ValueError):
+        normalized_narrative_perspective = validate_narrative_perspective(
+            resolved_narrative_perspective,
+        )
+    except ValueError:
         return {"ok": False, "error": "叙事视角设置无效"}
 
     # A seed restart is a new save, but it must keep the original save's rule

--- a/tests/test_authority_guard.py
+++ b/tests/test_authority_guard.py
@@ -182,7 +182,7 @@ def test_multiplayer_prompt_gets_authority_scope(tmp_path, monkeypatch):
     assert "多人权限范围" not in composer.compose_gm_prompt(solo)
 
 
-def test_dnd_advanced_prompt_declares_public_narrative_perspective(tmp_path, monkeypatch):
+def test_generic_prompt_declares_public_narrative_perspective(tmp_path, monkeypatch):
     prompts = tmp_path / "prompts"
     rules = tmp_path / "rules"
     prompts.mkdir()
@@ -192,13 +192,12 @@ def test_dnd_advanced_prompt_declares_public_narrative_perspective(tmp_path, mon
     monkeypatch.setattr(composer_module, "_GM_PROMPT_CACHE", {})
 
     inst = _make_multi_instance()
-    inst.ruleset_runtime = {"id": "core:dnd2024"}
     prompt = PromptComposer(prompts, rules).compose_gm_prompt(inst)
     assert "叙事视角" in prompt
     assert "显示名作第三人称" in prompt
 
 
-def test_dnd_advanced_prompt_honors_explicit_immersive_perspective(tmp_path, monkeypatch):
+def test_generic_prompt_honors_explicit_immersive_perspective(tmp_path, monkeypatch):
     prompts = tmp_path / "prompts"
     rules = tmp_path / "rules"
     prompts.mkdir()
@@ -208,7 +207,6 @@ def test_dnd_advanced_prompt_honors_explicit_immersive_perspective(tmp_path, mon
     monkeypatch.setattr(composer_module, "_GM_PROMPT_CACHE", {})
 
     inst = _make_multi_instance()
-    inst.ruleset_runtime = {"id": "core:dnd2024"}
     inst.narrative_perspective = "immersive"
     prompt = PromptComposer(prompts, rules).compose_gm_prompt(inst)
 

--- a/tests/test_gm_controls.py
+++ b/tests/test_gm_controls.py
@@ -44,7 +44,7 @@ async def test_set_solo_mode_marks_pending_round_ready(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_narrative_perspective_is_dnd_only_and_persisted(tmp_path):
+async def test_narrative_perspective_is_ruleset_neutral_and_persisted(tmp_path):
     registry = GameRegistry(tmp_path)
     key = ("web", "dnd-game", "bot")
     inst = GameInstance(
@@ -65,11 +65,11 @@ async def test_narrative_perspective_is_dnd_only_and_persisted(tmp_path):
     generic_key = ("web", "generic-game", "bot")
     generic = GameInstance(game_key=generic_key, rule_id="freeform_fantasy")
     registry.register(generic)
-    rejected = await games.set_narrative_perspective(
+    generic_result = await games.set_narrative_perspective(
         DummyAPI(registry), _GAME_KEY_SEP.join(generic_key), "immersive",
     )
-    assert rejected["ok"] is False
-    assert generic.narrative_perspective == "auto"
+    assert generic_result == {"ok": True, "narrative_perspective": "immersive"}
+    assert generic.narrative_perspective == "immersive"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webui_create_flow.py
+++ b/tests/test_webui_create_flow.py
@@ -540,6 +540,7 @@ async def test_create_game_uses_created_character_before_opening(web_api):
     result = await api.create_game(
         "template_world",
         "模板世界",
+        narrative_perspective="third_person",
         players=[{
             "character_name": "艾琳",
             "race": "精灵",
@@ -555,6 +556,7 @@ async def test_create_game_uses_created_character_before_opening(web_api):
     assert [p["character_name"] for p in inst.players.values()] == ["艾琳"]
     assert "艾琳" in fake_llm.calls[-1]["user_message"]
     assert "精灵 游侠" in fake_llm.calls[-1]["user_message"]
+    assert "显示名作第三人称" in fake_llm.calls[-1]["user_message"]
     assert result["players"][0]["character_name"] == "艾琳"
 
 


### PR DESCRIPTION
## Summary\n- move narrative perspective policy from the DND2024 runtime into the ruleset-neutral engine\n- allow GM perspective changes for every ruleset\n- inject the selected perspective into both opening narration and ongoing AI GM prompts\n- centralize validation and cover generic save, prompt, and new-game behavior\n\n## Verification\n- python -m pytest -q — 1431 passed, 1 skipped\n- python -m pytest tests/test_webui_create_flow.py tests/test_gm_controls.py tests/test_authority_guard.py tests/test_game_instance.py tests/test_language_support.py -q — 170 passed\n- 
pm test -- --run tests/GmToolbar.test.ts tests/RulesetExperienceIntegration.test.ts — 14 passed