### PR TITLE
style(settings): align generation param inputs and unit columns

### DIFF
--- a/frontend-v2/src/styles/v2/settings-status.css
+++ b/frontend-v2/src/styles/v2/settings-status.css
@@ -322,6 +322,13 @@
   font-size: 11px;
 }
 
+/* 单位列定宽：每行 .advanced-row 是独立 grid，第二列按内容自适应，
+   单位文字宽窄不一（秒 / Token）会让各行输入框与单位的横向位置漂移。
+   固定单位列宽度后所有行共享同一列边界，输入框与单位纵向对齐。 */
+.token-input-wrap > span {
+  min-width: 42px;
+}
+
 .advanced-save-row {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## 问题

设置 → 高级参数 → 生成参数的数字步进器各行横向不对齐（单位 秒 / Token 位置漂移，见截图）。

## 原因

每行 `.advanced-row` 是独立 grid，第二列 `auto` 按内容自适应：列宽 = 输入框 150px + 间隙 9px + 单位文字宽度。"秒"和"Token"宽窄不一，导致各行的输入框左缘与单位位置随标签宽度漂移。

## 修复

给 `.token-input-wrap > span`（单位列）固定 `min-width: 42px`，所有行共享同一列边界，输入框与单位纵向对齐。纯 CSS，不影响移动端（play-cinematic 的 width:100% 覆盖仍然生效）。