### PR TITLE
fix(docker): TLS-aware launcher health probe + Asia/Shanghai default TZ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Docker host port. Container still listens on 9876.
 DICEFRAME_HTTP_PORT=9876
 
+# Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;
+# set another IANA zone here (e.g. Europe/Berlin) to override it.
+TZ=Asia/Shanghai
+
 # Optional public-content mirror. Leave blank to use the official source.
 DICEFRAME_CONTENT_BASE_URL=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN DICEFRAME_BUILD_VERSION="${VERSION}" python scripts/build_docker_update.py \
 
 FROM python:3.11-slim AS managed-runtime-base
 
+# Runtime log timestamps follow this zone; override with `docker run -e TZ=...`
+# or a TZ entry in .env for compose. Debian slim ships no tzdata, install it.
+ENV TZ=Asia/Shanghai
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     TRPG_WEB_HOST=0.0.0.0 \
@@ -38,7 +42,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     TRPG_DOCKER_SEED_CHECKSUM=/opt/diceframe-seed/update.sha256
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates fonts-noto-cjk \
+    && apt-get install -y --no-install-recommends ca-certificates fonts-noto-cjk tzdata \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /app/data /app/plugins /opt/diceframe-launcher /opt/diceframe-seed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       TRPG_WEB_HOST: "0.0.0.0"
       TRPG_WEB_PORT: "9876"
       TRPG_DATA_DIR: "/app/data"
+      # The image already defaults to Asia/Shanghai; set TZ in .env to change it.
+      TZ: "${TZ:-Asia/Shanghai}"
 
       TRPG_LLM_API_KEY: "${TRPG_LLM_API_KEY:-}"
       TRPG_LLM_BASE_URL: "${TRPG_LLM_BASE_URL:-}"

--- a/src/docker_launcher/launcher.py
+++ b/src/docker_launcher/launcher.py
@@ -93,22 +93,26 @@ def _resolve_health_endpoint(data_dir: Path, env: dict[str, str] | None = None) 
     config.json 声明 self_signed 且 fingerprint.txt 存在时用 HTTPS 并按
     指纹固定证书。指纹文件缺失说明证书从未生成（服务端会回退 HTTP），
     保持 http。lets_encrypt 模式应用确实在说 HTTPS，探测改走 https。
-    TRPG_DOCKER_HEALTH_SCHEME 可显式覆盖（http/https），供特殊部署自救。
+    TRPG_DOCKER_HEALTH_SCHEME 可显式覆盖（http/https），供特殊部署自救；
+    强制 https 只覆盖 scheme，self_signed 模式仍保留证书指纹固定。
     """
     env = env if env is not None else os.environ
     forced = str(env.get("TRPG_DOCKER_HEALTH_SCHEME") or "").strip().lower()
-    if forced in ("http", "https"):
-        return forced, ""
-
     transport = _read_json(data_dir / "config.json").get("web_transport") or {}
     tls_mode = str(transport.get("tls_mode") or "").strip().lower() if isinstance(transport, dict) else ""
+    fingerprint = ""
     if tls_mode == "self_signed":
         try:
             fingerprint = _normalized_fingerprint(
                 (data_dir / "certs" / "self-signed" / "fingerprint.txt").read_text(encoding="utf-8")
             )
         except OSError:
-            return "http", ""
+            fingerprint = ""
+    if forced == "http":
+        return "http", ""
+    if forced == "https":
+        return "https", fingerprint
+    if tls_mode == "self_signed":
         return ("https", fingerprint) if fingerprint else ("http", "")
     if tls_mode == "lets_encrypt":
         return "https", ""

--- a/src/docker_launcher/launcher.py
+++ b/src/docker_launcher/launcher.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import functools
+import hashlib
+import http.client
 import json
 import os
+import re
 import shutil
 import signal
+import ssl
 import subprocess
 import sys
 import tempfile
 import time
-import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -77,6 +81,90 @@ def _read_checksum(path: Path, filename: str) -> str:
     return matches[0]
 
 
+def _normalized_fingerprint(text: str) -> str:
+    """指纹文件存的是冒号分隔大写 hex；比较时统一成无分隔大写。"""
+    return re.sub(r"[:\-\s]", "", str(text or "")).upper()
+
+
+def _resolve_health_endpoint(data_dir: Path, env: dict[str, str] | None = None) -> tuple[str, str]:
+    """决定本机健康探测的 scheme 与期望的自签证书指纹。
+
+    与 Windows launcher 的 ResolveServerEndpoint 同一契约：默认 HTTP；
+    config.json 声明 self_signed 且 fingerprint.txt 存在时用 HTTPS 并按
+    指纹固定证书。指纹文件缺失说明证书从未生成（服务端会回退 HTTP），
+    保持 http。lets_encrypt 模式应用确实在说 HTTPS，探测改走 https。
+    TRPG_DOCKER_HEALTH_SCHEME 可显式覆盖（http/https），供特殊部署自救。
+    """
+    env = env if env is not None else os.environ
+    forced = str(env.get("TRPG_DOCKER_HEALTH_SCHEME") or "").strip().lower()
+    if forced in ("http", "https"):
+        return forced, ""
+
+    transport = _read_json(data_dir / "config.json").get("web_transport") or {}
+    tls_mode = str(transport.get("tls_mode") or "").strip().lower() if isinstance(transport, dict) else ""
+    if tls_mode == "self_signed":
+        try:
+            fingerprint = _normalized_fingerprint(
+                (data_dir / "certs" / "self-signed" / "fingerprint.txt").read_text(encoding="utf-8")
+            )
+        except OSError:
+            return "http", ""
+        return ("https", fingerprint) if fingerprint else ("http", "")
+    if tls_mode == "lets_encrypt":
+        return "https", ""
+    return "http", ""
+
+
+def _chain_only_context() -> ssl.SSLContext:
+    """验证证书链但不校验主机名：回环探测对域名证书必然主机名不符。"""
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    return context
+
+
+def _verify_pinned_certificate(der: bytes, expected: str) -> None:
+    actual = hashlib.sha256(der).hexdigest().upper()
+    if actual != expected:
+        raise ssl.SSLError(
+            f"健康探测证书指纹不匹配（实际 {actual[:12]}...，期望 {expected[:12]}...）"
+        )
+
+
+def _unverified_context() -> ssl.SSLContext:
+    """仅用于自签探测的载体上下文；真正的信任判定在指纹比对里。"""
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """TLS 握手后按 fingerprint.txt 校验证书，替代系统信任链。"""
+
+    def __init__(self, *args: Any, fingerprint: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._pinned_fingerprint = fingerprint
+
+    def connect(self) -> None:
+        super().connect()
+        der = self.sock.getpeercert(binary_form=True) or b""
+        _verify_pinned_certificate(der, self._pinned_fingerprint)
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    """把固定指纹注入本机探测连接（与 Windows launcher 同一契约）。"""
+
+    def __init__(self, fingerprint: str) -> None:
+        super().__init__(context=_unverified_context())
+        self._fingerprint = fingerprint
+
+    def https_open(self, req: urllib.request.Request) -> Any:  # type: ignore[override]
+        connection_factory = functools.partial(
+            _PinnedHTTPSConnection, fingerprint=self._fingerprint
+        )
+        return self.do_open(connection_factory, req, context=self._context)
+
+
 class DockerLauncher:
     def __init__(
         self,
@@ -89,6 +177,7 @@ class DockerLauncher:
         python: str = sys.executable,
         startup_timeout: float = 60.0,
         poll_interval: float = 0.5,
+        data_dir: Path | None = None,
     ) -> None:
         self.runtime_root = runtime_root.resolve()
         self.versions_dir = self.runtime_root / "docker-versions"
@@ -103,6 +192,11 @@ class DockerLauncher:
         self.python = python
         self.startup_timeout = startup_timeout
         self.poll_interval = poll_interval
+        # 健康探测的 scheme 由 data 目录里的 Web Transport 配置决定。
+        self.data_dir = (
+            Path(data_dir) if data_dir is not None
+            else Path(os.getenv("TRPG_DATA_DIR", "/app/data"))
+        )
         self.child: subprocess.Popen[bytes] | None = None
         self.active_dir: Path | None = None
         self.stopping = False
@@ -207,23 +301,44 @@ class DockerLauncher:
             self._last_health_error = "候选进程已退出"
             return False
         normalized_path = "/" + str(health_path or "").lstrip("/")
-        url = f"http://{self.host}:{self.port}{normalized_path}"
-        try:
-            with urllib.request.urlopen(url, timeout=2) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-        except (OSError, ValueError, urllib.error.URLError) as exc:
-            self._last_health_error = f"{type(exc).__name__}: {exc}"
-            return False
-        reported = str(payload.get("version") or "").strip().lstrip("vV")
-        expected = str(expected_version or "").strip().lstrip("vV")
-        if not payload.get("ok"):
-            self._last_health_error = "健康接口返回 ok=false"
-            return False
-        if reported != expected:
-            self._last_health_error = f"版本不匹配（期望 {expected}，实际 {reported or '缺失'}）"
-            return False
-        self._last_health_error = ""
-        return True
+        scheme, fingerprint = _resolve_health_endpoint(self.data_dir)
+        attempts = ["https", "http"] if scheme == "https" else ["http"]
+        last_error = ""
+        for attempt_scheme in attempts:
+            url = f"{attempt_scheme}://{self.host}:{self.port}{normalized_path}"
+            try:
+                if attempt_scheme == "https":
+                    if fingerprint:
+                        opener = urllib.request.build_opener(
+                            _PinnedHTTPSHandler(fingerprint)
+                        )
+                    else:
+                        opener = urllib.request.build_opener(
+                            urllib.request.HTTPSHandler(context=_chain_only_context())
+                        )
+                    response = opener.open(url, timeout=2)
+                else:
+                    response = urllib.request.urlopen(url, timeout=2)
+                with response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except (OSError, ValueError, http.client.HTTPException) as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                continue
+            if not isinstance(payload, dict):
+                self._last_health_error = "健康接口响应不是 JSON 对象"
+                return False
+            reported = str(payload.get("version") or "").strip().lstrip("vV")
+            expected = str(expected_version or "").strip().lstrip("vV")
+            if not payload.get("ok"):
+                self._last_health_error = "健康接口返回 ok=false"
+                return False
+            if reported != expected:
+                self._last_health_error = f"版本不匹配（期望 {expected}，实际 {reported or '缺失'}）"
+                return False
+            self._last_health_error = ""
+            return True
+        self._last_health_error = last_error or "健康探测失败"
+        return False
 
     def _wait_healthy(self, directory: Path) -> bool:
         manifest = self._validate_dir(directory)

--- a/tests/test_docker_launcher.py
+++ b/tests/test_docker_launcher.py
@@ -378,7 +378,7 @@ def test_resolve_health_endpoint_env_override_wins(tmp_path):
     ) == ("http", "")
     assert _resolve_health_endpoint(
         data_dir, {"TRPG_DOCKER_HEALTH_SCHEME": "https"}
-    ) == ("https", "")
+    ) == ("https", "AABB")
     assert _resolve_health_endpoint(
         data_dir, {"TRPG_DOCKER_HEALTH_SCHEME": "ftp"}
     ) == ("https", "AABB")

--- a/tests/test_docker_launcher.py
+++ b/tests/test_docker_launcher.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
+import contextlib
+import datetime
+import ipaddress
 import json
+import ssl
 import stat
+import threading
 import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from src.docker_launcher import contracts
-from src.docker_launcher.launcher import DockerLauncher, _version_key
+from src.docker_launcher.launcher import (
+    DockerLauncher,
+    _normalized_fingerprint,
+    _resolve_health_endpoint,
+    _verify_pinned_certificate,
+    _version_key,
+)
 
 
 def _package_tree(root: Path, version: str = "2.4.0", probation: int = 0) -> Path:
@@ -237,3 +253,223 @@ def test_version_order_handles_prereleases():
     assert _version_key("2.4.0-beta.1") < _version_key("2.4.0")
     assert _version_key("2.4.0-beta.10") > _version_key("2.4.0-beta.2")
     assert _version_key("2.4.1") > _version_key("2.4.0")
+
+
+def _write_transport_config(data_dir: Path, tls_mode: str, fingerprint: str | None = None) -> None:
+    (data_dir / "certs" / "self-signed").mkdir(parents=True, exist_ok=True)
+    (data_dir / "config.json").write_text(
+        json.dumps({"web_transport": {"tls_mode": tls_mode}}), encoding="utf-8",
+    )
+    fingerprint_path = data_dir / "certs" / "self-signed" / "fingerprint.txt"
+    if fingerprint is None:
+        fingerprint_path.unlink(missing_ok=True)
+    else:
+        fingerprint_path.write_text(fingerprint, encoding="utf-8")
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        payload = json.dumps({"ok": True, "version": "v2.4.0"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_args) -> None:
+        pass
+
+
+class _QuietHTTPServer(ThreadingHTTPServer):
+    def handle_error(self, request, client_address) -> None:  # noqa: N802 - stdlib signature
+        pass  # TLS 探测打到明文端口（或反之）是这些测试的正常路径
+
+
+def _generate_self_signed() -> tuple[bytes, bytes, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "diceframe-health-test")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    fingerprint = certificate.fingerprint(hashes.SHA256()).hex().upper()
+    return cert_pem, key_pem, fingerprint
+
+
+@contextlib.contextmanager
+def _health_server(tmp_path: Path, *, tls: bool):
+    fingerprint = ""
+    server = _QuietHTTPServer(("127.0.0.1", 0), _HealthHandler)
+    if tls:
+        cert_pem, key_pem, fingerprint = _generate_self_signed()
+        cert_file = tmp_path / "server.crt"
+        key_file = tmp_path / "server.key"
+        cert_file.write_bytes(cert_pem)
+        key_file.write_bytes(key_pem)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(str(cert_file), str(key_file))
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield SimpleNamespace(port=server.server_address[1], fingerprint=fingerprint)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _launcher_with_data(tmp_path: Path, data_dir: Path) -> DockerLauncher:
+    launcher = DockerLauncher(
+        tmp_path / "runtime", tmp_path / "seed.zip", tmp_path / "seed.sha256",
+        data_dir=data_dir,
+    )
+    launcher.child = SimpleNamespace(poll=lambda: None)
+    return launcher
+
+
+def test_resolve_health_endpoint_follows_transport_config(tmp_path):
+    data_dir = tmp_path / "data"
+
+    assert _resolve_health_endpoint(data_dir, {}) == ("http", "")
+
+    _write_transport_config(data_dir, "self_signed", fingerprint="AA:BB:CC:DD\n")
+    assert _resolve_health_endpoint(data_dir, {}) == ("https", "AABBCCDD")
+
+    _write_transport_config(data_dir, "self_signed", fingerprint=None)
+    assert _resolve_health_endpoint(data_dir, {}) == ("http", "")
+
+    _write_transport_config(data_dir, "self_signed", fingerprint="   \n")
+    assert _resolve_health_endpoint(data_dir, {}) == ("http", "")
+
+    _write_transport_config(data_dir, "lets_encrypt")
+    assert _resolve_health_endpoint(data_dir, {}) == ("https", "")
+
+    _write_transport_config(data_dir, "off")
+    assert _resolve_health_endpoint(data_dir, {}) == ("http", "")
+
+    (data_dir / "config.json").write_text(
+        json.dumps({"web_transport": "not-a-dict"}), encoding="utf-8",
+    )
+    assert _resolve_health_endpoint(data_dir, {}) == ("http", "")
+
+
+def test_resolve_health_endpoint_env_override_wins(tmp_path):
+    data_dir = tmp_path / "data"
+    _write_transport_config(data_dir, "self_signed", fingerprint="AABB")
+    assert _resolve_health_endpoint(
+        data_dir, {"TRPG_DOCKER_HEALTH_SCHEME": "http"}
+    ) == ("http", "")
+    assert _resolve_health_endpoint(
+        data_dir, {"TRPG_DOCKER_HEALTH_SCHEME": "https"}
+    ) == ("https", "")
+    assert _resolve_health_endpoint(
+        data_dir, {"TRPG_DOCKER_HEALTH_SCHEME": "ftp"}
+    ) == ("https", "AABB")
+
+
+def test_normalized_fingerprint_strips_separators():
+    assert _normalized_fingerprint("ab:cd-ef GH\n") == "ABCDEFGH"
+    assert _normalized_fingerprint("") == ""
+
+
+def test_verify_pinned_certificate_matches_and_rejects():
+    import hashlib
+
+    der = b"certificate-bytes"
+    good = hashlib.sha256(der).hexdigest().upper()
+    _verify_pinned_certificate(der, good)  # 匹配时不抛异常
+    with pytest.raises(ssl.SSLError):
+        _verify_pinned_certificate(der, "00" * 32)
+
+
+def test_launcher_health_falls_back_to_http_when_https_unreachable(monkeypatch, tmp_path):
+    from src.docker_launcher.launcher import _PinnedHTTPSHandler
+
+    data_dir = tmp_path / "data"
+    _write_transport_config(data_dir, "self_signed", fingerprint="AA" * 32)
+    launcher = _launcher_with_data(tmp_path, data_dir)
+
+    http_urls: list[str] = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"ok": true, "version": "2.4.0"}'
+
+    captured_handlers: list = []
+
+    def fake_build_opener(*handlers):
+        captured_handlers.extend(handlers)
+
+        def _raise(_url, timeout):
+            raise OSError("TLS nowhere")
+
+        return SimpleNamespace(open=_raise)
+
+    def fake_urlopen(url, timeout):
+        http_urls.append(url)
+        return Response()
+
+    monkeypatch.setattr("src.docker_launcher.launcher.urllib.request.build_opener", fake_build_opener)
+    monkeypatch.setattr("src.docker_launcher.launcher.urllib.request.urlopen", fake_urlopen)
+
+    assert launcher._health("2.4.0") is True
+    assert http_urls == ["http://127.0.0.1:9876/api/system/update/health"]
+    assert isinstance(captured_handlers[0], _PinnedHTTPSHandler)
+
+
+def test_launcher_health_accepts_pinned_self_signed_https(tmp_path):
+    data_dir = tmp_path / "data"
+    launcher = _launcher_with_data(tmp_path, data_dir)
+
+    with _health_server(tmp_path, tls=True) as server:
+        fingerprint = server.fingerprint
+        colon_fingerprint = ":".join(fingerprint[i:i + 2] for i in range(0, len(fingerprint), 2))
+        _write_transport_config(data_dir, "self_signed", fingerprint=colon_fingerprint + "\n")
+        assert fingerprint == _normalized_fingerprint(colon_fingerprint)
+        launcher.port = server.port
+        assert launcher._health("2.4.0") is True
+        assert launcher._last_health_error == ""
+
+
+def test_launcher_health_rejects_mismatched_fingerprint(tmp_path):
+    data_dir = tmp_path / "data"
+    _write_transport_config(data_dir, "self_signed", fingerprint="BB" * 32)
+    launcher = _launcher_with_data(tmp_path, data_dir)
+
+    with _health_server(tmp_path, tls=True) as server:
+        launcher.port = server.port
+        assert launcher._health("2.4.0") is False
+
+
+def test_launcher_health_survives_degraded_http_fallback(tmp_path):
+    """配置声称 self_signed，但服务端证书加载失败回退 HTTP（原始 bug 场景）。"""
+    data_dir = tmp_path / "data"
+    _write_transport_config(data_dir, "self_signed", fingerprint="AA" * 32)
+    launcher = _launcher_with_data(tmp_path, data_dir)
+
+    with _health_server(tmp_path, tls=False) as server:
+        launcher.port = server.port
+        assert launcher._health("2.4.0") is True


### PR DESCRIPTION
## 背景

Docker launcher 的健康探测硬编码 `http://`。启用自签 HTTPS 后，探测必然失败：launcher 在 60s 启动超时后杀掉应用进程，容器退出，`restart: unless-stopped` 造成无限重启循环（运行日志表现为每隔约 58 秒一次「Lorebook 数据库已关闭」→ 重启）。

## 改动

- **健康探测适配 Web Transport 配置**（`_resolve_health_endpoint`）：
  - `off`：维持原 http 探测；
  - `self_signed`：https 探测，证书按 `certs/self-signed/fingerprint.txt` 指纹固定（与 Windows launcher `ResolveServerEndpoint` 同一契约，不做裸信任）；
  - `lets_encrypt`：https 探测，验证证书链（回环探测关闭主机名校验）；
  - https 失败时自动 http 兜底一次，覆盖服务端证书加载失败降级 HTTP 的场景；
  - 新增 `TRPG_DOCKER_HEALTH_SCHEME` 环境变量可强制指定探测 scheme。
- **镜像默认时区 Asia/Shanghai**：Debian slim 不带 tzdata，补装并把 `TZ` 烘进镜像 ENV；`-e TZ=...` 或 `.env` 可覆盖（docker-compose.yml 与 .env.example 已同步文档）。

## 测试

- 新增 8 个用例，含真实自签证书 TLS 集成测试（指纹匹配通过 / 不匹配拒绝 / HTTP 降级兜底）；
- 全仓 `pytest`：1530 passed, 1 skipped；
- `ruff` / `compileall` 通过。