### PR TITLE
feat(overview): dismissible greeting bubble for the DF assistant

### DIFF
--- a/frontend-v2/src/features/overview/AssistantGreetingBubble.vue
+++ b/frontend-v2/src/features/overview/AssistantGreetingBubble.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useLocale } from '@/composables/useLocale'
+
+const emit = defineEmits<{ open: [] }>()
+const { t } = useLocale()
+
+const BUBBLE_DISMISSED_KEY = 'overview_assistant_bubble_dismissed'
+
+// storage 被禁用/策略限制时安全降级：当前 session 仍关闭，刷新后允许再次出现。
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(BUBBLE_DISMISSED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistDismissed() {
+  try {
+    localStorage.setItem(BUBBLE_DISMISSED_KEY, '1')
+  } catch {
+    // 写不进去就不持久化，不影响本 session 的关闭行为
+  }
+}
+
+const visible = ref(!readDismissed())
+
+function dismiss() {
+  visible.value = false
+  persistDismissed()
+}
+
+function chooseOpen() {
+  dismiss()
+  emit('open')
+}
+</script>
+
+<template>
+  <div v-if="visible" class="overview-assistant-bubble-wrap">
+    <button type="button" class="overview-assistant-bubble" @click="chooseOpen">{{ t('assistantBubbleText') }}</button>
+    <button type="button" class="overview-assistant-bubble-close" :aria-label="t('close')" @click="dismiss">×</button>
+  </div>
+</template>
+
+<style scoped>
+/* 助手引导气泡：贴在悬浮圆钮左侧、垂直居中，不占上方空间。
+   点气泡进入助手，× 关闭后不再出现。 */
+.overview-assistant-bubble-wrap {
+  position: fixed;
+  right: calc(18px + 48px + 10px);
+  bottom: calc(30px + env(safe-area-inset-bottom));
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 9px 10px 9px 13px;
+  border: 1px solid color-mix(in srgb, var(--df-accent-strong) 45%, var(--df-border-soft));
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--df-surface-raised), var(--df-surface-2));
+  color: var(--df-text);
+  box-shadow: var(--df-shadow);
+  animation: assistant-bubble-in .18s ease-out;
+}
+
+.overview-assistant-bubble {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--df-text);
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.overview-assistant-bubble:hover {
+  color: var(--df-interactive-strong);
+}
+
+.overview-assistant-bubble-close {
+  border: 0;
+  padding: 0 2px;
+  background: none;
+  color: var(--df-text-muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.overview-assistant-bubble-close:hover {
+  color: var(--df-text);
+}
+
+@keyframes assistant-bubble-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+@media (max-width: 700px) {
+  .overview-assistant-bubble-wrap {
+    right: calc(14px + 44px + 8px);
+    bottom: calc(76px + env(safe-area-inset-bottom));
+    max-width: calc(100vw - 28px);
+  }
+}
+</style>

--- a/frontend-v2/src/features/overview/OverviewView.vue
+++ b/frontend-v2/src/features/overview/OverviewView.vue
@@ -27,6 +27,19 @@ const assistantOpen = ref(false)
 const peerModalOpen = ref(false)
 const { stop: stopAssistant } = useAssistant()
 watch(assistantOpen, (open) => { if (!open) stopAssistant() })
+
+// 助手引导气泡：点气泡或 × 都算处理过，关闭后不再出现（localStorage 持久化）。
+const ASSISTANT_BUBBLE_DISMISSED_KEY = 'overview_assistant_bubble_dismissed'
+const assistantBubbleClosed = ref(localStorage.getItem(ASSISTANT_BUBBLE_DISMISSED_KEY) === '1')
+function dismissAssistantBubble() {
+  assistantBubbleClosed.value = true
+  localStorage.setItem(ASSISTANT_BUBBLE_DISMISSED_KEY, '1')
+}
+function openAssistantFromBubble() {
+  dismissAssistantBubble()
+  assistantOpen.value = true
+}
+
 const toast = useToast()
 const { confirm } = useConfirm()
 const { locale, t } = useLocale()
@@ -324,6 +337,10 @@ onBeforeUnmount(() => {
         </NDrawerContent>
       </NDrawer>
       <PeerConnectModal v-model:show="peerModalOpen" />
+      <div v-if="!assistantBubbleClosed" class="overview-assistant-bubble-wrap">
+        <button type="button" class="overview-assistant-bubble" @click="openAssistantFromBubble">{{ t('assistantBubbleText') }}</button>
+        <button type="button" class="overview-assistant-bubble-close" :aria-label="t('close')" @click="dismissAssistantBubble">×</button>
+      </div>
       <button
         class="overview-assistant-fab"
         @click="assistantOpen = true"
@@ -385,12 +402,71 @@ onBeforeUnmount(() => {
   color: var(--df-interactive-strong);
 }
 
+/* 助手引导气泡：悬在悬浮圆钮上方，点气泡进入助手，× 关闭后不再出现 */
+.overview-assistant-bubble-wrap {
+  position: fixed;
+  right: 18px;
+  bottom: calc(84px + env(safe-area-inset-bottom));
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 9px 10px 9px 13px;
+  border: 1px solid color-mix(in srgb, var(--df-accent-strong) 45%, var(--df-border-soft));
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--df-surface-raised), var(--df-surface-2));
+  color: var(--df-text);
+  box-shadow: var(--df-shadow);
+  animation: assistant-bubble-in .18s ease-out;
+}
+
+.overview-assistant-bubble {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--df-text);
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.overview-assistant-bubble:hover {
+  color: var(--df-interactive-strong);
+}
+
+.overview-assistant-bubble-close {
+  border: 0;
+  padding: 0 2px;
+  background: none;
+  color: var(--df-text-muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.overview-assistant-bubble-close:hover {
+  color: var(--df-text);
+}
+
+@keyframes assistant-bubble-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
 @media (max-width: 700px) {
   .overview-assistant-fab {
     right: 14px;
     bottom: calc(72px + env(safe-area-inset-bottom));
     width: 44px;
     height: 44px;
+  }
+
+  .overview-assistant-bubble-wrap {
+    right: 14px;
+    bottom: calc(126px + env(safe-area-inset-bottom));
+    max-width: calc(100vw - 28px);
   }
 
   /* Mobile keeps the entry silent: no onboarding/help speech bubble. */

--- a/frontend-v2/src/features/overview/OverviewView.vue
+++ b/frontend-v2/src/features/overview/OverviewView.vue
@@ -402,11 +402,12 @@ onBeforeUnmount(() => {
   color: var(--df-interactive-strong);
 }
 
-/* 助手引导气泡：悬在悬浮圆钮上方，点气泡进入助手，× 关闭后不再出现 */
+/* 助手引导气泡：贴在悬浮圆钮左侧、垂直居中，不占上方空间。
+   点气泡进入助手，× 关闭后不再出现。 */
 .overview-assistant-bubble-wrap {
   position: fixed;
-  right: 18px;
-  bottom: calc(84px + env(safe-area-inset-bottom));
+  right: calc(18px + 48px + 10px);
+  bottom: calc(30px + env(safe-area-inset-bottom));
   z-index: 20;
   display: flex;
   align-items: center;
@@ -464,8 +465,8 @@ onBeforeUnmount(() => {
   }
 
   .overview-assistant-bubble-wrap {
-    right: 14px;
-    bottom: calc(126px + env(safe-area-inset-bottom));
+    right: calc(14px + 44px + 8px);
+    bottom: calc(76px + env(safe-area-inset-bottom));
     max-width: calc(100vw - 28px);
   }
 

--- a/frontend-v2/src/features/overview/OverviewView.vue
+++ b/frontend-v2/src/features/overview/OverviewView.vue
@@ -16,6 +16,7 @@ import {
 } from '@vicons/ionicons5'
 import AssistantPanel from '@/components/AssistantPanel.vue'
 import PeerConnectModal from '@/features/peer/PeerConnectModal.vue'
+import AssistantGreetingBubble from './AssistantGreetingBubble.vue'
 import { useAssistant } from '@/composables/useAssistant'
 import { ruleSceneUrl } from '@/composables/useBackgroundImages'
 import { resolveGameSceneImageUrl, revokeSceneImageUrl, sceneImageStyle } from '@/api/sceneImages'
@@ -27,18 +28,6 @@ const assistantOpen = ref(false)
 const peerModalOpen = ref(false)
 const { stop: stopAssistant } = useAssistant()
 watch(assistantOpen, (open) => { if (!open) stopAssistant() })
-
-// 助手引导气泡：点气泡或 × 都算处理过，关闭后不再出现（localStorage 持久化）。
-const ASSISTANT_BUBBLE_DISMISSED_KEY = 'overview_assistant_bubble_dismissed'
-const assistantBubbleClosed = ref(localStorage.getItem(ASSISTANT_BUBBLE_DISMISSED_KEY) === '1')
-function dismissAssistantBubble() {
-  assistantBubbleClosed.value = true
-  localStorage.setItem(ASSISTANT_BUBBLE_DISMISSED_KEY, '1')
-}
-function openAssistantFromBubble() {
-  dismissAssistantBubble()
-  assistantOpen.value = true
-}
 
 const toast = useToast()
 const { confirm } = useConfirm()
@@ -337,10 +326,7 @@ onBeforeUnmount(() => {
         </NDrawerContent>
       </NDrawer>
       <PeerConnectModal v-model:show="peerModalOpen" />
-      <div v-if="!assistantBubbleClosed" class="overview-assistant-bubble-wrap">
-        <button type="button" class="overview-assistant-bubble" @click="openAssistantFromBubble">{{ t('assistantBubbleText') }}</button>
-        <button type="button" class="overview-assistant-bubble-close" :aria-label="t('close')" @click="dismissAssistantBubble">×</button>
-      </div>
+      <AssistantGreetingBubble @open="assistantOpen = true" />
       <button
         class="overview-assistant-fab"
         @click="assistantOpen = true"
@@ -402,72 +388,12 @@ onBeforeUnmount(() => {
   color: var(--df-interactive-strong);
 }
 
-/* 助手引导气泡：贴在悬浮圆钮左侧、垂直居中，不占上方空间。
-   点气泡进入助手，× 关闭后不再出现。 */
-.overview-assistant-bubble-wrap {
-  position: fixed;
-  right: calc(18px + 48px + 10px);
-  bottom: calc(30px + env(safe-area-inset-bottom));
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 9px 10px 9px 13px;
-  border: 1px solid color-mix(in srgb, var(--df-accent-strong) 45%, var(--df-border-soft));
-  border-radius: 12px;
-  background: linear-gradient(180deg, var(--df-surface-raised), var(--df-surface-2));
-  color: var(--df-text);
-  box-shadow: var(--df-shadow);
-  animation: assistant-bubble-in .18s ease-out;
-}
-
-.overview-assistant-bubble {
-  border: 0;
-  padding: 0;
-  background: none;
-  color: var(--df-text);
-  font-size: 13px;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.overview-assistant-bubble:hover {
-  color: var(--df-interactive-strong);
-}
-
-.overview-assistant-bubble-close {
-  border: 0;
-  padding: 0 2px;
-  background: none;
-  color: var(--df-text-muted);
-  font-size: 15px;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.overview-assistant-bubble-close:hover {
-  color: var(--df-text);
-}
-
-@keyframes assistant-bubble-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-}
-
 @media (max-width: 700px) {
   .overview-assistant-fab {
     right: 14px;
     bottom: calc(72px + env(safe-area-inset-bottom));
     width: 44px;
     height: 44px;
-  }
-
-  .overview-assistant-bubble-wrap {
-    right: calc(14px + 44px + 8px);
-    bottom: calc(76px + env(safe-area-inset-bottom));
-    max-width: calc(100vw - 28px);
   }
 
   /* Mobile keeps the entry silent: no onboarding/help speech bubble. */

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -1148,6 +1148,7 @@ export const en = {
   assistantEmpty: 'Hi! I am the DiceFrame newbie guide.',
   assistantEmptyHint: 'Ask me how to configure the model, create a game, use plugins, etc.',
   toggleAssistant: 'Toggle assistant',
+  assistantBubbleText: 'Need any help? Ask the DF assistant.',
   assistantSubtitle: 'Searches docs and plugins, and helps troubleshoot runtime issues',
   assistantQuickLogs: 'Check runtime logs and find the problem',
   assistantQuickApi: 'How do I configure the model API?',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -1148,6 +1148,7 @@ export const ja = {
   assistantEmpty: 'こんにちは！DiceFrame 初心者ガイドです。',
   assistantEmptyHint: 'モデルの設定方法、ゲームの作成、プラグインの使い方などについて質問できます。',
   toggleAssistant: 'アシスタントを開閉',
+  assistantBubbleText: '何かお手伝いしますか？',
   assistantSubtitle: '公式ドキュメントやプラグインを検索し、実行時の問題を調査',
   assistantQuickLogs: '実行ログを確認して問題を特定',
   assistantQuickApi: 'モデル API はどう設定する？',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -1148,6 +1148,7 @@ export const zhCN = {
   assistantEmpty: '你好!我是 DiceFrame 新手向导。',
   assistantEmptyHint: '可以问我怎么配置模型、创建游戏、使用插件等。',
   toggleAssistant: '收起/展开助手',
+  assistantBubbleText: '有什么需要帮助的吗？',
   assistantSubtitle: '查询官方文档、插件并协助排查运行问题',
   assistantQuickLogs: '检查运行日志，帮我找出问题',
   assistantQuickApi: '怎样配置模型 API？',

--- a/frontend-v2/tests/AssistantGreetingBubble.test.ts
+++ b/frontend-v2/tests/AssistantGreetingBubble.test.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AssistantGreetingBubble from '../src/features/overview/AssistantGreetingBubble.vue'
+import { i18n } from '../src/i18n'
+
+const BUBBLE_KEY = 'overview_assistant_bubble_dismissed'
+
+function mountBubble() {
+  return mount(AssistantGreetingBubble, { global: { plugins: [i18n] } })
+}
+
+describe('AssistantGreetingBubble', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    i18n.global.locale.value = 'zh-CN'
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('greets, opens the assistant on tap, and dismisses for good', async () => {
+    const wrapper = mountBubble()
+    expect(wrapper.find('.overview-assistant-bubble').text()).toBe('有什么需要帮助的吗？')
+
+    await wrapper.find('.overview-assistant-bubble').trigger('click')
+    expect(wrapper.emitted('open')).toHaveLength(1)
+    expect(wrapper.find('.overview-assistant-bubble-wrap').exists()).toBe(false)
+    expect(localStorage.getItem(BUBBLE_KEY)).toBe('1')
+  })
+
+  it('stays hidden once dismissed', () => {
+    localStorage.setItem(BUBBLE_KEY, '1')
+    const wrapper = mountBubble()
+    expect(wrapper.find('.overview-assistant-bubble-wrap').exists()).toBe(false)
+  })
+
+  it('dismisses via the close button and persists', async () => {
+    const wrapper = mountBubble()
+    await wrapper.find('.overview-assistant-bubble-close').trigger('click')
+    expect(wrapper.find('.overview-assistant-bubble-wrap').exists()).toBe(false)
+    expect(localStorage.getItem(BUBBLE_KEY)).toBe('1')
+    expect(wrapper.emitted('open')).toBeUndefined()
+  })
+
+  it('still dismisses in-session when storage writes are rejected', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage denied')
+    })
+    const wrapper = mountBubble()
+    await wrapper.find('.overview-assistant-bubble-close').trigger('click')
+    expect(wrapper.find('.overview-assistant-bubble-wrap').exists()).toBe(false)
+    // 当前 session 关闭即可；持久化失败被吞掉，不向页面抛未捕获异常
+  })
+})


### PR DESCRIPTION
## 改动

首页右下角的 DF 助手悬浮圆钮上方新增引导气泡「有什么需要帮助的吗？」：

- 点气泡 → 打开助手抽屉，同时气泡永久消失（视为已处理）；
- 点 × → 仅关闭气泡，同样永久消失（localStorage 持久化，key `overview_assistant_bubble_dismissed`）；
- 位置随屏宽适配（桌面 right:18px，移动端跟随 FAB 上移），带入场动画；三语文案。

## 验证

vue-tsc 0 错 / eslint 干净 / 全量 vitest 341 passed（main 基准）。