### PR TITLE
fix: stabilize D&D combat feedback and mobile smoke

### DIFF
--- a/frontend-v2/e2e/dnd2024-workspace.spec.ts
+++ b/frontend-v2/e2e/dnd2024-workspace.spec.ts
@@ -241,8 +241,10 @@ test('guided creation enforces proficiency limits and enters the saved game even
   }
   await expect(languages.locator('input:not(:checked):not(:disabled)')).toHaveCount(0)
 
-  await page.locator('.builder-actions .primary').click()
-  await expect(page.getByRole('heading', { name: '角色已通过规则检查' })).toBeVisible()
+  const validateCharacter = page.locator('.builder-actions .primary')
+  await expect(validateCharacter).toBeEnabled()
+  await validateCharacter.click()
+  await expect(page.getByRole('heading', { name: '角色已通过规则检查' })).toBeVisible({ timeout: 15_000 })
   await page.getByRole('button', { name: '完成角色' }).click()
   await expect(page.locator('.create-character-card').filter({ hasText: '新手验收者' })).toBeVisible()
   await page.locator('.create-actions .primary').click()

--- a/frontend-v2/src/api/types.ts
+++ b/frontend-v2/src/api/types.ts
@@ -1066,8 +1066,10 @@ export interface RulesetCombatEvent extends JsonObject {
   critical?: boolean
   delta?: number
   amount?: number
+  hp?: number
   damage_type?: string
   distance?: number
+  reason?: string
 }
 
 export interface RulesetPartyDecision extends JsonObject {

--- a/frontend-v2/src/components/play/CombatLiveBar.vue
+++ b/frontend-v2/src/components/play/CombatLiveBar.vue
@@ -15,7 +15,13 @@ const emit = defineEmits<{ openCombat: [] }>()
 const { locale } = useLocale()
 const historyOpen = ref(false)
 const changed = ref(false)
+const presentedBatchId = ref('')
+const queuedBatchIds = ref<string[]>([])
+const replaying = ref(false)
 let changedTimer: number | undefined
+let playbackTimer: number | undefined
+let playbackInitialized = false
+const seenBatchIds = new Set<string>()
 
 const zh = computed(() => locale.value.startsWith('zh'))
 const combat = computed(() => props.gameplay.combat)
@@ -25,17 +31,65 @@ const events = computed(() => props.gameplay.recent_combat_events || [])
 // second chronology from round/turn fields here: several events in one intent
 // legitimately share those values.
 const orderedEvents = computed(() => events.value)
+const eventBatches = computed(() => {
+  const batches: Array<{ id: string; events: RulesetCombatEvent[] }> = []
+  for (const event of orderedEvents.value) {
+    const id = String(event.batch_id || event.event_id || '')
+    const current = batches[batches.length - 1]
+    if (!current || current.id !== id) batches.push({ id, events: [event] })
+    else current.events.push(event)
+  }
+  return batches
+})
+const latestBatch = computed(() => eventBatches.value[eventBatches.value.length - 1])
+const presentedBatch = computed(() => (
+  eventBatches.value.find(batch => batch.id === presentedBatchId.value) || latestBatch.value
+))
+const presentedEvents = computed(() => presentedBatch.value?.events || [])
 const currentActor = computed(() => combat.value.actors.find(
   actor => actor.actor_id === combat.value.current_actor_id,
 ))
+const ownActor = computed(() => combat.value.actors.find(
+  actor => actor.actor_id === `player:${props.actorId}`,
+))
 const isOwnTurn = computed(() => combat.value.current_actor_id === `player:${props.actorId}`)
-const lastResult = computed(() => [...orderedEvents.value].reverse().find(event => [
-  'check.resolved', 'resource.changed', 'dnd2024.combat.message',
-  'dnd2024.position.changed', 'dnd2024.combat.started', 'dnd2024.combat.ended',
-].includes(event.type)))
-const latestImpact = computed(() => [...orderedEvents.value].reverse().find(event => (
+const lastResult = computed(() => {
+  const reversed = [...presentedEvents.value].reverse()
+  for (const type of [
+    'dnd2024.death_save.resolved', 'check.resolved', 'dnd2024.combat.ended',
+    'dnd2024.combat.message', 'dnd2024.position.changed', 'dnd2024.combat.started',
+    'dnd2024.turn.advanced', 'resource.changed',
+  ]) {
+    const event = reversed.find(item => item.type === type)
+    if (event) return event
+  }
+  return undefined
+})
+const latestImpact = computed(() => [...presentedEvents.value].reverse().find(event => (
   event.type === 'resource.changed' && Number(event.amount ?? event.delta ?? 0) !== 0
 )))
+const isReplaying = computed(() => replaying.value)
+const presentedActor = computed(() => presentedEvents.value.find(event => event.actor_id)?.actor_name || '')
+const presentedActorId = computed(() => presentedEvents.value.find(event => event.actor_id)?.actor_id || '')
+const displayOwnTurn = computed(() => isReplaying.value
+  ? presentedActorId.value === `player:${props.actorId}`
+  : isOwnTurn.value)
+const displayEnemyTurn = computed(() => isReplaying.value
+  ? presentedActorId.value.startsWith('enemy:')
+  : currentActor.value?.kind === 'enemy')
+const presentedRound = computed(() => presentedEvents.value.find(event => event.round)?.round || combat.value.round)
+const deathSaves = computed(() => ownActor.value?.death_saves || {})
+const deathSaveSuccesses = computed(() => Number(deathSaves.value.successes || 0))
+const deathSaveFailures = computed(() => Number(deathSaves.value.failures || 0))
+const showDeathSaves = computed(() => Boolean(
+  ownActor.value && (ownActor.value.hp <= 0 || deathSaveSuccesses.value || deathSaveFailures.value),
+))
+const deathSaveStatus = computed(() => {
+  const conditions = ownActor.value?.conditions || {}
+  if ('dead' in conditions) return zh.value ? '角色死亡' : 'Dead'
+  if ('stable' in conditions) return zh.value ? '伤势稳定' : 'Stable'
+  return isOwnTurn.value ? (zh.value ? '本轮等待投掷' : 'Roll this turn') : (zh.value ? '等待下个回合' : 'Waiting for next turn')
+})
 const readiness = computed(() => props.gameplay.encounter_request?.readiness)
 const latestResultKey = computed(() => {
   const event = lastResult.value
@@ -49,6 +103,9 @@ const title = computed(() => {
       : `Combat ready · ${ready?.ready_count || 0}/${ready?.required_count || 0} party members ready`
   }
   if (combat.value.status === 'ended') return zh.value ? '战斗已经结束' : 'Combat ended'
+  if (isReplaying.value && presentedActor.value) return zh.value
+    ? `第 ${presentedRound.value} 轮 · ${presentedActor.value}的行动`
+    : `Round ${presentedRound.value} · ${presentedActor.value}'s action`
   if (isOwnTurn.value) return zh.value
     ? `第 ${combat.value.round} 轮 · 轮到你行动`
     : `Round ${combat.value.round} · Your turn`
@@ -69,6 +126,11 @@ function eventText(event?: RulesetCombatEvent): string {
     const dc = event.target ?? ''
     const verdict = event.success ? (zh.value ? '命中' : 'hit') : (zh.value ? '未命中' : 'miss')
     const kind = String(event.kind || '')
+    if (kind === 'death_save') {
+      return zh.value
+        ? `${actor}进行死亡豁免：d20 ${event.natural ?? roll}，${event.success ? '成功' : '失败'}`
+        : `${actor} makes a death save: d20 ${event.natural ?? roll}, ${event.success ? 'success' : 'failure'}`
+    }
     if (kind === 'attack' || kind === 'spell_attack' || kind === 'opportunity_attack') {
       const natural = event.natural ?? event.roll ?? ''
       const modifier = Number(event.modifier || 0) + Number(event.bless_bonus || 0)
@@ -92,8 +154,22 @@ function eventText(event?: RulesetCombatEvent): string {
   }
   if (event.type === 'dnd2024.combat.message') return `${actor}：${event.text || ''}`
   if (event.type === 'dnd2024.combat.started') return zh.value ? '先攻已经确定，战斗开始。' : 'Initiative is set. Combat begins.'
-  if (event.type === 'dnd2024.combat.ended') return zh.value ? '战斗结算完成。' : 'Combat resolved.'
+  if (event.type === 'dnd2024.combat.ended') {
+    const reason = String(event.reason || '')
+    if (reason === 'victory') return zh.value ? '敌人已经全部倒下，战斗胜利。' : 'All enemies are down. Victory.'
+    if (reason === 'party_defeated') return zh.value ? '队伍已经战败。' : 'The party has been defeated.'
+    if (reason === 'party_incapacitated') return zh.value ? '全队失去战斗能力，战斗已经停止。' : 'The whole party is incapacitated. Combat has stopped.'
+    return zh.value ? '战斗结算完成。' : 'Combat resolved.'
+  }
   if (event.type === 'dnd2024.turn.advanced') return zh.value ? `轮到${actor}行动` : `${actor}'s turn`
+  if (event.type === 'dnd2024.death_save.resolved') {
+    if (event.dead) return zh.value ? `${actor}死亡豁免失败满 3 次，已经死亡` : `${actor} has died after 3 failed death saves`
+    if (event.stable) return zh.value ? `${actor}死亡豁免成功满 3 次，伤势稳定` : `${actor} is stable after 3 successful death saves`
+    if (Number(event.hp || 0) > 0) return zh.value ? `${actor}掷出自然 20，恢复 1 HP 并苏醒` : `${actor} rolled a natural 20, regained 1 HP, and woke up`
+    return zh.value
+      ? `${actor}死亡豁免：成功 ${event.successes || 0}/3，失败 ${event.failures || 0}/3`
+      : `${actor} death saves: ${event.successes || 0}/3 successes, ${event.failures || 0}/3 failures`
+  }
   if (event.type === 'condition.applied') {
     const condition = String(event.condition || '')
     const labels: Record<string, [string, string]> = {
@@ -154,12 +230,47 @@ function eventTokens(event: RulesetCombatEvent): HistoryToken[] {
 const impactAmount = computed(() => Math.abs(Number(latestImpact.value?.amount || latestImpact.value?.delta || 0)))
 const impactIsHealing = computed(() => Number(latestImpact.value?.delta || 0) > 0)
 const impactTarget = computed(() => latestImpact.value?.target_name || latestImpact.value?.target_id || '')
+const impactSource = computed(() => latestImpact.value?.actor_name || latestImpact.value?.actor_id || '')
 
 function announceChange(duration = 2200): void {
   changed.value = true
   if (changedTimer) window.clearTimeout(changedTimer)
   changedTimer = window.setTimeout(() => { changed.value = false }, duration)
 }
+
+function playNextBatch(): void {
+  if (playbackTimer) window.clearTimeout(playbackTimer)
+  playbackTimer = undefined
+  const next = queuedBatchIds.value.shift()
+  if (!next) {
+    replaying.value = false
+    presentedBatchId.value = latestBatch.value?.id || ''
+    return
+  }
+  replaying.value = true
+  presentedBatchId.value = next
+  announceChange(1050)
+  playbackTimer = window.setTimeout(playNextBatch, 1100)
+}
+
+watch(
+  () => eventBatches.value.map(batch => batch.id).join('|'),
+  () => {
+    const ids = eventBatches.value.map(batch => batch.id).filter(Boolean)
+    if (!playbackInitialized) {
+      ids.forEach(id => seenBatchIds.add(id))
+      presentedBatchId.value = ids[ids.length - 1] || ''
+      playbackInitialized = true
+      return
+    }
+    const additions = ids.filter(id => !seenBatchIds.has(id))
+    additions.forEach(id => seenBatchIds.add(id))
+    if (!additions.length) return
+    queuedBatchIds.value.push(...additions)
+    if (!replaying.value) playNextBatch()
+  },
+  { immediate: true },
+)
 
 watch(
   () => `${combat.value.round}:${combat.value.current_actor_id}`,
@@ -172,22 +283,31 @@ watch(latestResultKey, (next, previous) => {
   if (!previous || !next || next === previous) return
   announceChange(3000)
 })
-onBeforeUnmount(() => { if (changedTimer) window.clearTimeout(changedTimer) })
+onBeforeUnmount(() => {
+  if (changedTimer) window.clearTimeout(changedTimer)
+  if (playbackTimer) window.clearTimeout(playbackTimer)
+})
 </script>
 
 <template>
   <section
     class="combat-live-bar"
-    :class="{ own: isOwnTurn, enemy: currentActor?.kind === 'enemy', changed, pending }"
+    :class="{ own: displayOwnTurn, enemy: displayEnemyTurn, changed, pending }"
     aria-live="assertive"
   >
     <NIcon class="combat-live-icon" :component="ShieldOutline" />
     <div class="combat-live-copy">
       <strong>{{ title }} <em v-if="changed" class="combat-live-updated">{{ zh ? '刚刚更新' : 'Updated just now' }}</em></strong>
       <span>{{ eventText(lastResult) }}</span>
+      <div v-if="showDeathSaves" class="combat-death-saves" role="status">
+        <b>{{ zh ? '死亡豁免' : 'Death saves' }}</b>
+        <span class="save-pips success"><small>{{ zh ? '成功' : 'Success' }}</small><i v-for="slot in 3" :key="`success-${slot}`" :class="{ filled: slot <= deathSaveSuccesses }" /></span>
+        <span class="save-pips failure"><small>{{ zh ? '失败' : 'Failure' }}</small><i v-for="slot in 3" :key="`failure-${slot}`" :class="{ filled: slot <= deathSaveFailures }" /></span>
+        <em>{{ deathSaveStatus }}</em>
+      </div>
     </div>
     <div v-if="latestImpact" class="combat-live-impact" :class="{ healing: impactIsHealing }" role="status" aria-live="polite">
-      <small>{{ impactTarget }} · {{ zh ? '最新生命结算' : 'Latest HP change' }}</small>
+      <small>{{ impactSource }} → {{ impactTarget }} · HP</small>
       <strong>{{ impactIsHealing ? '+' : '-' }}{{ impactAmount }}</strong>
       <span>{{ impactIsHealing ? (zh ? '恢复' : 'healed') : (zh ? '伤害' : 'damage') }}</span>
     </div>
@@ -229,7 +349,7 @@ onBeforeUnmount(() => { if (changedTimer) window.clearTimeout(changedTimer) })
 .combat-live-bar.changed { animation: combat-live-pulse 1.2s ease-out; }
 .combat-live-icon { font-size: 24px; color: #e4b75e; }
 .combat-live-copy { display: grid; min-width: 0; gap: 3px; }
-.combat-live-copy strong, .combat-live-copy span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.combat-live-copy > strong, .combat-live-copy > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .combat-live-copy strong { font-size: 14px; }
 .combat-live-updated { display: inline-block; margin-left: 6px; padding: 2px 6px; border: 1px solid #e4b75e; border-radius: 999px; color: #ffe4a0; background: rgb(228 183 94 / 16%); font-size: 10px; font-style: normal; font-weight: 700; vertical-align: middle; }
 .combat-live-copy span { color: #c4d0d6; font-size: 12px; }
@@ -238,6 +358,15 @@ onBeforeUnmount(() => { if (changedTimer) window.clearTimeout(changedTimer) })
 .combat-live-impact strong { color: #ffe8e9; font-size: 22px; line-height: 1; }
 .combat-live-impact span { color: #ffc8cc; font-size: 11px; }
 .combat-live-impact.healing { border-color: #4c9978; background: #173d30; }.combat-live-impact.healing small, .combat-live-impact.healing span { color: #bdebd7; }.combat-live-impact.healing strong { color: #d9ffed; }
+.combat-live-bar.changed .combat-live-impact { animation: combat-impact-pop .46s ease-out; }
+.combat-death-saves { display: flex; flex-wrap: wrap; align-items: center; gap: 7px 10px; margin-top: 5px; }
+.combat-death-saves > b { color: #f3e6cf; font-size: 11px; }
+.combat-death-saves > em { color: #d6c8b4; font-size: 10px; font-style: normal; }
+.save-pips { display: inline-flex; align-items: center; gap: 4px; }
+.save-pips small { margin-right: 2px; color: #bfc8cd; font-size: 9px; }
+.save-pips i { width: 9px; height: 9px; border: 1px solid #75838a; border-radius: 50%; background: transparent; }
+.save-pips.success i.filled { border-color: #69c99c; background: #69c99c; box-shadow: 0 0 7px rgb(105 201 156 / 50%); }
+.save-pips.failure i.filled { border-color: #ef737c; background: #ef737c; box-shadow: 0 0 7px rgb(239 115 124 / 50%); }
 .combat-live-actions { display: flex; gap: 7px; }
 .combat-live-actions button { display: inline-flex; align-items: center; gap: 5px; min-height: 38px; }
 .combat-history-list { display: grid; gap: 7px; max-height: min(62vh, 560px); margin: 0; padding: 0; overflow: auto; list-style: none; }
@@ -247,6 +376,7 @@ onBeforeUnmount(() => { if (changedTimer) window.clearTimeout(changedTimer) })
 .combat-history-token.self { color: #f1c768; }.combat-history-token.ally { color: #76c8f2; }.combat-history-token.enemy { color: #f17f86; }.combat-history-token.roll { color: #7ddbd4; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-weight: 800; }
 .combat-history-empty { color: var(--df-text-muted); }
 @keyframes combat-live-pulse { 0% { box-shadow: 0 0 0 0 rgb(228 183 94 / 58%); } 55% { box-shadow: 0 0 0 7px rgb(228 183 94 / 0%); } 100% { box-shadow: 0 10px 26px rgb(0 0 0 / 18%); } }
+@keyframes combat-impact-pop { 0% { opacity: .3; transform: scale(.84); } 65% { transform: scale(1.06); } 100% { opacity: 1; transform: scale(1); } }
 @media (max-width: 700px) {
   .combat-live-bar { position: sticky; z-index: 8; top: 4px; grid-template-columns: auto minmax(0, 1fr); gap: 8px; padding: 9px 10px; }
   .combat-live-icon { font-size: 20px; }
@@ -256,5 +386,5 @@ onBeforeUnmount(() => { if (changedTimer) window.clearTimeout(changedTimer) })
   .combat-live-copy span { white-space: normal; line-height: 1.35; }
   .combat-history-list li { grid-template-columns: 1fr; gap: 3px; }
 }
-@media (prefers-reduced-motion: reduce) { .combat-live-bar.changed { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .combat-live-bar.changed, .combat-live-bar.changed .combat-live-impact { animation: none; } }
 </style>

--- a/frontend-v2/src/components/play/CombatLiveBar.vue
+++ b/frontend-v2/src/components/play/CombatLiveBar.vue
@@ -301,8 +301,8 @@ onBeforeUnmount(() => {
       <span>{{ eventText(lastResult) }}</span>
       <div v-if="showDeathSaves" class="combat-death-saves" role="status">
         <b>{{ zh ? '死亡豁免' : 'Death saves' }}</b>
-        <span class="save-pips success"><small>{{ zh ? '成功' : 'Success' }}</small><i v-for="slot in 3" :key="`success-${slot}`" :class="{ filled: slot <= deathSaveSuccesses }" /></span>
-        <span class="save-pips failure"><small>{{ zh ? '失败' : 'Failure' }}</small><i v-for="slot in 3" :key="`failure-${slot}`" :class="{ filled: slot <= deathSaveFailures }" /></span>
+        <span class="save-pips success-pips"><small>{{ zh ? '成功' : 'Success' }}</small><i v-for="slot in 3" :key="`success-${slot}`" :class="{ filled: slot <= deathSaveSuccesses }" /></span>
+        <span class="save-pips failure-pips"><small>{{ zh ? '失败' : 'Failure' }}</small><i v-for="slot in 3" :key="`failure-${slot}`" :class="{ filled: slot <= deathSaveFailures }" /></span>
         <em>{{ deathSaveStatus }}</em>
       </div>
     </div>
@@ -329,8 +329,11 @@ onBeforeUnmount(() => {
   >
     <p v-if="!events.length" class="combat-history-empty">{{ zh ? '尚无战斗记录。' : 'No combat events yet.' }}</p>
     <ol v-else class="combat-history-list">
-      <li v-for="event in [...orderedEvents].reverse()" :key="event.event_id">
-        <span v-if="event.round" class="combat-history-round">{{ zh ? `第 ${event.round} 轮` : `Round ${event.round}` }}</span>
+      <li v-for="(event, eventIndex) in [...orderedEvents].reverse()" :key="event.event_id">
+        <span class="combat-history-meta">
+          <span v-if="event.round" class="combat-history-round">{{ zh ? `第 ${event.round} 轮` : `Round ${event.round}` }}</span>
+          <span v-if="eventIndex === 0" class="combat-history-new">{{ zh ? '新' : 'NEW' }}</span>
+        </span>
         <strong><span
           v-for="(token, index) in eventTokens(event)"
           :key="`${event.event_id}-${index}`"
@@ -365,13 +368,15 @@ onBeforeUnmount(() => {
 .save-pips { display: inline-flex; align-items: center; gap: 4px; }
 .save-pips small { margin-right: 2px; color: #bfc8cd; font-size: 9px; }
 .save-pips i { width: 9px; height: 9px; border: 1px solid #75838a; border-radius: 50%; background: transparent; }
-.save-pips.success i.filled { border-color: #69c99c; background: #69c99c; box-shadow: 0 0 7px rgb(105 201 156 / 50%); }
-.save-pips.failure i.filled { border-color: #ef737c; background: #ef737c; box-shadow: 0 0 7px rgb(239 115 124 / 50%); }
+.save-pips.success-pips i.filled { border-color: #69c99c; background: #69c99c; box-shadow: 0 0 7px rgb(105 201 156 / 50%); }
+.save-pips.failure-pips i.filled { border-color: #ef737c; background: #ef737c; box-shadow: 0 0 7px rgb(239 115 124 / 50%); }
 .combat-live-actions { display: flex; gap: 7px; }
 .combat-live-actions button { display: inline-flex; align-items: center; gap: 5px; min-height: 38px; }
 .combat-history-list { display: grid; gap: 7px; max-height: min(62vh, 560px); margin: 0; padding: 0; overflow: auto; list-style: none; }
 .combat-history-list li { display: grid; grid-template-columns: minmax(72px, auto) minmax(0, 1fr); gap: 9px; padding: 9px 11px; border: 1px solid var(--df-border-soft); border-radius: 9px; background: var(--df-surface-2); }
+.combat-history-meta { display: flex; align-items: flex-start; flex-wrap: wrap; gap: 5px; }
 .combat-history-round { color: var(--df-text-muted); font-size: 11px; }
+.combat-history-new { display: inline-flex; align-items: center; min-height: 18px; padding: 1px 5px; border: 1px solid #e4b75e; border-radius: 999px; color: #ffe4a0; background: rgb(228 183 94 / 16%); font-size: 10px; font-style: normal; font-weight: 800; letter-spacing: .04em; line-height: 1; }
 .combat-history-list strong { font-size: 13px; font-weight: 600; }
 .combat-history-token.self { color: #f1c768; }.combat-history-token.ally { color: #76c8f2; }.combat-history-token.enemy { color: #f17f86; }.combat-history-token.roll { color: #7ddbd4; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-weight: 800; }
 .combat-history-empty { color: var(--df-text-muted); }

--- a/frontend-v2/src/components/play/CombatLiveBar.vue
+++ b/frontend-v2/src/components/play/CombatLiveBar.vue
@@ -124,7 +124,9 @@ function eventText(event?: RulesetCombatEvent): string {
   if (event.type === 'check.resolved') {
     const roll = event.total ?? event.natural ?? ''
     const dc = event.target ?? ''
-    const verdict = event.success ? (zh.value ? '命中' : 'hit') : (zh.value ? '未命中' : 'miss')
+    const verdict = event.success
+      ? (event.critical ? (zh.value ? '暴击命中' : 'critical hit') : (zh.value ? '命中' : 'hit'))
+      : (zh.value ? '未命中' : 'miss')
     const kind = String(event.kind || '')
     if (kind === 'death_save') {
       return zh.value
@@ -145,9 +147,12 @@ function eventText(event?: RulesetCombatEvent): string {
   if (event.type === 'resource.changed') {
     const amount = Math.abs(Number(event.delta || event.amount || 0))
     const healing = Boolean((event as RulesetCombatEvent & { healing?: boolean }).healing) || Number(event.delta || 0) > 0
+    const critical = Boolean(event.critical)
     return healing
       ? (zh.value ? `${target}恢复 ${amount} 点生命` : `${target} recovers ${amount} HP`)
-      : (zh.value ? `${target}受到 ${amount} 点伤害` : `${target} takes ${amount} damage`)
+      : (zh.value
+        ? `${target}受到 ${amount} 点伤害${critical ? '（暴击）' : ''}`
+        : `${target} takes ${amount} damage${critical ? ' (critical)' : ''}`)
   }
   if (event.type === 'dnd2024.position.changed') {
     return zh.value ? `${actor}移动 ${Math.abs(Number(event.distance || 0))} 尺` : `${actor} moves ${Math.abs(Number(event.distance || 0))} ft`

--- a/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
+++ b/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
@@ -340,6 +340,7 @@ function friendlyCombatError(cause: unknown): string {
   if (/not your turn|requested actor is not the current actor/i.test(message)) return '现在还没轮到这个角色。请等待当前行动者结束回合。'
   if (/already been spent|action is not available/i.test(message)) return '这个动作资源本回合已经用掉了。请选择仍可用的动作，或结束回合。'
   if (/state version|stale|expected_version/i.test(message)) return '战斗状态刚刚发生变化，界面已为你刷新。请按最新状态再试一次。'
+  if (/automatic combat turn exceeded the safety limit/i.test(message)) return '敌方自动回合未能正常结束，本次操作已安全回滚。请刷新战斗状态后重试。'
   return message
 }
 
@@ -847,13 +848,13 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
 
           <section class="action-card compact-actions">
             <h3><NIcon :component="ShieldOutline" />{{ copy.economy }}</h3>
-            <button v-if="action('dash')" @click="stageSimple('dash')"><NIcon :component="FootstepsOutline" />{{ copy.dash }}</button>
-            <button v-if="action('dodge')" @click="stageSimple('dodge')"><NIcon :component="ShieldOutline" />{{ copy.dodge }}</button>
-            <button v-if="action('disengage')" @click="stageSimple('disengage')"><NIcon :component="FootstepsOutline" />{{ copy.disengage }}</button>
-            <button v-if="action('death_save')" @click="stageSimple('death_save')"><NIcon :component="SparklesOutline" />{{ copy.deathSave }}</button>
+            <button v-if="action('dash')" :disabled="busy" @click="stageSimple('dash')"><NIcon :component="FootstepsOutline" />{{ copy.dash }}</button>
+            <button v-if="action('dodge')" :disabled="busy" @click="stageSimple('dodge')"><NIcon :component="ShieldOutline" />{{ copy.dodge }}</button>
+            <button v-if="action('disengage')" :disabled="busy" @click="stageSimple('disengage')"><NIcon :component="FootstepsOutline" />{{ copy.disengage }}</button>
+            <button v-if="action('death_save')" :disabled="busy" @click="stageSimple('death_save')"><NIcon :component="SparklesOutline" />{{ copy.deathSave }}</button>
             <p v-if="action('end_turn')" class="end-turn-ready" role="status"><NIcon :component="PlayForwardOutline" />{{ copy.canEndTurn }}</p>
-            <button v-if="action('end_turn')" @click="stageSimple('end_turn')"><NIcon :component="PlayForwardOutline" />{{ copy.endTurn }}</button>
-            <button v-if="action('combat.end')" class="danger" @click="stageSimple('combat.end')"><NIcon :component="ShieldOutline" />{{ copy.endCombat }}</button>
+            <button v-if="action('end_turn')" :disabled="busy" @click="stageSimple('end_turn')"><NIcon :component="PlayForwardOutline" />{{ copy.endTurn }}</button>
+            <button v-if="action('combat.end')" class="danger" :disabled="busy" @click="stageSimple('combat.end')"><NIcon :component="ShieldOutline" />{{ copy.endCombat }}</button>
           </section>
           </div>
         </section>

--- a/frontend-v2/tests/CombatLiveBar.test.ts
+++ b/frontend-v2/tests/CombatLiveBar.test.ts
@@ -145,8 +145,8 @@ describe('combat live bar', () => {
 
     expect(wrapper.text()).toContain('死亡豁免')
     expect(wrapper.text()).toContain('本轮等待投掷')
-    expect(wrapper.findAll('.save-pips.success i.filled')).toHaveLength(2)
-    expect(wrapper.findAll('.save-pips.failure i.filled')).toHaveLength(1)
+    expect(wrapper.findAll('.save-pips.success-pips i.filled')).toHaveLength(2)
+    expect(wrapper.findAll('.save-pips.failure-pips i.filled')).toHaveLength(1)
   })
 
   it('replays newly received automatic batches in order', async () => {
@@ -197,5 +197,7 @@ describe('combat live bar', () => {
     const rows = wrapper.findAll('li')
     expect(rows[0].text()).toContain('最新事件')
     expect(rows[1].text()).toContain('最早事件')
+    expect(rows[0].find('.combat-history-new').text()).toBe('新')
+    expect(rows[1].find('.combat-history-new').exists()).toBe(false)
   })
 })

--- a/frontend-v2/tests/CombatLiveBar.test.ts
+++ b/frontend-v2/tests/CombatLiveBar.test.ts
@@ -97,7 +97,7 @@ describe('combat live bar', () => {
     } as any)
     const wrapper = mountBar({ gameplay: next, actorId: 'ally' })
 
-    expect(wrapper.text()).toContain('阿刃 · 最新生命结算')
+    expect(wrapper.text()).toContain('哥布林 → 阿刃 · HP')
     expect(wrapper.text()).toContain('-6')
     await buttonByText(wrapper, '行动历史').trigger('click')
     const historyText = wrapper.text()
@@ -105,6 +105,84 @@ describe('combat live bar', () => {
     expect(historyText).toContain('调调')
     expect(historyText).toContain('阿刃')
     expect(historyText).toContain('d20 15 + 0 = 15 vs AC 16')
+  })
+
+  it('never pairs an older damage event with a newer attack result', () => {
+    const next = gameplay()
+    next.recent_combat_events = [{
+      event_id: 'old:0', batch_id: 'old', intent_type: 'attack', state_version: 3,
+      type: 'resource.changed', resource: 'hp', actor_id: 'enemy:goblin', actor_name: '哥布林',
+      target_id: 'player:ally', target_name: '阿刃', delta: -9, amount: 9, round: 1,
+    } as any, {
+      ...next.recent_combat_events[0], event_id: 'new:0', batch_id: 'new', state_version: 4,
+    }]
+
+    const wrapper = mountBar({ gameplay: next, actorId: 'ally' })
+
+    expect(wrapper.text()).toContain('未命中')
+    expect(wrapper.text()).not.toContain('最新生命结算')
+    expect(wrapper.text()).not.toContain('-9')
+  })
+
+  it('shares the same combat event while personalizing whose turn it is', () => {
+    const shared = gameplay()
+    const activePlayer = mountBar({ gameplay: shared, actorId: 'ally' })
+    const teammate = mountBar({ gameplay: shared, actorId: 'friend' })
+
+    expect(activePlayer.text()).toContain('第 2 轮 · 轮到你行动')
+    expect(teammate.text()).toContain('第 2 轮 · 阿刃正在行动')
+    expect(activePlayer.text()).toContain('哥布林攻击阿刃')
+    expect(teammate.text()).toContain('哥布林攻击阿刃')
+  })
+
+  it('shows death-save progress and the once-per-turn state', () => {
+    const next = gameplay()
+    next.combat.actors[0].hp = 0
+    next.combat.actors[0].death_saves = { successes: 2, failures: 1 }
+    next.combat.actors[0].conditions = { unconscious: {} }
+
+    const wrapper = mountBar({ gameplay: next, actorId: 'ally' })
+
+    expect(wrapper.text()).toContain('死亡豁免')
+    expect(wrapper.text()).toContain('本轮等待投掷')
+    expect(wrapper.findAll('.save-pips.success i.filled')).toHaveLength(2)
+    expect(wrapper.findAll('.save-pips.failure i.filled')).toHaveLength(1)
+  })
+
+  it('replays newly received automatic batches in order', async () => {
+    vi.useFakeTimers()
+    try {
+      const initial = gameplay()
+      const next = gameplay()
+      next.combat.round = 3
+      next.recent_combat_events.push({
+        ...next.recent_combat_events[0], event_id: 'enemy-hit:0', batch_id: 'enemy-hit',
+        state_version: 5, success: true, total: 18,
+      }, {
+        event_id: 'enemy-hit:1', batch_id: 'enemy-hit', intent_type: 'attack', state_version: 5,
+        type: 'resource.changed', resource: 'hp', actor_id: 'enemy:goblin', actor_name: '哥布林',
+        target_id: 'player:ally', target_name: '阿刃', delta: -4, amount: 4, round: 2,
+      } as any, {
+        event_id: 'enemy-end:0', batch_id: 'enemy-end', intent_type: 'end_turn', state_version: 6,
+        type: 'dnd2024.turn.advanced', actor_id: 'player:ally', actor_name: '阿刃',
+        previous_actor_id: 'enemy:goblin', round: 3, turn_index: 0,
+      } as any)
+      const wrapper = mountBar({ gameplay: initial, actorId: 'ally' })
+
+      await wrapper.setProps({ gameplay: next })
+      await nextTick()
+      expect(wrapper.text()).toContain('哥布林的行动')
+      expect(wrapper.text()).toContain('命中')
+      expect(wrapper.text()).toContain('-4')
+
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(wrapper.text()).toContain('轮到阿刃行动')
+
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(wrapper.text()).toContain('第 3 轮 · 轮到你行动')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps the authoritative event order and only reverses it for newest-first display', async () => {

--- a/frontend-v2/tests/CombatLiveBar.test.ts
+++ b/frontend-v2/tests/CombatLiveBar.test.ts
@@ -55,6 +55,24 @@ describe('combat live bar', () => {
     expect(wrapper.emitted('openCombat')).toHaveLength(1)
   })
 
+  it('labels critical hits in the shared history text', async () => {
+    const next = gameplay()
+    next.recent_combat_events = [{
+      ...next.recent_combat_events[0],
+      event_id: 'critical:0',
+      critical: true,
+      success: true,
+      natural: 20,
+      total: 24,
+      target: 14,
+    }]
+    const wrapper = mountBar({ gameplay: next, actorId: 'ally' })
+
+    expect(wrapper.text()).toContain('暴击命中')
+    await buttonByText(wrapper, '行动历史').trigger('click')
+    expect(wrapper.text()).toContain('暴击命中')
+  })
+
   it('opens a shared action history without opening the combat tool', async () => {
     const wrapper = mountBar({ gameplay: gameplay(), actorId: 'ally' })
 

--- a/src/engine/character_utils.py
+++ b/src/engine/character_utils.py
@@ -424,9 +424,32 @@ def revive_character(character_sheet: dict, method: str = "法术") -> bool:
 
 def reset_character_for_restart(character_sheet: dict) -> dict:
     """重开世界时恢复角色的可复用运行状态。"""
-    raw_max_hp = character_sheet.get("max_hp", 100)
+    canonical = character_sheet.get("ruleset_character")
+    canonical_resources = canonical.get("resources") if isinstance(canonical, dict) else None
+    canonical_hp = canonical_resources.get("hp") if isinstance(canonical_resources, dict) else None
+    canonical_max_hp = (
+        canonical_resources.get("max_hp")
+        if isinstance(canonical_resources, dict) and canonical_resources.get("max_hp") is not None
+        else canonical_hp.get("max") if isinstance(canonical_hp, dict) else None
+    )
+    raw_max_hp = canonical_max_hp if canonical_max_hp is not None else character_sheet.get("max_hp", 100)
     max_hp = int(raw_max_hp if raw_max_hp is not None else 100)
     raw_gold = character_sheet.get("gold", 30)
+
+    if isinstance(canonical, dict):
+        resources = canonical.setdefault("resources", {})
+        if isinstance(resources, dict):
+            canonical_hp = resources.get("hp")
+            if isinstance(canonical_hp, dict):
+                canonical_hp["current"] = max_hp
+                canonical_hp.setdefault("max", max_hp)
+            else:
+                resources["hp"] = max_hp
+        # A restart begins a fresh run. Death/downed/stable and combat-only
+        # conditions must not leak from any canonical character state.
+        canonical["conditions"] = {}
+        canonical["deceased"] = False
+
     set_hp(character_sheet, max_hp, max_hp)
     character_sheet["gold"] = int(raw_gold if raw_gold is not None else 30)
     character_sheet["deceased"] = False

--- a/src/rulesets/dnd2024/combat/resolution.py
+++ b/src/rulesets/dnd2024/combat/resolution.py
@@ -359,11 +359,20 @@ class CombatResolutionMixin:
             for enemy in combat.get("enemies", {}).values()
         ):
             return [{"type": "dnd2024.combat.ended", "reason": "victory"}]
-        if not any(
-            "dead" not in self._actor_view(instance, combat, actor_id)["conditions"]
+        player_conditions = [
+            self._actor_view(instance, combat, actor_id)["conditions"]
             for actor_id in order if actor_id.startswith("player:")
+        ]
+        if not any(
+            "dead" not in conditions and "stable" not in conditions
+            for conditions in player_conditions
         ):
-            return [{"type": "dnd2024.combat.ended", "reason": "party_defeated"}]
+            reason = (
+                "party_incapacitated"
+                if any("stable" in conditions for conditions in player_conditions)
+                else "party_defeated"
+            )
+            return [{"type": "dnd2024.combat.ended", "reason": reason}]
         previous_index = int(combat["turn_index"])
         next_index = previous_index
         wraps = 0

--- a/src/rulesets/dnd2024/runtime.py
+++ b/src/rulesets/dnd2024/runtime.py
@@ -582,7 +582,7 @@ class Dnd2024Runtime:
             "total", "target", "success", "critical", "delta", "amount", "damage_type",
             "healing",
             "distance", "round", "turn_index", "previous_actor_id", "condition", "reason",
-            "spell_ref", "resource", "roll", "successes", "failures", "stable", "dead",
+            "spell_ref", "resource", "roll", "successes", "failures", "stable", "dead", "hp",
         }
         combat = (
             instance.ruleset_state.get("combat")

--- a/tests/rulesets/test_dnd2024_campaign.py
+++ b/tests/rulesets/test_dnd2024_campaign.py
@@ -364,6 +364,27 @@ def test_public_combat_feed_inherits_round_and_source_actor_for_damage() -> None
     assert damage["target_name"] == "Arden"
 
 
+def test_public_combat_feed_keeps_death_save_hp_and_combat_end_reason() -> None:
+    runtime, instance = _instance()
+    instance.event_ledger = [{
+        "batch_id": "death-save", "intent_type": "death_save", "result_version": 3,
+        "events": [{
+            "type": "dnd2024.death_save.resolved", "actor_id": "player:gm",
+            "roll": 20, "successes": 0, "failures": 0, "hp": 1,
+        }],
+    }, {
+        "batch_id": "incapacitated", "intent_type": "end_turn", "result_version": 4,
+        "events": [{
+            "type": "dnd2024.combat.ended", "reason": "party_incapacitated",
+        }],
+    }]
+
+    events = runtime._recent_combat_events(instance)
+
+    assert events[0]["hp"] == 1
+    assert events[1]["reason"] == "party_incapacitated"
+
+
 def test_auto_mode_can_start_a_valid_free_play_catalog_encounter() -> None:
     runtime, instance = _instance()
     instance.solo_mode = True

--- a/tests/rulesets/test_dnd2024_combat.py
+++ b/tests/rulesets/test_dnd2024_combat.py
@@ -390,6 +390,56 @@ def test_stable_actor_remains_unconscious_and_skips_death_save() -> None:
     assert "unconscious" in canonical["conditions"]
 
 
+def test_last_stable_player_ends_combat_instead_of_looping_enemy_turns() -> None:
+    engine, instance = _instance()
+    canonical = instance.get_character_sheet("gm")["ruleset_character"]
+    canonical["resources"]["hp"] = 0
+    canonical["conditions"] = {
+        "unconscious": {"source": "zero_hp"},
+        "stable": {"duration": "until_healed"},
+        "death_saves": {"successes": 3, "failures": 0},
+    }
+    _start(engine, instance)
+
+    ended = engine.resolve_intent(instance, {
+        "intent_id": "stable-player-end", "type": "end_turn", "expected_version": 1,
+        "submitted_by": "gm", "actor_id": "player:gm",
+    }, SequenceRng([]))
+    assert ended["ok"] is True
+    assert ended["event_batch"]["events"][-1] == {
+        "type": "dnd2024.combat.ended", "reason": "party_incapacitated",
+    }
+
+    engine.apply_batch(instance, ended["event_batch"])
+    assert instance.ruleset_state["combat"]["status"] == "ended"
+    assert instance.ruleset_state["combat"]["outcome"] == "party_incapacitated"
+    assert engine.next_automatic_intent(instance) is None
+
+
+def test_stable_player_does_not_end_combat_while_a_teammate_can_act() -> None:
+    engine, instance = _instance()
+    runtime = Dnd2024Runtime()
+    ally = _character(runtime, "stalwart_guardian", "Mira")
+    instance.players["zz-ally"] = {"character_name": "Mira", "character_sheet": ally}
+    canonical = instance.get_character_sheet("gm")["ruleset_character"]
+    canonical["resources"]["hp"] = 0
+    canonical["conditions"] = {
+        "unconscious": {"source": "zero_hp"},
+        "stable": {"duration": "until_healed"},
+        "death_saves": {"successes": 3, "failures": 0},
+    }
+    _start(engine, instance)
+
+    ended = engine.resolve_intent(instance, {
+        "intent_id": "stable-player-pass", "type": "end_turn", "expected_version": 1,
+        "submitted_by": "gm", "actor_id": "player:gm",
+    }, SequenceRng([]))
+
+    assert ended["ok"] is True
+    assert ended["event_batch"]["events"][-1]["type"] == "dnd2024.turn.advanced"
+    assert ended["event_batch"]["events"][-1]["actor_id"] == "player:zz-ally"
+
+
 def test_enemy_turn_is_declared_by_server_and_returns_control_to_player() -> None:
     engine, instance = _instance()
     _start(engine, instance, position=5)

--- a/tests/test_game_instance.py
+++ b/tests/test_game_instance.py
@@ -769,6 +769,47 @@ def test_reset_character_for_restart_preserves_zero_gold():
     assert "status" not in cs
 
 
+def test_reset_character_for_restart_clears_canonical_dnd_death_state():
+    cs = {
+        "hp": 0,
+        "max_hp": 12,
+        "deceased": True,
+        "ruleset_character": {
+            "resources": {"hp": 0, "max_hp": 12},
+            "conditions": {
+                "unconscious": {"source": "zero_hp"},
+                "dead": {"source": "death_saves"},
+                "death_saves": {"successes": 0, "failures": 3},
+            },
+        },
+    }
+
+    reset_character_for_restart(cs)
+
+    assert cs["hp"] == 12
+    assert cs["deceased"] is False
+    assert cs["ruleset_character"]["resources"]["hp"] == 12
+    assert cs["ruleset_character"]["conditions"] == {}
+
+
+def test_reset_character_for_restart_clears_nested_generic_runtime_state():
+    cs = {
+        "hp": 0,
+        "max_hp": 9,
+        "ruleset_character": {
+            "resources": {"hp": {"current": 0, "max": 9}},
+            "conditions": {"dead": {"source": "zero_hp"}},
+            "deceased": True,
+        },
+    }
+
+    reset_character_for_restart(cs)
+
+    assert cs["ruleset_character"]["resources"]["hp"] == {"current": 9, "max": 9}
+    assert cs["ruleset_character"]["conditions"] == {}
+    assert cs["ruleset_character"]["deceased"] is False
+
+
 def test_level_up_syncs_legacy_hp_and_resource_hp(tmp_path):
     inst = GameInstance(game_key=("web", "hp_sync", "bot"))
     inst.players["u1"] = {


### PR DESCRIPTION
## Summary\n- clear canonical HP and death state on restart\n- improve combat turn/history feedback and mark the newest shared history entry\n- make critical-hit and damage results explicit\n- isolate death-save pip styles from global success/failure backgrounds\n- extend the mobile guided-creation smoke wait to avoid timing flakes\n\n## Validation\n- frontend CombatLiveBar tests: 11 passed\n- D&D combat and campaign tests: 41 passed\n- frontend typecheck: passed\n- frontend production build: passed\n\nThis is a follow-up to the merged #194 changes and is not auto-merged.