### PR TITLE
docs: establish flexible engineering and architecture governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+## Summary
+
+<!-- 这次改动解决什么问题？描述行为，不需要复述所有文件。 -->
+
+## Why
+
+<!-- 为什么需要这样改？如果是明显 bug，可以很简短。 -->
+
+## Impact
+
+只勾选实际受影响的项目：
+
+- [ ] API
+- [ ] Persisted Data / Save / Database
+- [ ] Migration
+- [ ] Compatibility / Breaking Change
+- [ ] Security / Permission / Privacy
+- [ ] Multiplayer / Actor / Turn Authority
+- [ ] Ruleset Mechanics
+- [ ] Architecture / Dependency Boundary
+- [ ] Plugin / Content / Extension Contract
+- [ ] UI only
+
+## Design / Migration Notes
+
+<!--
+普通 bug / 小功能可以写 N/A。
+
+如果涉及架构变化，请简述 Current -> Proposed。
+如果涉及 persisted data / breaking change，请说明 migration、compatibility、
+version boundary 或明确的 rejection strategy。
+-->
+
+N/A
+
+## Validation
+
+<!-- 列出实际运行或新增的测试。不要写没有运行的测试。 -->
+
+- [ ] Relevant backend tests
+- [ ] Relevant frontend tests
+- [ ] Build / typecheck where applicable
+- [ ] Architecture / security checks where applicable
+- [ ] Manual verification where meaningful
+
+## Contract Check
+
+- [ ] 用户数据不会被无意覆盖或丢失
+- [ ] 权限 / private data 边界未退化
+- [ ] 若改 persisted identity，已处理旧引用
+- [ ] 若改关键产品契约，已更新对应测试 / `docs/testing-contracts.md`
+- [ ] 若架构事实发生变化，已更新 `docs/ARCHITECTURE_*.md`
+
+<!-- 不适用的项可以保持未勾选；这个清单用于提示风险，不是要求每个 PR 全部勾满。 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,25 @@
-# Codex 协作入口
+# Codex / AI 协作入口
 
-架构事实来源：
+修改代码前，按任务范围阅读：
 
-- [docs/ARCHITECTURE_CN.md](docs/ARCHITECTURE_CN.md)
-- [docs/ARCHITECTURE_EN.md](docs/ARCHITECTURE_EN.md)
+1. 架构事实来源：
+   - [docs/ARCHITECTURE_CN.md](docs/ARCHITECTURE_CN.md)
+   - [docs/ARCHITECTURE_EN.md](docs/ARCHITECTURE_EN.md)
+2. 工程修改规则：
+   - [docs/ENGINEERING_RULES.md](docs/ENGINEERING_RULES.md)
+3. 涉及权限、存档、迁移、多人、规则等高风险行为时：
+   - [docs/testing-contracts.md](docs/testing-contracts.md)
+4. 涉及已有重大架构决策时：
+   - [docs/adr/](docs/adr/)
 
-关键规则：不要把翻译后的显示名称当作 identity；V2 不新增后缀全文复制式本地化；兼容逻辑留在 `src/compat/` 或明确的适配边界；Locale 不得改变 canonical identity 或 mechanics；D&D 专属行为不得修改 generic d20。
+关键原则：
+
+- 当前架构是事实来源，不是不可改变的路线图。
+- 可以做大型重构、拆分、迁移和 breaking change；必须显式处理受影响的 contract。
+- 不要把翻译后的 display name 当作 canonical identity。
+- Locale 不得无意改变 mechanics。
+- compatibility 应留在明确边界，不要散回正常业务逻辑。
+- specific ruleset 不应反向污染 generic engine。
+- migration correctness > migration completeness；无法证明安全时 fail closed。
+- 系统模板不得无条件覆盖用户数据。
+- AI 可以改架构，但不能靠猜测创造字段、API 或迁移语义。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,25 @@
-# Architecture Entry Point
+# Architecture & Engineering Entry Point
 
-The architecture source of truth is:
+Before modifying the repository, read the documents relevant to the task:
 
-- [docs/ARCHITECTURE_CN.md](docs/ARCHITECTURE_CN.md)
-- [docs/ARCHITECTURE_EN.md](docs/ARCHITECTURE_EN.md)
+1. Architecture source of truth:
+   - [docs/ARCHITECTURE_CN.md](docs/ARCHITECTURE_CN.md)
+   - [docs/ARCHITECTURE_EN.md](docs/ARCHITECTURE_EN.md)
+2. Engineering change rules:
+   - [docs/ENGINEERING_RULES.md](docs/ENGINEERING_RULES.md)
+3. For permissions, persistence, migrations, multiplayer, rules, or other high-risk contracts:
+   - [docs/testing-contracts.md](docs/testing-contracts.md)
+4. For existing long-lived architecture decisions:
+   - [docs/adr/](docs/adr/)
 
-Keep translated display names separate from identity. Do not add V2 suffix-copy localization, move compatibility into normal business logic, or change generic d20 behavior for D&D-specific features. Locale overlays must preserve canonical identity and mechanics.
+Key principles:
+
+- The current architecture is a source of truth, not an immutable roadmap.
+- Large refactors, module splits, migrations, and intentional breaking changes are allowed when affected contracts are handled explicitly.
+- Keep translated display text separate from canonical identity.
+- Locale must not accidentally change mechanics.
+- Keep compatibility in explicit compatibility/adapter boundaries instead of scattering legacy branches through normal runtime code.
+- Specific rulesets should not leak back into the generic engine.
+- Migration correctness is more important than migration completeness; fail closed when safe conversion cannot be proven.
+- Bundled/system templates must not unconditionally overwrite user data.
+- AI-assisted changes must verify real repository fields and APIs instead of inventing them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,44 @@
 - 插件和内容包请遵循 [插件开发指南](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-development.md) 及 [插件审核规则](https://github.com/diceframe/diceframe-content/blob/main/docs/zh/plugin-registry.md)。
 - Android 客户端在独立仓库 [diceframe-mobile](https://github.com/diceframe/diceframe-mobile)，其 Bug、需求与代码贡献请提交到该仓库；APK 等发布物见 [Releases](https://github.com/diceframe/diceframe-mobile/releases)。
 
+## 架构与工程规范
+
+当前实现的架构事实来源：
+
+- [docs/ARCHITECTURE_CN.md](docs/ARCHITECTURE_CN.md)
+- [docs/ARCHITECTURE_EN.md](docs/ARCHITECTURE_EN.md)
+
+修改代码时遵循：
+
+- [docs/ENGINEERING_RULES.md](docs/ENGINEERING_RULES.md)
+
+关键产品与测试契约：
+
+- [docs/testing-contracts.md](docs/testing-contracts.md)
+
+这些规范不会冻结 DiceFrame 的当前架构。大型功能、模块拆分、迁移、breaking change 和架构重做都允许；要求是明确处理受影响的用户数据、兼容性、权限、持久化 identity、测试和文档。
+
 ## 修改原则
 
-- 保持 Web API 字段向后兼容；前端和未来的 Bot 都可能消费这些接口。
+- 保持 Web API 字段向后兼容；如确需 breaking change，应明确版本、迁移、兼容或拒绝策略。
 - 新功能同时补齐必要的测试、用户手册和迁移说明。
-- 复用现有分层、服务和共享 helper，不在核心层引入 WebUI 依赖。
+- 默认复用现有分层、服务和共享 helper；如现有架构不再合适，可以通过明确的架构改动重新设计。
 - 不提交运行时存档、个人数据、API Key、构建产物或本机配置。
 - 自动化账号（例如 `claude[bot]`、`github-actions[bot]`、`web-flow`）的提交记录保持原样，不通过改作者信息来隐藏或冒充人工贡献。
+
+## Pull Request
+
+DiceFrame 不设置 PR 最大行数或最大文件数。
+
+优先：
+
+> 最小完整改动，而不是最小代码行数。
+
+如果 migration、backend、frontend、tests 和 docs 构成一个不可合理拆分的完整变化，可以放在同一个 PR。
+
+如果两个改动能够独立产生价值、独立验证、独立回滚，则应尽量分开。
+
+PR 模板中的风险勾选用于提醒 reviewer 关注 API、存档、权限、多人、规则和架构等风险面，不是额外审批流程。
 
 ## 本地验证
 
@@ -33,6 +64,12 @@ npm run build
 后端改动请按仓库现有测试配置运行对应的 Python 测试；涉及真实浏览器交互时，再补充 Playwright 验证。
 
 Pull Request 上的 Browser smoke 会保留完整日志，但浏览器或运行环境波动不会单独阻塞贡献；类型检查、单元测试、构建和后端检查仍是合并门槛。合并到 `main` 前会再次严格执行浏览器冒烟。
+
+## AI-assisted development
+
+允许使用 Codex、Claude、ChatGPT 等工具辅助开发。
+
+AI 生成代码与人工代码遵守同样的架构、数据、安全和测试要求。提交者仍需要理解实际改动，并验证 AI 没有凭空创造字段、API、兼容行为或迁移语义。
 
 ## 贡献者名单
 

--- a/docs/ENGINEERING_RULES.md
+++ b/docs/ENGINEERING_RULES.md
@@ -1,0 +1,712 @@
+# DiceFrame Engineering Rules
+
+> 本文规定“如何安全地修改 DiceFrame”，不是冻结当前架构。
+>
+> 当前实现的架构事实来源仍是：
+>
+> - `docs/ARCHITECTURE_CN.md`
+> - `docs/ARCHITECTURE_EN.md`
+>
+> 测试与产品关键契约见：
+>
+> - `docs/testing-contracts.md`
+
+## 1. 目的
+
+DiceFrame 需要同时支持快速增加功能、长期维护旧数据、多人权限隔离、不同规则系统扩展，以及较大的重构和迁移。
+
+因此本规范保护的是：
+
+- 用户数据
+- 权限与隐私
+- 持久化 identity
+- public / extension contracts
+- ruleset mechanics 边界
+- multiplayer authority
+- migration correctness
+- 可验证的产品行为
+
+本规范**不保护**：
+
+- 当前文件路径
+- 当前类名和 helper
+- 当前内部实现
+- 当前模块数量
+- 当前 UI 组织方式
+- 当前技术方案本身
+
+只要受影响的契约被有意识地处理，DiceFrame 允许拆分、合并、迁移、替换甚至重做现有架构。
+
+---
+
+## 2. 规范用语
+
+本文使用：
+
+- **MUST**：默认不可违反的产品/数据/安全要求。
+- **SHOULD**：当前推荐架构或工程做法；有明确理由时可以改变。
+- **MAY**：明确允许的做法。
+
+如果某个改动需要改变 SHOULD 级规则，不视为违规；应在 PR 中说明新的边界，并同步更新架构事实来源。
+
+如果确实需要改变 MUST 级契约，应把它视为显式 breaking / product-contract change，提供版本、迁移、兼容或明确拒绝策略，而不是静默改变。
+
+---
+
+## 3. Architecture is allowed to change
+
+DiceFrame **MAY** 为了新功能、可靠性、性能、安全性、维护性或长期演进：
+
+- 拆分或合并模块；
+- 移动职责；
+- 替换内部实现；
+- 删除已经失去意义的 abstraction；
+- 引入新的 abstraction；
+- 修改持久化模型；
+- 调整 API；
+- 重新组织 runtime / services / frontend；
+- 拆分仓库、package 或 subsystem；
+- 进行跨模块的大型重构。
+
+大型改动不会因为“与当前 `ARCHITECTURE` 不同”而被禁止。
+
+但改动 **MUST** 显式处理它影响到的稳定表面，包括：
+
+- persisted data；
+- compatibility；
+- public / extension API；
+- security / permissions；
+- multiplayer authority；
+- ruleset mechanics；
+- migration；
+- tests；
+- architecture documentation。
+
+合并后，更新过的 `ARCHITECTURE` 才是新的事实来源。
+
+---
+
+## 4. Stable Surface：按稳定表面判断风险
+
+不要按“改了多少行”判断改动危险程度。按它触碰了什么判断。
+
+### Level 0 — Internal implementation
+
+例如：
+
+- 内部 helper；
+- 私有 class；
+- 文件/目录布局；
+- 未对外暴露的内部函数；
+- 内部算法与缓存实现；
+- UI 组件拆分。
+
+这些内容 **MAY** 自由重构。
+
+如果行为契约不变，不需要兼容旧内部实现。
+
+### Level 1 — Architectural boundary
+
+例如：
+
+- route / WebAPI / service / core 的职责边界；
+- ruleset runtime 边界；
+- frontend / backend authority 边界；
+- migration / compatibility 组织方式；
+- subsystem 或 repository 边界。
+
+这些内容 **MAY** 改变。
+
+发生变化时 **SHOULD**：
+
+- 在 PR 中描述 `Current -> Proposed`；
+- 说明为什么现有边界不再合适；
+- 更新 `docs/ARCHITECTURE_*.md`；
+- 若属于长期、有替代方案争议的重要决策，再增加 ADR。
+
+### Level 2 — Public / extension contract
+
+例如：
+
+- Web API；
+- Plugin contract；
+- Content V2；
+- Ruleset Bundle；
+- Adventure Bundle；
+- externally consumed schema；
+- 对 Bot / client 暴露的稳定字段。
+
+这些内容默认 **SHOULD** 保持兼容。
+
+需要 breaking change 时 **MUST**：
+
+- 显式标注；
+- 提供版本边界；
+- 给出 migration / adapter / deprecation / rejection strategy 中至少一种合理方案；
+- 添加对应测试；
+- 更新相关文档。
+
+### Level 3 — Persisted / authority / security contract
+
+例如：
+
+- save；
+- SQLite / persisted state；
+- canonical persisted identity；
+- GM / player / private visibility；
+- actor ownership；
+- multiplayer turn authority；
+- 权威规则状态；
+- 权限与认证边界。
+
+这是最高保护级别。
+
+改变这些内容时 **MUST** 优先保证数据正确性、权限正确性和确定性；不能为了“自动兼容”猜测用户数据。
+
+---
+
+## 5. 用户数据与持久化 identity
+
+### 5.1 用户数据不是系统模板的缓存
+
+系统默认模板和用户数据库是两个不同的 authority。
+
+系统 **MUST NOT** 因为当前 bundled template 发生变化，就无条件覆盖已经存在的用户记录。
+
+允许：
+
+```text
+能够证明仍是旧官方默认值
+→ 有条件升级到新官方默认值
+```
+
+禁止：
+
+```text
+当前模板
+→ 每次启动强制同步/覆盖用户数据库
+```
+
+只要无法证明某条数据仍是系统默认状态，就 **MUST** 按用户数据处理并保留。
+
+### 5.2 Persisted Identity Rule
+
+一旦某个 canonical ID 可能进入以下任一表面：
+
+- save；
+- database；
+- world；
+- lorebook；
+- character；
+- plugin；
+- ruleset；
+- adventure；
+- network payload；
+- externally referenced content；
+
+它就不再只是内部命名。
+
+重命名或删除 persisted identity 时 **MUST** 考虑：
+
+- alias；
+- migration；
+- explicit version boundary；
+- deprecation；
+- explicit rejection。
+
+**MUST NOT** 仅因为“源码里改名更好看”就让旧数据失去引用。
+
+display name / locale text **MUST NOT** 替代 canonical identity。
+
+---
+
+## 6. Migration
+
+### 6.1 默认边界
+
+当前默认：
+
+```text
+persisted schema / persisted state upgrade
+→ src/migrations/
+
+historical external/runtime shape compatibility
+→ src/compat/ 或明确 adapter 边界
+```
+
+这是 **SHOULD**，不是永远不可改变的目录规则。
+
+如果未来重做 migration architecture，可以通过明确的架构改动重新定义。
+
+### 6.2 Migration MUST
+
+Migration **MUST**：
+
+- 幂等；
+- 可测试；
+- 有明确 source version / identity / digest / snapshot 等安全边界；
+- 不无意丢字段；
+- 不无意覆盖用户修改；
+- 对未知未来版本 fail closed；
+- 对部分失败保持可预测行为；
+- 尽可能使用明确、可解释的转换，而不是启发式猜测。
+
+### 6.3 Correctness > completeness
+
+> **Migration correctness is more important than migration completeness.**
+
+如果无法可靠判断旧数据的含义：
+
+允许：
+
+```text
+无法安全自动迁移
+→ 保留 / 拒绝 / 要求用户确认
+```
+
+不允许：
+
+```text
+“看起来大概是这样”
+→ 猜测并重写用户数据
+```
+
+无法证明安全迁移时 **MUST** fail closed。
+
+### 6.4 已发布 migration
+
+已发布 migration 的历史语义 **SHOULD NOT** 被静默改写。
+
+需要补救时，优先新增版本化 migration 或明确 repair step，而不是让同一个旧 migration 在不同版本中产生不同结果。
+
+---
+
+## 7. Compatibility 与 Breaking Change
+
+Backward compatibility 是默认策略，不是永恒义务。
+
+DiceFrame **MAY** 在旧兼容包袱明显阻碍正确性、维护性、安全性或长期架构时进行 breaking change。
+
+Breaking change **MUST** 是显式的，而不是偶然发生。
+
+根据影响范围，应提供：
+
+- migration；
+- compatibility adapter；
+- alias；
+- deprecation window；
+- major/schema/runtime version boundary；
+- 明确的 unsupported / rejection behavior。
+
+兼容逻辑 **SHOULD** 集中在 compatibility / adapter 边界。
+
+**SHOULD NOT** 让大量 legacy `if/else` 永久散落在正常 runtime 业务路径中。
+
+---
+
+## 8. 当前架构默认方向
+
+以下是当前推荐方向，属于 **SHOULD** 级架构约束：
+
+```text
+routes
+  ↓
+WebAPI
+  ↓
+services
+  ↓
+core / engine
+```
+
+- core / engine **SHOULD NOT** 反向依赖 `src.webui`；
+- route **SHOULD** 保持薄层；
+- WebAPI **SHOULD** 负责委托与边界转换，而不是重新实现业务规则；
+- service 间协作 **SHOULD** 使用明确接口，而不是绕过边界访问内部状态。
+
+如果某次重构要改变这条依赖方向，允许改变，但应按 Level 1 architecture change 处理。
+
+---
+
+## 9. Ruleset isolation
+
+DiceFrame 的 generic engine 是多个规则系统共享的基础。
+
+当前默认方向：
+
+```text
+specific ruleset
+      ↓
+generic runtime / engine primitives
+```
+
+而不是：
+
+```text
+generic engine
+      ↓
+specific D&D / CoC implementation
+```
+
+因此：
+
+- D&D 专属行为 **SHOULD** 留在 D&D runtime / capability 边界；
+- CoC 专属行为 **SHOULD** 留在 CoC 边界；
+- generic d20 **SHOULD NOT** 因某一个规则系统的特例而改变通用语义；
+- ruleset **MAY** 通过明确 capability / runtime contract 扩展通用体验。
+
+这里保护的是**依赖方向和 mechanics authority**，不是永久锁死某个目录路径。
+
+未来把某个 ruleset 移到 package、独立仓库或新 runtime 结构完全允许。
+
+---
+
+## 10. Canonical identity 与 Locale
+
+Canonical identity **MUST** 与 display text 分离。
+
+例如：
+
+```text
+fighter
+longsword
+npc_innkeeper
+```
+
+是 identity；
+
+```text
+战士 / Fighter
+长剑 / Longsword
+老汤姆 / Old Tom
+```
+
+是 display text。
+
+Locale **MUST NOT**：
+
+- 改变 canonical ID；
+- 改变 mechanics；
+- 改变规则技能池；
+- 改变权限；
+- 增删 canonical entity；
+- 用翻译后的字符串充当 runtime identity。
+
+如果未来 localization architecture 改变，这个 identity/mechanics 契约仍应保留，除非明确做 breaking content-model change。
+
+---
+
+## 11. Server authority、Security 与 Privacy
+
+### 11.1 服务端是最终 authority
+
+以下内容 **MUST NOT** 只依赖客户端约束：
+
+- 权限；
+- actor ownership；
+- GM-only 操作；
+- private visibility；
+- turn authority；
+- resource consumption；
+- authoritative mechanics。
+
+前端可以隐藏按钮，但隐藏按钮不是安全边界。
+
+### 11.2 Private data
+
+GM-only / player-private 数据 **MUST NOT** 先发给无权用户再靠 UI 隐藏。
+
+权限过滤应在服务端或更早的 authoritative projection 边界完成。
+
+### 11.3 输入不可信
+
+以下均视为不可信输入：
+
+- browser/client；
+- Bot；
+- Plugin；
+- imported content；
+- uploaded save；
+- LLM output；
+- migration source data。
+
+所有权威状态修改都应经过对应验证边界。
+
+---
+
+## 12. Multiplayer authority
+
+任何会修改多人游戏状态的新功能 **MUST** 明确：
+
+- 当前 `game`；
+- `actor`；
+- actor ownership；
+- turn / phase authority；
+- 并发行为；
+- 是否允许 GM override；
+- failure semantics。
+
+**MUST NOT** 假设：
+
+> “前端正常情况下不会这样调用。”
+
+不同游戏、不同玩家和不同 actor 的数据必须保持隔离。
+
+涉及并发提交、round advance、资源消耗的行为 **SHOULD** 有 integration / concurrency coverage。
+
+---
+
+## 13. LLM 不是权威状态机
+
+LLM 可以：
+
+- 提议；
+- 叙事；
+- 解析自然语言；
+- 生成候选内容；
+- 给出 tool / intent candidate。
+
+LLM 输出 **MUST NOT** 绕过 engine / reducer / validator 直接成为权威状态修改。
+
+例如 HP、资源、战役事实、权限、冒险推进、战斗状态等，最终仍应经过确定性或可验证的 authoritative path。
+
+---
+
+## 14. Frontend boundary
+
+Frontend 默认负责：
+
+- interaction；
+- presentation；
+- local UI state；
+- 对 backend authoritative result 的展示。
+
+Frontend **SHOULD NOT** 重复实现一套与 backend 不同的核心 mechanics / permission model。
+
+这不限制：
+
+- Vue 组件如何拆；
+- store 怎么组织；
+- navigation 怎么重构；
+- 页面如何重做；
+- 未来是否替换 frontend 技术。
+
+保护的是 authority，不是 UI 实现。
+
+---
+
+## 15. Tests protect contracts, not implementations
+
+测试的目标是保护产品承诺和风险边界，不是冻结当前实现。
+
+测试 **MAY** 因重构被：
+
+- 重写；
+- 合并；
+- 移动；
+- 删除重复覆盖。
+
+前提是对应 contract 的有效覆盖仍然存在。
+
+涉及关键契约时，以 `docs/testing-contracts.md` 为事实来源。
+
+新增高风险产品契约时 **SHOULD**：
+
+1. 增加对应测试；
+2. 如果它属于长期关键契约，补入 `testing-contracts.md`。
+
+不要为了测试而保留一个已经不合理的内部 helper / class / 文件结构。
+
+同时不要通过删除测试来掩盖 regression。
+
+---
+
+## 16. PR 大小：保护完整性，不限制行数
+
+DiceFrame 不设置：
+
+- 最大改动行数；
+- 最大文件数；
+- 大型 PR 禁令。
+
+原则是：
+
+> **Prefer the smallest coherent change, not the smallest diff.**
+>
+> 优先最小“完整改动”，而不是最小“代码行数”。
+
+一个完整 migration 可能合理地同时包含：
+
+- migration；
+- compatibility；
+- backend；
+- frontend；
+- tests；
+- docs。
+
+如果把这些拆开会产生无法独立验证或不安全的中间状态，就不应为了“PR 小”强拆。
+
+反过来，如果两个变化可以：
+
+- 独立产生价值；
+- 独立验证；
+- 独立回滚；
+
+则 **SHOULD** 分开提交，减少审计噪音。
+
+---
+
+## 17. PR 风险声明
+
+PR 不需要先判断自己属于某个固定等级。
+
+只需识别是否触碰这些影响面：
+
+```text
+API
+Persisted Data
+Migration
+Compatibility / Breaking
+Security / Permission
+Multiplayer
+Ruleset Mechanics
+Architecture
+Plugin / Extension Contract
+UI only
+```
+
+触碰的风险面越多，review 和测试越应该集中到对应契约。
+
+风险声明的目的不是阻止合并，而是避免“做了高风险改动却没人意识到”。
+
+---
+
+## 18. Design Note 与 ADR
+
+### 普通 bug / 小功能
+
+不需要 ADR。
+
+### 需要在 PR 中写 Design Note 的情况
+
+通常包括：
+
+- 改变 subsystem 边界；
+- 改变主要依赖方向；
+- 引入新的 persistence model；
+- breaking public/extension contract；
+- 选择一个会长期影响后续工作的核心 abstraction。
+
+Design Note 可以直接放在 PR description 中，不要求单独文件。
+
+### 需要 ADR 的情况
+
+只有当决策：
+
+- 预计长期存在；
+- 有多个长期可行方案；
+- 未来维护者很可能问“为什么当初这样做”；
+- 涉及 repository split、runtime model、content model、persistence architecture、plugin architecture 等重要方向；
+
+才 **SHOULD** 新增 ADR。
+
+ADR 不是审批凭证；它是长期的“为什么”。
+
+详见 `docs/adr/README.md`。
+
+---
+
+## 19. Dependencies
+
+新依赖不是禁止项。
+
+新增 runtime / security-sensitive / large dependency 时 **SHOULD** 说明：
+
+- 为什么现有能力不足；
+- 它进入哪个边界；
+- 对镜像体积、平台支持、安全和维护的明显影响。
+
+普通开发依赖无需写长篇论证。
+
+不要为了“零依赖”重复实现已有成熟基础设施，也不要为了一个小 helper 引入过重依赖。
+
+---
+
+## 20. Generated / derived artifacts
+
+如果某文件是从明确 source-of-truth 自动生成的：
+
+- **SHOULD** 修改 source，而不是直接长期维护生成结果；
+- 生成方式 **SHOULD** 可复现；
+- 若生成文件需要入库，应在文档或文件头说明来源。
+
+运行缓存、本机产物、临时测试结果 **MUST NOT** 作为源码提交。
+
+---
+
+## 21. AI-assisted development
+
+DiceFrame 允许使用 Codex、Claude、ChatGPT 和其他 AI 辅助开发。
+
+AI output 不是 authority。
+
+AI agent 在修改前 **SHOULD**：
+
+- 阅读相关现有架构和附近实现；
+- 查证实际字段/API，而不是凭猜测创造；
+- 识别是否触碰 persisted / security / multiplayer / ruleset contract；
+- 避免无关清理扩大 diff。
+
+AI agent **MAY**：
+
+- 大型重构；
+- 删除 obsolete code；
+- 修改架构；
+- 拆分模块；
+- 新增 migration；
+- 改 public API。
+
+但必须像人类贡献一样处理相应契约、测试、迁移和文档。
+
+“这是 AI 写的”不能作为不了解代码含义或跳过验证的理由。
+
+---
+
+## 22. Intentional exceptions
+
+这些规则用于避免**无意的架构退化**，不是阻止**有意的架构演进**。
+
+当某个改动确实需要：
+
+- 改变当前 SHOULD 规则；
+- 改变当前架构；
+- 打破某个稳定 contract；
+
+应：
+
+1. 明确说明变化是 intentional；
+2. 解释为什么旧边界不再适合；
+3. 处理 migration / compatibility / security / tests；
+4. 更新对应 architecture / contract 文档；
+5. 重大长期决策必要时增加 ADR。
+
+完成这些后，改变架构本身不是违规。
+
+---
+
+## 23. 最终判断原则
+
+遇到规范没有明确写到的情况，按以下顺序判断：
+
+1. 会不会破坏或泄露用户数据？
+2. 会不会破坏权限、私密信息或 multiplayer authority？
+3. 会不会让旧持久化 identity / save 无法解释？
+4. 会不会无意改变 public / extension contract？
+5. 会不会让 specific ruleset 反向污染 generic engine？
+6. 有没有可验证的 migration / compatibility / test？
+7. 如果以上都处理好了，这个重构是否让系统更清晰、更可靠？
+
+前六项是风险控制。
+
+第七项提醒我们：
+
+> DiceFrame 的架构应该能够继续变得更好，而不是因为规范而停止演进。

--- a/docs/ENGINEERING_RULES.md
+++ b/docs/ENGINEERING_RULES.md
@@ -51,6 +51,21 @@ DiceFrame 需要同时支持快速增加功能、长期维护旧数据、多人�
 
 如果确实需要改变 MUST 级契约，应把它视为显式 breaking / product-contract change，提供版本、迁移、兼容或明确拒绝策略，而不是静默改变。
 
+需要区分两类 MUST：
+
+- API、schema、canonical identity、产品行为等**可版本化的产品契约**，可以按上述方式显式 breaking；
+- **安全不变量**不能仅因 intentional breaking change 被放宽，包括：
+
+```text
+unauthorized data access
+private / GM 数据泄露
+跨 actor 的未授权状态修改
+客户端取代服务端 authority
+secret 泄露
+```
+
+权限 / authority 架构本身 **MAY** 重构；但新模型 **MUST** 保持等价或更强的授权判定、actor 隔离与服务端 authority。安全不变量上的回归不是 breaking change，而是正确性缺陷——无论 PR 如何描述都必须修复，不能通过 versioning / migration 流程“合法化”。
+
 ---
 
 ## 3. Architecture is allowed to change

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,47 @@
+# ADR-XXXX: Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+
+## Context
+
+现在有什么问题？
+
+为什么现有设计不再适合？
+
+有哪些必须保留的约束或产品契约？
+
+## Decision
+
+决定采用什么方案？
+
+新的主要边界 / authority / data flow 是什么？
+
+## Alternatives Considered
+
+只记录真正考虑过的主要替代方案，以及没有选择它们的原因。
+
+## Consequences
+
+### Benefits
+
+- 
+
+### Costs / Risks
+
+- 
+
+### Migration / Compatibility
+
+- 是否影响 persisted data？
+- 是否影响 public / extension API？
+- 是否需要 migration / alias / deprecation？
+- rollback / failure behavior 是什么？
+
+## Validation
+
+如何证明这个决策落地后没有破坏关键契约？
+
+## Supersedes / Superseded By
+
+如无则写 `None`。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,61 @@
+# Architecture Decision Records
+
+ADR 用来记录“为什么做出一个长期架构决定”，不是所有 PR 的审批流程。
+
+## 什么时候需要 ADR
+
+通常只有以下情况值得写：
+
+- 改变主要依赖方向；
+- 重新定义 persistence / migration architecture；
+- 重新定义 plugin / extension model；
+- 重新定义 Content / Ruleset / Adventure 的长期模型；
+- 拆分或合并 repository / package；
+- 替换一个影响大量后续工作的核心 abstraction；
+- 多个长期方案都合理，需要记录为什么选择其中一个。
+
+## 什么时候不需要
+
+以下情况一般不需要 ADR：
+
+- 普通 bug fix；
+- UI 调整；
+- 小型 refactor；
+- 单次 migration；
+- 普通新 API；
+- 实现细节变化；
+- 没有长期设计争议的普通功能。
+
+复杂但只影响当前 PR 的设计，可以直接写在 PR 的 Design Note 中。
+
+## 状态
+
+ADR 使用：
+
+- `Proposed`
+- `Accepted`
+- `Superseded`
+- `Deprecated`
+
+如果新 ADR 取代旧 ADR，不删除历史文件，在旧 ADR 中标注被哪个 ADR supersede。
+
+## 命名
+
+```text
+0001-short-title.md
+0002-short-title.md
+```
+
+编号只表示记录顺序，不表示优先级。
+
+## 原则
+
+ADR 记录的是：
+
+> 当时基于什么上下文，为什么选择这个方向。
+
+它不是：
+
+> 以后永远不能改变。
+
+如果未来条件变化，写一个新的 ADR supersede 旧决策即可。


### PR DESCRIPTION
## Summary

- establish a shared engineering-rules source of truth without freezing the current architecture
- classify change risk by stable surfaces rather than diff size
- explicitly allow large refactors and intentional breaking changes when affected contracts are handled
- define migration, persisted identity, multiplayer authority, privacy and ruleset safety principles
- add lightweight ADR guidance for long-lived architecture decisions
- keep AGENTS.md and CLAUDE.md as thin entry points
- add a risk-oriented pull request template

## Scope

Documentation and repository governance only.

No runtime, API, database, migration, ruleset, frontend behavior, dependency, or CI behavior changes.

## Design principles

- contracts over implementation
- migration correctness over migration completeness
- fail closed when safe migration cannot be proven
- current architecture is a source of truth, not an immutable roadmap
- prefer the smallest coherent change, not the smallest diff

## Files

New:

- `docs/ENGINEERING_RULES.md` — engineering rules (MUST/SHOULD/MAY, stable-surface levels, migration / identity / authority / ruleset principles)
- `docs/adr/README.md` — when an ADR is and is not warranted, status and naming conventions
- `docs/adr/0000-template.md` — ADR template
- `.github/PULL_REQUEST_TEMPLATE.md` — risk-oriented impact checklist (not an approval gate)

Updated:

- `AGENTS.md` / `CLAUDE.md` — remain thin entry points routing AI agents to the shared sources of truth
- `CONTRIBUTING.md` — adds architecture & engineering-rules pointers, large-PR / breaking-change guidance, AI-assisted development rules; keeps the existing workflow, verification commands and contributor notes

## Validation

- checked repository-relative document links
- checked final diff for unrelated changes
- `git diff --check`
