### PR TITLE
release: prepare v2.4.2-beta.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,73 +1,53 @@
-# DiceFrame v2.4.1
+# DiceFrame v2.4.2-beta.1
+
+> 这是预览版本，主要验证世界书可见性改进、内置世界书升级迁移与相关兼容性。重要数据请提前备份。
 
 ## 中文
 
-DiceFrame v2.4.1 带来统一的多人跑团体验、高级 DND5E 规则支持、冒险包管理、移动端游玩能力，以及更可靠的更新和问题排查工具。
-
 ### 本次更新
 
-- **统一游玩流程**：剧情、公共消息、行动输入、队伍状态和 GM 控制台回到同一条对局流程；帮助内容不再打断正常游玩。
-- **高级 DND5E 规则**：加入角色创建、角色中心、法术与资源、休息、升级资格和规则校验，并由服务端维护权威状态。
-- **AI GM 与冒险推进**：支持根据玩家行动推进剧情、收集多人行动、处理检定和唤醒符合剧情的遭遇；GM 仍可随时裁定和接管。
-- **多人战斗**：提供先攻、回合、移动、攻击、伤害、敌方行动、准备状态和公共战斗历史的同步流程。玩家只能操作自己的角色，GM 管理遭遇和战役状态。
-- **冒险包**：支持可视化新建、复制、编辑、校验、导入、导出、删除和 AI 草稿。冒险包提供剧情结构，世界书继续负责世界背景；两者可以组合使用但不会互相覆盖。
-- **稳定重开**：对局会固定冒险包的 identity、版本和内容摘要；内容缺失或被修改时会明确报告，而不是静默切换到另一套场景。
-- **叙事视角**：创建对局时可选择第一人称或第三人称叙事，GM 也可在对局中调整；该能力适用于所有规则，而非 DND5E 专属设置。
-- **连接安全**：设置中新增“安全”页，可在 HTTP、本地自签名 HTTPS 与受信任 HTTPS 之间切换，并支持为域名或符合条件的公网 IP 申请和自动续期 Let’s Encrypt 证书。
-- **语音输入**：可配置 OpenAI 兼容的语音识别模型，在 HTTPS 或 localhost 环境中通过行动输入框旁的麦克风按钮把语音转为文字。
-- **移动端与联机**：改进移动端导航、对局界面、地图、角色和多人连接流程，并改善独立 Web 前端的连接体验。
-- **运行日志与排障**：新增按天轮转、默认保留 30 天的运行日志，可在设置中查看、清除或导出给开发者；DF 助手可以分析脱敏后的日志，帮助定位常见问题。
-- **模型请求控制**：普通模型请求超时可独立配置，不再与连接测试超时绑定，长篇生成与临时连通性检查可以使用不同等待时间。
-- **托管 Docker 更新**：容器内支持下载、校验、健康检查、观察期切换和失败回滚；当前与上一应用版本独立保存，业务数据不随版本切换。
-- **更新可靠性**：改进 Windows 便携版与托管 Docker 的运行时依赖校验、启动等待和连续失败判断，减少慢速设备、存档较多或短暂断连造成的误回滚，并修复 Docker 更新包缺少加密依赖时无法启动的问题。
-- **更新包校验**：Release 使用统一的 `SHA256SUMS` 清单，便于手动下载和新版更新器校验。
-- **兼容性**：DND5E 专属机制保持在高级 DND5E 规则边界内，不会自动改变传统规则、CoC、赛博朋克或 generic d20 的玩法。
+- **世界书视角检查器**：世界书页新增 GM / 全队 / 各角色视角的可见性检查器，可按视角筛选条目并查看受众构成；检查器的展开状态会跨会话记忆，窄屏抽屉默认收起。
+- **AI 生成世界书可见性**：AI 生成世界书条目时按内容性质分配 GM 秘密 / 全队公开 / 指定角色可见，并受提示词安全契约约束，AI 输出不直接绕过权威可见性规则。
+- **可见性编辑兼容**：世界书编辑器提供 GM 秘密 / 全队公开 / 指定角色三档控制；兼容历史数据中的 `PUBLIC`、`公开` 等大小写与别名写法以及 `"Alice,Bob"` 逗号分隔字符串，公开标记不再被误判后在保存时静默变成 GM 秘密。
+- **内置世界书内容重审计**：混合"公开常识 + GM 调查线索"的内置条目被拆分为公开条目与秘密条目；公开常识对所有玩家生效，秘密线索保持 GM-only。
+- **老安装升级迁移**：老存档首次启动时会自动把仍与旧官方默认完全一致的条目升级到重审计后的公开/秘密状态；迁移目标在发布时冻结、逐字段检测用户修改、幂等执行——用户编辑过的条目绝不会被系统模板覆盖，无法安全判定的场景一律保留原状。
+- **界面细节**：原生复选框与单选框尺寸、设置页数字对齐、资料库卡片操作按钮布局、移动端全宽导航、导航分组标题精简、助手问候气泡等一系列界面改进。
+- **测试与工程治理**：精简测试套件；新增工程规范（`docs/ENGINEERING_RULES.md`）、ADR 指南（`docs/adr/`）与风险导向的 PR 模板，明确"规范约束风险和契约，不冻结当前实现"。
 
 ### 升级提示
 
-- 升级前请备份完整的 `data/` 文件夹。
-- Windows 便携版、源码包和托管 Docker 均可使用各自的应用内更新流程；只有涉及 Python ABI、系统库、字体或 launcher 协议变化时，Docker 才需要更新基础镜像。
+- 这是预览版本；升级前请备份完整的 `data/` 文件夹。
+- 老存档首次启动会执行一次内置世界书升级迁移：只有仍与旧官方默认逐字段一致的条目才会升级；用户修改过的条目保留原样。
 - Docker Update 当前支持 `linux-amd64`。
 
 ### 下载与校验
 
-- Windows 便携版：`DiceFrame-v2.4.1-windows-portable.zip`
-- Windows 源码包：`DiceFrame-v2.4.1-windows.zip`
-- Docker 托管更新：`DiceFrame-v2.4.1-docker-update-linux-amd64.zip`
+- Windows 便携版：`DiceFrame-v2.4.2-beta.1-windows-portable.zip`
+- Windows 源码包：`DiceFrame-v2.4.2-beta.1-windows.zip`
+- Docker 托管更新：`DiceFrame-v2.4.2-beta.1-docker-update-linux-amd64.zip`
 - 手动下载时，请使用 Release 中的 `SHA256SUMS` 统一校验。
 
 ## English
 
-DiceFrame v2.4.1 brings a unified multiplayer play flow, advanced DND5E rules, adventure-bundle management, improved mobile play, and more reliable updates and diagnostics.
+### What's changed
 
-### What's new
-
-- **Unified play flow**: Narrative, public messages, action input, party state, and the GM console now follow one play flow. Help content no longer interrupts normal play.
-- **Advanced DND5E rules**: Character creation, character center, spells and resources, rests, advancement eligibility, and rules validation are backed by authoritative server state.
-- **AI GM and adventure progression**: Player actions can advance the story, collect multiplayer actions, resolve checks, and awaken encounters that fit the current narrative. The GM can always adjudicate or take over.
-- **Multiplayer combat**: Initiative, turns, movement, attacks, damage, enemy actions, readiness, and public combat history are synchronized. Players control only their own characters while the GM manages encounters and campaigns.
-- **Adventure bundles**: Visual create, copy, edit, validate, import, export, delete, and AI-draft workflows are available. Adventure bundles provide optional story structure while lorebooks continue to define world context; they can be combined without overwriting each other.
-- **Deterministic resume**: Games pin an adventure identity, version, and content digest. Missing or changed content is reported explicitly instead of silently switching scenes.
-- **Narrative perspective**: Choose first- or third-person narration when creating a game, and let the GM adjust it during play. This setting works across all rulesets rather than being specific to DND5E.
-- **Connection security**: A new Security settings page can switch between HTTP, local self-signed HTTPS, and trusted HTTPS, with Let’s Encrypt issuance and automatic renewal for domains or eligible public IP addresses.
-- **Voice input**: Configure an OpenAI-compatible speech-recognition model and dictate actions from the microphone button beside the action composer when using HTTPS or localhost.
-- **Mobile and multiplayer connectivity**: Navigation, play, maps, characters, and peer connection flows are improved for mobile, along with standalone Web frontend connectivity.
-- **Runtime logs and diagnostics**: Daily-rotated runtime logs retain the latest 30 days by default and can be viewed, cleared, or exported for developers from Settings. DF Assistant can analyze redacted logs to help diagnose common issues.
-- **Model request controls**: Normal model request timeout is configurable independently from connection-test timeout, so long generations and quick connectivity checks can use different limits.
-- **Managed Docker updates**: Containers can download, verify, health-check, probation-test, switch, and roll back application versions while keeping current and previous payloads separate from business data.
-- **Update reliability**: Runtime dependency checks, startup waits, and continuous-failure handling are improved for Windows portable and managed Docker updates. This reduces false rollbacks on slower devices, installations with many saved games, or brief connection interruptions, and fixes Docker startup failures caused by missing cryptography dependencies.
-- **Update verification**: Releases use one unified `SHA256SUMS` manifest for manual downloads and newer updater clients.
-- **Compatibility**: DND5E-specific mechanics stay within the advanced DND5E rules boundary and do not automatically change traditional rules, CoC, cyberpunk, or generic d20 gameplay.
+- **Lorebook perspective inspector**: The lorebook page gains a visibility inspector for the GM / party / each character perspective, with per-perspective entry filtering and audience breakdown. The inspector remembers its collapsed state across sessions and stays collapsed by default on narrow screens.
+- **AI-generated lore visibility**: AI-generated lorebook entries receive GM-secret / party-wide / named-character visibility based on content nature, bounded by a prompt-safety contract so AI output never bypasses authoritative visibility rules.
+- **Visibility editing compatibility**: The lorebook editor offers three explicit visibility modes and tolerates historical shapes such as `PUBLIC`-style casing/aliases and comma-separated `"Alice,Bob"` strings. Public markers are no longer misclassified and silently stripped to GM-secret on save.
+- **Built-in lore re-audit**: Built-in entries that mixed public common knowledge with GM-only clues are split into a public entry and a secret entry. Common knowledge is now party-visible while investigative clues stay GM-only.
+- **Upgrade migration for existing installs**: On first startup, existing databases migrate old official entries to the re-audited public/secret state only when every field still matches the pre-regrade official default. The migration target is frozen at publish time, user edits are detected field-by-field, and execution is idempotent — user-edited entries are never overwritten, and anything that cannot be judged safely is left untouched.
+- **UI polish**: Native checkbox/radio sizing, settings number alignment, library card action layout, full-width mobile navigation, simplified navigation group titles, assistant greeting bubble, and more.
+- **Tests and engineering governance**: The test suite is slimmed; engineering rules (`docs/ENGINEERING_RULES.md`), ADR guidance (`docs/adr/`), and a risk-oriented PR template are added, making explicit that governance constrains risk and contracts rather than freezing the current architecture.
 
 ### Upgrade notes
 
-- Back up the complete `data/` directory before upgrading.
-- Windows portable, source-package, and managed-Docker installations can use their respective in-app update flows. Docker needs a base-image update only when the Python ABI, system libraries, fonts, or launcher protocol change.
+- This is a preview release; back up the complete `data/` directory before upgrading.
+- Existing databases run a one-time built-in lore upgrade migration on first startup: only entries still matching the old official default field-for-field are upgraded; user-edited entries are preserved as-is.
 - Docker Update currently supports `linux-amd64`.
 
 ### Downloads and verification
 
-- Windows portable: `DiceFrame-v2.4.1-windows-portable.zip`
-- Windows source: `DiceFrame-v2.4.1-windows.zip`
-- Managed Docker update: `DiceFrame-v2.4.1-docker-update-linux-amd64.zip`
+- Windows portable: `DiceFrame-v2.4.2-beta.1-windows-portable.zip`
+- Windows source: `DiceFrame-v2.4.2-beta.1-windows.zip`
+- Managed Docker update: `DiceFrame-v2.4.2-beta.1-docker-update-linux-amd64.zip`
 - For manual downloads, verify all archives with the `SHA256SUMS` file attached to the Release.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.4.1"
+__version__ = "2.4.2-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## Summary

- bump `src/version.py` to `2.4.2-beta.1`
- rewrite `RELEASE_NOTES.md` for the v2.4.2-beta.1 preview release (worldbook visibility rework, built-in lore upgrade migration, governance docs)

The `v2.4.2-beta.1` tag points at this commit; the release build is already running from the tag. Merging makes the tagged commit reachable from `main`.