### PR TITLE
style(base): checkboxes and radios as native compact controls (once for all pages)

### DIFF
--- a/frontend-v2/src/styles/v2/base.css
+++ b/frontend-v2/src/styles/v2/base.css
@@ -150,6 +150,22 @@ select {
   background: var(--df-control-bg);
 }
 
+/* 勾选框/单选框是原生紧凑控件：旧全局规则（styles.css 的
+   input{width:100%;border;padding}）把每个勾渲染成满宽大框，
+   各页面曾被迫逐处手写 width:auto/16px/22px 补救。本规则在
+   设计系统层一次声明，特异性高于元素选择器，覆盖全部现有与
+   未来的 checkbox/radio；个别页面的定制尺寸（如 22px 方块）
+   仍按原样生效。 */
+input[type='checkbox'],
+input[type='radio'] {
+  width: auto;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  accent-color: var(--df-accent);
+}
+
 input:focus,
 textarea:focus,
 select:focus {


### PR DESCRIPTION
## 问题

「共享给全队」这类勾选框站位极宽：老全局规则 `styles.css` 的 `input,textarea,select{width:100%;border;padding:8px 10px}` 把**所有** input（含 checkbox/radio）按文本输入框渲染。各页面被迫逐处手修：create.css、peer.css 的 `width:auto`、ProfessionalCharacterCenter 的 16px、AdvancementPanel 的 22px。没修到的页面一直是坏的：KP 提问弹窗的共享勾、酒馆导入 radio、dnd2024 建卡 radio、markdown 任务列表勾。

## 修复（一劳永逸）

在 v2 设计系统层 `base.css` 声明一次：checkbox/radio 保持原生紧凑尺寸、去边框去内边距、`accent-color: var(--df-accent)` 主题着色。特异性高于元素选择器，全量生效；个别页面定制尺寸仍按原样生效。纯 CSS 单文件改动。