### PR TITLE
style: collapse settings section nav on tablet widths

### DIFF
--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -8,7 +8,7 @@ import {
   KeyOutline, CopyOutline, EyeOutline, RefreshOutline, ColorPaletteOutline,
   ImageOutline, PowerOutline, MicOutline, SearchOutline, AddOutline,
   TrashOutline, CheckmarkCircleOutline, AlertCircleOutline, SparklesOutline,
-  VolumeHighOutline, ShieldCheckmarkOutline,
+  VolumeHighOutline, ShieldCheckmarkOutline, ChevronDownOutline,
 } from '@vicons/ionicons5'
 import { useSettingsStore, providerSecretKey } from '@/stores/useSettingsStore'
 import { useToast } from '@/composables/useToast'
@@ -260,6 +260,53 @@ const sections: SettingsSection[] = [
   { id: 'advanced', labelKey: 'settingsSectionAdvanced', icon: OptionsOutline },
   { id: 'about', labelKey: 'settingsSectionAbout', icon: InformationCircleOutline },
 ]
+
+// 窄屏（平板/手机）下节列表收成一行「当前节」，点开才展开完整目录；
+// 宽屏保持常驻侧栏。用户的选择记到 localStorage。
+const SETTINGS_NAV_OPEN_KEY = 'settings_nav_open'
+const settingsNavNarrow = ref(false)
+const settingsNavOpen = ref(false)
+const activeSection = computed(() => sections.find(s => s.id === section.value) || sections[0])
+
+function applySettingsNavWidth(media: MediaQueryList | null) {
+  if (!media) return
+  settingsNavNarrow.value = media.matches
+  if (!media.matches) settingsNavOpen.value = false
+}
+
+function watchSettingsNavWidth() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+  const media = window.matchMedia('(max-width: 980px)')
+  applySettingsNavWidth(media)
+  const listener = (event: MediaQueryListEvent) => applySettingsNavWidth(event.matches ? media : null)
+  if (typeof media.addEventListener === 'function') media.addEventListener('change', listener)
+  else if (typeof media.addListener === 'function') media.addListener(listener)
+}
+
+function toggleSettingsNav() {
+  settingsNavOpen.value = !settingsNavOpen.value
+  try {
+    localStorage.setItem(SETTINGS_NAV_OPEN_KEY, settingsNavOpen.value ? '1' : '0')
+  } catch {
+    // storage 不可用时仅当前 session 生效
+  }
+}
+
+function resolveSettingsNavOpen() {
+  try {
+    return localStorage.getItem(SETTINGS_NAV_OPEN_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+settingsNavOpen.value = resolveSettingsNavOpen()
+watchSettingsNavWidth()
+
+function selectSettingsSection(id: SettingsSectionId) {
+  section.value = id
+  if (settingsNavNarrow.value) settingsNavOpen.value = false
+}
 
 function queryValue(value: unknown): string {
   return String(Array.isArray(value) ? (value[0] || '') : (value || ''))
@@ -1491,12 +1538,27 @@ function redownloadUpdatePackage() {
       </section>
     </div>
     <div class="settings-layout">
-      <aside class="settings-nav">
+      <aside
+        class="settings-nav"
+        :class="{ collapsed: settingsNavNarrow && !settingsNavOpen, expanded: settingsNavNarrow && settingsNavOpen }"
+      >
+        <button
+          v-if="settingsNavNarrow"
+          type="button"
+          class="nav-item settings-nav-toggle"
+          :aria-expanded="settingsNavOpen"
+          @click="toggleSettingsNav"
+        >
+          <NIcon :component="activeSection.icon" />
+          <span>{{ t(activeSection.labelKey) }}</span>
+          <NIcon :component="ChevronDownOutline" class="settings-nav-chevron" :class="{ open: settingsNavOpen }" />
+        </button>
         <button
           v-for="s in sections"
+          v-show="!settingsNavNarrow || settingsNavOpen"
           :key="s.id"
           :class="['nav-item', { active: section === s.id }]"
-          @click="section = s.id"
+          @click="selectSettingsSection(s.id)"
         >
           <NIcon :component="s.icon" />
           <span>{{ t(s.labelKey) }}</span>

--- a/frontend-v2/src/styles/v2/artwork.css
+++ b/frontend-v2/src/styles/v2/artwork.css
@@ -126,3 +126,38 @@ body.light .play-main {
     min-height: 40px;
   }
 }
+
+/* 设置节导航：窄屏默认收成一行「当前节」，点开展开完整目录（localStorage 记忆）。
+   置于本文件末尾以覆盖 layout/control-room 的横排与 min-height 规则。 */
+.settings-nav .settings-nav-toggle { display: none; }
+.settings-nav.collapsed { min-height: 0; padding-block: 0; }
+.settings-nav.collapsed .nav-item:not(.settings-nav-toggle) { display: none; }
+
+@media (max-width: 980px) {
+  .settings-nav .settings-nav-toggle {
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding-inline: 13px;
+    text-align: left;
+    border: 1px solid var(--df-border-soft);
+    border-radius: var(--df-radius-md);
+    background: var(--df-surface-1);
+    color: var(--df-text);
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .settings-nav .settings-nav-chevron {
+    margin-left: auto;
+    transition: transform .18s ease;
+  }
+
+  .settings-nav .settings-nav-chevron.open { transform: rotate(180deg); }
+
+  .settings-nav.expanded { flex-direction: column; overflow: visible; min-height: 0; }
+  .settings-nav.expanded .nav-item { flex: 1 1 auto; width: 100%; }
+}


### PR DESCRIPTION
## Summary

- user report: on tablet px the settings section nav renders as a vertical stack of ten full-width bars, pushing all content below the fold
- at <=980px the nav now renders one toggle row (current section icon + label + chevron); tap to expand the full list, picking a section collapses it again
- the open/closed choice persists in localStorage (`settings_nav_open`); desktop (>=981px) keeps the sticky sidebar unchanged
- expanded state forces the vertical list so existing phone horizontal-strip rules don't conflict

## Validation

- `npm run typecheck` / `npm run lint` / `npm run test` (350 passed)

UI-only; no behavior, API, or persistence impact outside the new nav toggle preference.