### PR TITLE
style(characters): align library card action rows across rule types

### DIFF
--- a/frontend-v2/src/styles/v2/characters.css
+++ b/frontend-v2/src/styles/v2/characters.css
@@ -249,6 +249,12 @@
   background: linear-gradient(145deg, var(--df-surface-2), var(--df-surface-1));
 }
 
+/* 职业卡（5E 2024 等）比普通卡多「职业升级/高级角色中心」按钮，动作区会折行；
+   把动作区钉在卡片底部，折行向上生长，各卡的按钮行保持同一底边。 */
+.library-character-card .actions {
+  margin-top: auto;
+}
+
 .library-character-card .character-card-summary {
   align-items: flex-start;
 }


### PR DESCRIPTION
## 问题

共享角色卡库中，5E 2024 SRD 等职业规则的卡片比普通卡多两个动作按钮（职业升级、高级角色中心），`.actions` 折成两行；其余卡只有一行。网格等高拉伸下，各卡「删除」按钮高度参差（见截图第三张卡）。

## 修复

`.library-character-card .actions { margin-top: auto }`——动作区钉在卡片底边，职业卡的折行向上生长，所有卡的按钮行共享同一底边。纯 CSS 一条规则；卡片本体已是 flex column，无需其他改动。

## 验证

worktree 内 `npm ci` 后全量 vitest：75 文件 / 341 tests 全过。