### PR TITLE
fix: restore settings nav when resizing back to desktop width

### DIFF
--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -268,17 +268,19 @@ const settingsNavNarrow = ref(false)
 const settingsNavOpen = ref(false)
 const activeSection = computed(() => sections.find(s => s.id === section.value) || sections[0])
 
-function applySettingsNavWidth(media: MediaQueryList | null) {
-  if (!media) return
-  settingsNavNarrow.value = media.matches
-  if (!media.matches) settingsNavOpen.value = false
+function applySettingsNavWidth(matches: boolean) {
+  settingsNavNarrow.value = matches
+  // 拖回宽屏时收起展开状态，再次进入窄屏从折叠默认开始
+  if (!matches) settingsNavOpen.value = false
 }
 
 function watchSettingsNavWidth() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
   const media = window.matchMedia('(max-width: 980px)')
-  applySettingsNavWidth(media)
-  const listener = (event: MediaQueryListEvent) => applySettingsNavWidth(event.matches ? media : null)
+  applySettingsNavWidth(media.matches)
+  // 注意：窄→宽的 change 事件 matches=false，必须把 narrow 置回 false，
+  // 否则拖大窗口后节列表永远隐藏（resize 回宽屏侧栏消失的来源）。
+  const listener = (event: MediaQueryListEvent) => applySettingsNavWidth(event.matches)
   if (typeof media.addEventListener === 'function') media.addEventListener('change', listener)
   else if (typeof media.addListener === 'function') media.addListener(listener)
 }


### PR DESCRIPTION
## Summary

- manually reported: shrink the window to phone width, drag back to desktop -> the settings sidebar section list disappeared entirely
- root cause: the #188 matchMedia change listener called the applier with `null` when the query stopped matching, and its guard returned early, so `settingsNavNarrow` stayed `true` forever - the list stayed v-show-hidden outside the collapsed toggle
- the listener now forwards the real `matches` flag; leaving narrow mode also collapses the expanded state so re-entering narrow starts from the default

## Validation

- `npm run typecheck` / `npm run lint` / targeted vitest

One-listener fix; no behavior changes beyond the reported regression.