### PR TITLE
fix: auto-normalize asset ids when installing content packs

### DIFF
--- a/src/content/contracts.py
+++ b/src/content/contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 import re
 from typing import Any
 
@@ -14,6 +15,28 @@ def canonical_id(value: str) -> str:
     if not _ID.fullmatch(result):
         raise ValueError(f"invalid canonical id: {value!r}")
     return result
+
+
+def asset_local_id(value: str) -> str:
+    """资产文件名 → 合法 canonical id（自动规范化，不做命名强制）。
+
+    资产是被**路径**引用的叶子资源（``scene_image.path`` 等按原样解析），
+    文件名由作者随意起：哈希、原名、中文都应能安装。已经合法的名字原样
+    保留（存量身份不漂移）；非法的名字沿用历史清洗规则（非法字符转
+    ``_``、小写、去首尾 ``_``）后做最小修复：空名回退 ``asset``，非字母
+    开头加 ``n`` 前缀，并追加原名的短哈希后缀，避免不同文件规范化后互相
+    覆盖。
+    """
+    raw = str(value or "").strip()
+    try:
+        return canonical_id(raw)
+    except ValueError:
+        pass
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", raw).lower().strip("_") or "asset"
+    if not re.match(r"^[a-z]", cleaned):
+        cleaned = f"n{cleaned}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    return f"{cleaned[:87]}-{digest}"
 
 
 @dataclass(frozen=True)

--- a/src/plugin_host/registry.py
+++ b/src/plugin_host/registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import re
 from typing import Any
 
-from src.content.contracts import ResourceRef, canonical_id
+from src.content.contracts import ResourceRef, asset_local_id, canonical_id
 
 from .map_validation import (
     MAP_IMAGE_KINDS,
@@ -46,12 +46,15 @@ class PluginContribution:
     @property
     def ref(self) -> ResourceRef:
         # Asset paths are legacy local keys; retain the original key while
-        # exposing a canonical identity for the V2 registry.
-        local_id = (
-            canonical_id(self.key)
-            if self.content_schema_version >= 2 and self.kind in _V2_CANONICAL_KINDS
-            else re.sub(r"[^a-zA-Z0-9_-]", "_", self.key).lower().strip("_") or "asset"
-        )
+        # exposing a canonical identity for the V2 registry. Asset file names
+        # are free-form author input (assets are referenced by path, not by
+        # id), so their identity is auto-normalized instead of enforced.
+        if self.kind.endswith("_asset"):
+            local_id = asset_local_id(self.key)
+        elif self.content_schema_version >= 2 and self.kind in _V2_CANONICAL_KINDS:
+            local_id = canonical_id(self.key)
+        else:
+            local_id = re.sub(r"[^a-zA-Z0-9_-]", "_", self.key).lower().strip("_") or "asset"
         return ResourceRef(f"plugin:{self.plugin_id}", self.kind, local_id)
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_plugin_content_pack.py
+++ b/tests/test_plugin_content_pack.py
@@ -229,6 +229,59 @@ def test_content_pack_scene_image_assets_are_exposed_as_plugin_references(tmp_pa
     }
 
 
+def test_content_pack_hash_named_scene_assets_are_normalized_on_install(tmp_path):
+    """作者用哈希/原名/中文命名图片也能安装：资产身份自动规范化，路径引用不变。"""
+    plugins = tmp_path / "plugins"
+    write_plugin(
+        plugins,
+        "hash-pack",
+        plugin_type="content-pack",
+        entrypoint=False,
+        manifest_extra={"contributes": {
+            "world_templates": ["content/worlds/*.json"],
+            "scene_images": ["assets/scenes/*"],
+        }},
+    )
+    pack = plugins / "hash-pack"
+    (pack / "content" / "worlds").mkdir(parents=True)
+    scenes = pack / "assets" / "scenes"
+    scenes.mkdir(parents=True)
+    world_hash = "311efe3bc91c167568bacb6bd7cc0e7e78c016a7763e4502f7ce4e67de4d6d4c"
+    (scenes / f"{world_hash}.webp").write_bytes(b"RIFF-hash-world")
+    (scenes / "valley.webp").write_bytes(b"RIFF-plain")
+    (scenes / "背景 一.png").write_bytes(b"PNG-cn-1")
+    (scenes / "背景 二.png").write_bytes(b"PNG-cn-2")
+    (pack / "content" / "worlds" / "valley.json").write_text(json.dumps({
+        "world_id": "valley",
+        "world_name": "Valley",
+        "default_rule": "freeform_fantasy",
+        "scene_image": {"kind": "asset", "path": f"assets/scenes/{world_hash}.webp"},
+    }), encoding="utf-8")
+    config_dir = tmp_path / "data" / "hash-pack"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(json.dumps({"enabled": True}), encoding="utf-8")
+
+    host = PluginHost(plugins, tmp_path / "data")
+    host.discover()
+
+    assets = {item.relative_path: item for item in host.contributions.list("scene_image_asset")}
+    assert f"assets/scenes/{world_hash}.webp" in assets
+    # 数字开头的哈希名：规范化为字母开头 + 原名短哈希后缀
+    assert assets[f"assets/scenes/{world_hash}.webp"].ref.local_id.startswith("n311efe")
+    # 已经合法的名字原样保留（存量身份不漂移）
+    assert assets["assets/scenes/valley.webp"].ref.local_id == "valley"
+    # 中文/空格名各自得到唯一身份，不互相覆盖
+    cn_ids = {item.ref.local_id for path, item in assets.items() if path.endswith(".png")}
+    assert len(cn_ids) == 2
+    # 路径引用解析不受身份规范化影响
+    world = host.load_world_template("valley")
+    assert world["scene_image"] == {
+        "kind": "plugin",
+        "plugin_id": "hash-pack",
+        "path": f"assets/scenes/{world_hash}.webp",
+    }
+
+
 def test_content_pack_manifest_declares_scene_image_assets():
     manifest = plugin_service.build_content_pack_manifest(
         "scene-pack", "Scene Pack", "1.0.0", "", True, True, False,


### PR DESCRIPTION
## Summary

- content pack authors name images freely (hashes from authoring tools, downloads, Chinese names); assets are referenced by path, not id, so installing should not depend on filename spelling
- asset contributions (kinds ending in `_asset`) now derive their registry id via new `asset_local_id()`: already-canonical names keep their id verbatim (no drift for installed packs); invalid names are cleaned with the historical sanitize rules, minimally repaired (empty -> `asset`, non-letter-leading -> `n` prefix) and get a short hash suffix of the original name so different files can never normalize onto each other
- authored identities (rules, worlds, characters, spells...) keep strict `canonical_id` — they are referenced by other content and must stay explicit
- path-based references (`scene_image.path`) are untouched; resolution unchanged

## Before / After

Installing a pack whose world references `assets/scenes/311efe...webp` previously failed the whole install with `invalid canonical id: '311efe...'`; it now installs and the world's scene image resolves as before.

## Validation

- new regression test: hash-named, plain, and Chinese/spaced scene assets install, ids normalize/dedup correctly, path reference still resolves
- `ruff` + full backend suite: 1686 passed, 1 skipped