### PR TITLE
ci: order release assets for users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,8 @@ jobs:
           overwrite_files: false
           preserve_order: true
           files: |
-            dist/DiceFrame-${{ github.ref_name }}-windows.zip
             dist/DiceFrame-${{ github.ref_name }}-windows-portable.zip
+            dist/DiceFrame-${{ github.ref_name }}-windows.zip
             dist/DiceFrame-${{ github.ref_name }}-docker-update-linux-amd64.zip
             dist/SHA256SUMS
 


### PR DESCRIPTION
Summary: Upload release assets in this user-facing order: Windows portable, Windows source, Docker update, checksums. Keep preserve_order enabled. Validation: YAML parse and git diff --check passed.