### PR TITLE
style(lorebook): perspective filters live in the inspector; drawer stays shut on phones

### DIFF
--- a/frontend-v2/src/features/lorebook/LorePerspectiveInspector.vue
+++ b/frontend-v2/src/features/lorebook/LorePerspectiveInspector.vue
@@ -13,9 +13,14 @@ defineProps<{
   previewError: string
   selectedEntry: LoreEntry | null
   selectedProjection: LoreProjection | null
+  filter: 'all' | 'visible' | 'hidden'
 }>()
 
-const emit = defineEmits<{ (e: 'select-viewer', viewer: string): void; (e: 'close'): void }>()
+const emit = defineEmits<{
+  (e: 'select-viewer', viewer: string): void
+  (e: 'select-filter', filter: 'all' | 'visible' | 'hidden'): void
+  (e: 'close'): void
+}>()
 const { t } = useLocale()
 
 function playerLabel(p: Player): string {
@@ -45,6 +50,15 @@ function playerLabel(p: Player): string {
       </div>
       <p v-if="characterViewerLocked" class="muted small">{{ t(lockedReason === 'peer' ? 'loreViewerLockedPeer' : 'loreViewerLockedStandalone') }}</p>
       <p v-else-if="viewerFallback" class="muted small">{{ t('loreViewerFallbackHint') }}</p>
+    </section>
+
+    <section class="lore-inspector-block">
+      <span class="lore-inspector-label">{{ t('loreFilterLabel') }}</span>
+      <div class="lore-filter-options" role="group" :aria-label="t('loreFilterLabel')">
+        <button :class="{ active: filter === 'all' }" @click="emit('select-filter', 'all')">{{ t('loreFilterAll') }}</button>
+        <button :class="{ active: filter === 'visible' }" @click="emit('select-filter', 'visible')">{{ t('loreSummaryVisible') }}</button>
+        <button :class="{ active: filter === 'hidden' }" @click="emit('select-filter', 'hidden')">{{ t('loreFilterHidden') }}</button>
+      </div>
     </section>
 
     <section class="lore-inspector-block">

--- a/frontend-v2/src/features/lorebook/LorebookView.vue
+++ b/frontend-v2/src/features/lorebook/LorebookView.vue
@@ -71,11 +71,6 @@ function toggleEntrySelection(entry: LoreEntry) {
 }
 
 const perspectiveFilter = ref<'all' | 'visible' | 'hidden'>('all')
-const perspectiveFilters = computed(() => [
-  { id: 'all' as const, label: t('loreFilterAll') },
-  { id: 'visible' as const, label: t('loreSummaryVisible') },
-  { id: 'hidden' as const, label: t('loreFilterHidden') },
-])
 function matchesPerspectiveFilter(entry: LoreEntry): boolean {
   if (perspectiveFilter.value === 'all') return true
   const visible = projectionOf(entry.id)?.visible || false
@@ -83,9 +78,10 @@ function matchesPerspectiveFilter(entry: LoreEntry): boolean {
 }
 
 function resolveInspectorOpen(): boolean {
+  // 「收起」的选择在任何屏宽都尊重；「展开」只在宽屏生效——
+  // 否则宽屏上随手展开一次，手机每次进页面都会被抽屉自动遮挡。
   const saved = localStorage.getItem('lore_inspector_open')
-  if (saved) return saved === '1'
-  // 宽屏常驻展开；窄屏默认收起，避免一进页面就被抽屉盖住一半。
+  if (saved === '0') return false
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true
   return !window.matchMedia('(max-width: 1100px)').matches
 }
@@ -378,15 +374,6 @@ async function importLore(e: Event) {
       </button>
     </div>
 
-    <div v-if="entries.length" class="lore-viewer-filter" role="group" :aria-label="t('loreViewerLabel')">
-      <button
-        v-for="f in perspectiveFilters"
-        :key="f.id"
-        :class="{ active: perspectiveFilter === f.id }"
-        @click="perspectiveFilter = f.id"
-      >{{ f.label }}</button>
-    </div>
-
     <div v-if="loreSections.length" class="lore-categories">
       <section v-for="section in loreSections" :key="section.type" class="lore-category-section">
         <header class="lore-category-head">
@@ -470,7 +457,9 @@ async function importLore(e: Event) {
         :preview-error="previewError"
         :selected-entry="selectedEntry"
         :selected-projection="selectedProjection"
+        :filter="perspectiveFilter"
         @select-viewer="setViewer"
+        @select-filter="perspectiveFilter = $event"
         @close="inspectorOpen = false"
       />
     </div>

--- a/frontend-v2/src/features/lorebook/LorebookView.vue
+++ b/frontend-v2/src/features/lorebook/LorebookView.vue
@@ -80,15 +80,31 @@ function matchesPerspectiveFilter(entry: LoreEntry): boolean {
 function resolveInspectorOpen(): boolean {
   // 「收起」的选择在任何屏宽都尊重；「展开」只在宽屏生效——
   // 否则宽屏上随手展开一次，手机每次进页面都会被抽屉自动遮挡。
-  const saved = localStorage.getItem('lore_inspector_open')
+  let saved: string | null = null
+  try {
+    saved = localStorage.getItem('lore_inspector_open')
+  } catch {
+    return true
+  }
   if (saved === '0') return false
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true
   return !window.matchMedia('(max-width: 1100px)').matches
 }
 const inspectorOpen = ref(resolveInspectorOpen())
+function persistInspectorOpen(open: boolean) {
+  try {
+    localStorage.setItem('lore_inspector_open', open ? '1' : '0')
+  } catch {
+    // storage 不可用时仅当前 session 生效
+  }
+}
 function toggleInspector() {
   inspectorOpen.value = !inspectorOpen.value
-  localStorage.setItem('lore_inspector_open', inspectorOpen.value ? '1' : '0')
+  persistInspectorOpen(inspectorOpen.value)
+}
+function closeInspector() {
+  inspectorOpen.value = false
+  persistInspectorOpen(false)
 }
 
 function worldIdOf(w: WorldSummary | undefined): string { return String(w?.id || w?.world_id || '') }
@@ -445,7 +461,7 @@ async function importLore(e: Event) {
       <template #actions><button @click="loreEdit = null">{{ t('cancel') }}</button><button class="primary" @click="saveLore">{{ t('saveAction') }}</button></template>
     </Modal>
       </main>
-      <div v-if="inspectorOpen" class="lore-inspector-backdrop" @click="inspectorOpen = false"></div>
+      <div v-if="inspectorOpen" class="lore-inspector-backdrop" @click="closeInspector"></div>
       <LorePerspectiveInspector
         v-if="inspectorOpen"
         :players="players"
@@ -460,7 +476,7 @@ async function importLore(e: Event) {
         :filter="perspectiveFilter"
         @select-viewer="setViewer"
         @select-filter="perspectiveFilter = $event"
-        @close="inspectorOpen = false"
+        @close="closeInspector"
       />
     </div>
   </section>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -54,6 +54,7 @@ export const en = {
   lorePerspectiveTitle: 'Perspective & Visibility',
   loreInspectorToggle: 'Perspective',
   loreViewerLabel: 'Current perspective',
+  loreFilterLabel: 'Entry filter',
   loreViewerGm: 'GM omniscient',
   loreViewerParty: 'Whole party',
   loreViewerLockedStandalone: 'No save connected, so character perspectives are unavailable.',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -54,6 +54,7 @@ export const ja = {
   lorePerspectiveTitle: '視点と可視性',
   loreInspectorToggle: '視点',
   loreViewerLabel: '現在の視点',
+  loreFilterLabel: '項目フィルター',
   loreViewerGm: 'GM 全知',
   loreViewerParty: 'パーティ全体',
   loreViewerLockedStandalone: 'セーブ未接続のため、キャラクター視点は利用できません。',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -54,6 +54,7 @@ export const zhCN = {
   lorePerspectiveTitle: '视角与可见性',
   loreInspectorToggle: '视角',
   loreViewerLabel: '当前视角',
+  loreFilterLabel: '条目筛选',
   loreViewerGm: 'GM 全知',
   loreViewerParty: '全队',
   loreViewerLockedStandalone: '未连接存档，暂不支持角色视角。',

--- a/frontend-v2/src/styles/v2/lorebook2.css
+++ b/frontend-v2/src/styles/v2/lorebook2.css
@@ -119,15 +119,14 @@
   word-break: break-word;
 }
 
-/* 视角过滤段与可见性徽标 */
-.lore-viewer-filter {
+/* 视角筛选段（渲染在「视角与可见性」检查器内）与可见性徽标 */
+.lore-filter-options {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-top: 8px;
 }
 
-.lore-viewer-filter button {
+.lore-filter-options button {
   padding: 4px 10px;
   font-size: 12px;
 }

--- a/frontend-v2/tests/LorePerspectiveInspector.test.ts
+++ b/frontend-v2/tests/LorePerspectiveInspector.test.ts
@@ -29,6 +29,7 @@ function factory(overrides: Record<string, unknown> = {}) {
       previewError: '',
       selectedEntry: null,
       selectedProjection: null,
+      filter: 'all',
       ...overrides,
     },
   })
@@ -46,6 +47,16 @@ describe('LorePerspectiveInspector', () => {
 
     await buttons[2].trigger('click')
     expect(wrapper.emitted('select-viewer')).toEqual([['u1']])
+  })
+
+  it('filters entries from inside the inspector', async () => {
+    const wrapper = factory({ filter: 'visible' })
+    const filterButtons = wrapper.findAll('.lore-filter-options button')
+    expect(filterButtons.map(b => b.text())).toEqual(['全部条目', '此视角可见', '此视角未知'])
+    expect(filterButtons[1].classes()).toContain('active')
+
+    await filterButtons[2].trigger('click')
+    expect(wrapper.emitted('select-filter')).toEqual([['hidden']])
   })
 
   it('marks the current viewer active', () => {

--- a/frontend-v2/tests/LorebookView.test.ts
+++ b/frontend-v2/tests/LorebookView.test.ts
@@ -165,7 +165,7 @@ describe('LorebookView perspective inspector', () => {
     await flushPromises()
     expect(wrapper.findAll('.lore-row')).toHaveLength(3)
 
-    const filterButtons = wrapper.findAll('.lore-viewer-filter button')
+    const filterButtons = wrapper.findAll('.lore-filter-options button')
     await filterButtons.find(b => b.text() === '此视角可见')!.trigger('click')
     expect(wrapper.findAll('.lore-row')).toHaveLength(1)
     expect(wrapper.find('.lore-row').text()).toContain('城门守卫')

--- a/frontend-v2/tests/LorebookView.test.ts
+++ b/frontend-v2/tests/LorebookView.test.ts
@@ -121,6 +121,43 @@ describe('LorebookView perspective inspector', () => {
     expect(wrapper.find('.lore-perspective-inspector').exists()).toBe(false)
   })
 
+  it('persists a manual close across remounts', async () => {
+    const first = mountView()
+    await flushPromises()
+    expect(first.find('.lore-perspective-inspector').exists()).toBe(true)
+
+    await first.find('.lore-inspector-close').trigger('click')
+    expect(first.find('.lore-perspective-inspector').exists()).toBe(false)
+    expect(localStorage.getItem('lore_inspector_open')).toBe('0')
+    first.unmount()
+
+    const second = mountView()
+    await flushPromises()
+    expect(second.find('.lore-perspective-inspector').exists()).toBe(false)
+    second.unmount()
+  })
+
+  it('does not auto-open on narrow screens even with a saved open', async () => {
+    localStorage.setItem('lore_inspector_open', '1')
+    stubNarrowViewport()
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.lore-perspective-inspector').exists()).toBe(false)
+  })
+
+  it('keeps mounting and closing when localStorage writes are rejected', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage denied')
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.lore-perspective-inspector').exists()).toBe(true)
+    await wrapper.find('.lore-inspector-close').trigger('click')
+    expect(wrapper.find('.lore-perspective-inspector').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('renders audience badges and the summary from backend projections only', async () => {
     const wrapper = mountView()
     await flushPromises()


### PR DESCRIPTION
叠在 #167 之上的跟进（base 为 feat/webui-lorebook-perspective-inspector，#167 合并后自动改指 main）。

## 改动

1. **条目筛选移进检查器**：「全部条目 / 此视角可见 / 此视角未知」从列表工具栏移入「视角与可见性」面板，紧挨它们依赖的视角选择。状态仍在视图层（检查器新增 `filter` prop + `select-filter` 事件），列表过滤逻辑不变。
2. **窄屏不再自动弹出抽屉**：`resolveInspectorOpen` 改为——「收起」在任何屏宽都被尊重；保存过的「展开」只在宽屏（>1100px）生效。修复宽屏上随手展开一次之后，手机每次进页面都被抽屉自动遮挡的问题。

## 验证

- vitest 78 文件 / 361 tests 全过（含更新后的视图测试与新增的检查器筛选测试）；
- vue-tsc 0 错；eslint 干净。