### PR TITLE
release: prepare v2.4.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,41 +1,73 @@
-# DiceFrame v2.4.1-beta.2
-
-> 这是预览版本，主要用于验证 Windows 便携版与托管 Docker 的自动更新流程。重要数据请提前备份。
+# DiceFrame v2.4.1
 
 ## 中文
 
+DiceFrame v2.4.1 带来统一的多人跑团体验、高级 DND5E 规则支持、冒险包管理、移动端游玩能力，以及更可靠的更新和问题排查工具。
+
 ### 本次更新
 
-- **修复托管 Docker 更新无法启动**：补齐 HTTPS 证书组件所需的 Linux 运行时依赖，解决升级后因缺少 `_cffi_backend` 而自动回滚的问题。
-- **增加发布包启动门禁**：Docker 更新包在发布前会检查依赖完整性，并在 Linux 构建环境中实际导入加密模块，避免同类缺包进入 Release。
-- **减少更新误回滚**：新版本启动后，偶发的连接重置或短暂不可用不再立即触发回滚；只有健康检查持续失败才会恢复旧版本。
-- **统一更新等待策略**：Windows 便携版与托管 Docker 现在使用一致的启动等待、观察期和连续失败容错规则，存档较多或设备较慢时更可靠。
-- **改进 Docker 更新诊断**：健康检查遵循更新包声明的接口路径，并在失败时显示进程退出、接口异常或版本不匹配等更具体的原因。
-- **安全设置布局**：无本地证书时，证书指纹占位卡片会与访问保护卡片并排显示，并继续随窗口宽度自动适配。
+- **统一游玩流程**：剧情、公共消息、行动输入、队伍状态和 GM 控制台回到同一条对局流程；帮助内容不再打断正常游玩。
+- **高级 DND5E 规则**：加入角色创建、角色中心、法术与资源、休息、升级资格和规则校验，并由服务端维护权威状态。
+- **AI GM 与冒险推进**：支持根据玩家行动推进剧情、收集多人行动、处理检定和唤醒符合剧情的遭遇；GM 仍可随时裁定和接管。
+- **多人战斗**：提供先攻、回合、移动、攻击、伤害、敌方行动、准备状态和公共战斗历史的同步流程。玩家只能操作自己的角色，GM 管理遭遇和战役状态。
+- **冒险包**：支持可视化新建、复制、编辑、校验、导入、导出、删除和 AI 草稿。冒险包提供剧情结构，世界书继续负责世界背景；两者可以组合使用但不会互相覆盖。
+- **稳定重开**：对局会固定冒险包的 identity、版本和内容摘要；内容缺失或被修改时会明确报告，而不是静默切换到另一套场景。
+- **叙事视角**：创建对局时可选择第一人称或第三人称叙事，GM 也可在对局中调整；该能力适用于所有规则，而非 DND5E 专属设置。
+- **连接安全**：设置中新增“安全”页，可在 HTTP、本地自签名 HTTPS 与受信任 HTTPS 之间切换，并支持为域名或符合条件的公网 IP 申请和自动续期 Let’s Encrypt 证书。
+- **语音输入**：可配置 OpenAI 兼容的语音识别模型，在 HTTPS 或 localhost 环境中通过行动输入框旁的麦克风按钮把语音转为文字。
+- **移动端与联机**：改进移动端导航、对局界面、地图、角色和多人连接流程，并改善独立 Web 前端的连接体验。
+- **运行日志与排障**：新增按天轮转、默认保留 30 天的运行日志，可在设置中查看、清除或导出给开发者；DF 助手可以分析脱敏后的日志，帮助定位常见问题。
+- **模型请求控制**：普通模型请求超时可独立配置，不再与连接测试超时绑定，长篇生成与临时连通性检查可以使用不同等待时间。
+- **托管 Docker 更新**：容器内支持下载、校验、健康检查、观察期切换和失败回滚；当前与上一应用版本独立保存，业务数据不随版本切换。
+- **更新可靠性**：改进 Windows 便携版与托管 Docker 的运行时依赖校验、启动等待和连续失败判断，减少慢速设备、存档较多或短暂断连造成的误回滚，并修复 Docker 更新包缺少加密依赖时无法启动的问题。
+- **更新包校验**：Release 使用统一的 `SHA256SUMS` 清单，便于手动下载和新版更新器校验。
+- **兼容性**：DND5E 专属机制保持在高级 DND5E 规则边界内，不会自动改变传统规则、CoC、赛博朋克或 generic d20 的玩法。
+
+### 升级提示
+
+- 升级前请备份完整的 `data/` 文件夹。
+- Windows 便携版、源码包和托管 Docker 均可使用各自的应用内更新流程；只有涉及 Python ABI、系统库、字体或 launcher 协议变化时，Docker 才需要更新基础镜像。
+- Docker Update 当前支持 `linux-amd64`。
 
 ### 下载与校验
 
-- Windows 便携版：`DiceFrame-v2.4.1-beta.2-windows-portable.zip`
-- Windows 源码包：`DiceFrame-v2.4.1-beta.2-windows.zip`
-- Docker 托管更新：`DiceFrame-v2.4.1-beta.2-docker-update-linux-amd64.zip`
+- Windows 便携版：`DiceFrame-v2.4.1-windows-portable.zip`
+- Windows 源码包：`DiceFrame-v2.4.1-windows.zip`
+- Docker 托管更新：`DiceFrame-v2.4.1-docker-update-linux-amd64.zip`
 - 手动下载时，请使用 Release 中的 `SHA256SUMS` 统一校验。
 
 ## English
 
-> This is a preview release intended primarily to verify automatic updates for Windows portable and managed Docker installations. Back up important data before upgrading.
+DiceFrame v2.4.1 brings a unified multiplayer play flow, advanced DND5E rules, adventure-bundle management, improved mobile play, and more reliable updates and diagnostics.
 
-### What's changed
+### What's new
 
-- **Fixed managed Docker startup after updating**: The Linux runtime now includes the dependencies required by HTTPS certificate support, resolving automatic rollback caused by a missing `_cffi_backend` module.
-- **Added a release-package runtime gate**: Docker update artifacts are checked for dependency completeness and their cryptography modules are imported on the Linux build runner before publication.
-- **Fewer false update rollbacks**: A transient connection reset or brief health-check interruption no longer rolls back a newly started version immediately. Rollback now requires a continuous health-check failure.
-- **Aligned update timing**: Windows portable and managed Docker now use matching startup, probation, and continuous-failure tolerance policies for more reliable updates on slower devices or installations with more saved games.
-- **Better Docker update diagnostics**: Health checks follow the path declared by the update package and report clearer process-exit, endpoint, and version-mismatch failures.
-- **Security settings layout**: When no local certificate exists, the certificate fingerprint placeholder is aligned beside Access Protection and remains responsive at narrower widths.
+- **Unified play flow**: Narrative, public messages, action input, party state, and the GM console now follow one play flow. Help content no longer interrupts normal play.
+- **Advanced DND5E rules**: Character creation, character center, spells and resources, rests, advancement eligibility, and rules validation are backed by authoritative server state.
+- **AI GM and adventure progression**: Player actions can advance the story, collect multiplayer actions, resolve checks, and awaken encounters that fit the current narrative. The GM can always adjudicate or take over.
+- **Multiplayer combat**: Initiative, turns, movement, attacks, damage, enemy actions, readiness, and public combat history are synchronized. Players control only their own characters while the GM manages encounters and campaigns.
+- **Adventure bundles**: Visual create, copy, edit, validate, import, export, delete, and AI-draft workflows are available. Adventure bundles provide optional story structure while lorebooks continue to define world context; they can be combined without overwriting each other.
+- **Deterministic resume**: Games pin an adventure identity, version, and content digest. Missing or changed content is reported explicitly instead of silently switching scenes.
+- **Narrative perspective**: Choose first- or third-person narration when creating a game, and let the GM adjust it during play. This setting works across all rulesets rather than being specific to DND5E.
+- **Connection security**: A new Security settings page can switch between HTTP, local self-signed HTTPS, and trusted HTTPS, with Let’s Encrypt issuance and automatic renewal for domains or eligible public IP addresses.
+- **Voice input**: Configure an OpenAI-compatible speech-recognition model and dictate actions from the microphone button beside the action composer when using HTTPS or localhost.
+- **Mobile and multiplayer connectivity**: Navigation, play, maps, characters, and peer connection flows are improved for mobile, along with standalone Web frontend connectivity.
+- **Runtime logs and diagnostics**: Daily-rotated runtime logs retain the latest 30 days by default and can be viewed, cleared, or exported for developers from Settings. DF Assistant can analyze redacted logs to help diagnose common issues.
+- **Model request controls**: Normal model request timeout is configurable independently from connection-test timeout, so long generations and quick connectivity checks can use different limits.
+- **Managed Docker updates**: Containers can download, verify, health-check, probation-test, switch, and roll back application versions while keeping current and previous payloads separate from business data.
+- **Update reliability**: Runtime dependency checks, startup waits, and continuous-failure handling are improved for Windows portable and managed Docker updates. This reduces false rollbacks on slower devices, installations with many saved games, or brief connection interruptions, and fixes Docker startup failures caused by missing cryptography dependencies.
+- **Update verification**: Releases use one unified `SHA256SUMS` manifest for manual downloads and newer updater clients.
+- **Compatibility**: DND5E-specific mechanics stay within the advanced DND5E rules boundary and do not automatically change traditional rules, CoC, cyberpunk, or generic d20 gameplay.
+
+### Upgrade notes
+
+- Back up the complete `data/` directory before upgrading.
+- Windows portable, source-package, and managed-Docker installations can use their respective in-app update flows. Docker needs a base-image update only when the Python ABI, system libraries, fonts, or launcher protocol change.
+- Docker Update currently supports `linux-amd64`.
 
 ### Downloads and verification
 
-- Windows portable: `DiceFrame-v2.4.1-beta.2-windows-portable.zip`
-- Windows source: `DiceFrame-v2.4.1-beta.2-windows.zip`
-- Managed Docker update: `DiceFrame-v2.4.1-beta.2-docker-update-linux-amd64.zip`
+- Windows portable: `DiceFrame-v2.4.1-windows-portable.zip`
+- Windows source: `DiceFrame-v2.4.1-windows.zip`
+- Managed Docker update: `DiceFrame-v2.4.1-docker-update-linux-amd64.zip`
 - For manual downloads, verify all archives with the `SHA256SUMS` file attached to the Release.

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -1031,7 +1031,7 @@ export const en = {
   publishedAt: 'Published',
   checkFailed: 'Check failed',
   repoNoReleaseMessage: 'No public Release in this repository.',
-  updateAvailableHelp: 'A new version is available. Keep the data/ directory before upgrading. Docker users should redeploy with the new source or image.',
+  updateAvailableHelp: 'A new version is available. Back up the complete data/ directory, then use the download and installation option for your current deployment below.',
   releaseNotes: 'Release Notes',
   checkUpdate: 'Check for Updates',
   openReleasePage: 'Open Release Page',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -1031,7 +1031,7 @@ export const ja = {
   publishedAt: '公開日時',
   checkFailed: '確認に失敗',
   repoNoReleaseMessage: 'リポジトリに公開 Release がありません。',
-  updateAvailableHelp: '新しいバージョンが利用可能です。アップグレード前に data/ ディレクトリを保持してください。Docker ユーザーは新しいソースコードかイメージで再デプロイしてください。',
+  updateAvailableHelp: '新しいバージョンが利用可能です。アップグレード前に data/ ディレクトリ全体をバックアップし、現在の配置方法に対応する下記のダウンロードとインストール手順を使用してください。',
   releaseNotes: 'リリースノート',
   checkUpdate: '更新を確認',
   openReleasePage: 'リリースページを開く',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -1031,7 +1031,7 @@ export const zhCN = {
   publishedAt: '发布时间',
   checkFailed: '检查失败',
   repoNoReleaseMessage: '仓库暂无公开 Release。',
-  updateAvailableHelp: '有新版可用。升级前保留 data/ 目录；Docker 用户请用新版源码或镜像重新部署。',
+  updateAvailableHelp: '有新版可用。升级前请备份完整的 data/ 目录，并按下方当前部署方式完成下载与安装。',
   releaseNotes: '更新日志',
   checkUpdate: '检查更新',
   openReleasePage: '打开发布页',

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.4.1-beta.2"
+__version__ = "2.4.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Summary
- promote the verified v2.4.1 beta line to the stable v2.4.1 release
- publish the complete user-facing feature notes carried forward from the withdrawn v2.4.0 release
- replace the obsolete blanket Docker redeploy message with deployment-aware update guidance in Chinese, English, and Japanese

## Verification
- frontend typecheck and lint
- frontend unit tests: 323 passed
- frontend production build
- updater, Docker updater/launcher, and Docker release validation tests: 56 passed
- exact v2.4.1 managed Docker package build and contract validation