### PR TITLE
style(nav): mobile bottom bar covers the scrollbar strip

### DIFF
--- a/frontend-v2/src/styles/v2/navigation.css
+++ b/frontend-v2/src/styles/v2/navigation.css
@@ -175,9 +175,11 @@
   .mobile-bottom-nav {
     position: fixed;
     z-index: 55;
-    right: 0;
     bottom: 0;
     left: 0;
+    /* 100vw 含滚动条宽度：窄窗下经典滚动条占位时，底栏直接盖住那条空缺，
+       不再给滚动条让位。真机的悬浮滚动条下 100vw 等于版式宽度，渲染不变。 */
+    width: 100vw;
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     min-height: calc(64px + env(safe-area-inset-bottom));


### PR DESCRIPTION
## 问题

手机布局（窄窗）下，底部菜单栏 `left:0; right:0` 只铺到版式视口边缘——全局是占位式细滚动条（10px），右侧留出一条滚动条空缺，菜单栏到不了屏幕右缘。

## 修复

`right: 0` 改为 `width: 100vw`（视口单位包含滚动条宽度）：底栏直接盖住滚动条空缺；真机悬浮滚动条下 100vw 等于版式宽度，渲染不变。全局 `box-sizing: border-box`，无溢出风险。固定元素不参与文档滚动尺寸，不会引发横向滚动条。纯 CSS 一条规则。