### PR TITLE
test: enforce architecture debt baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run frontend tests
         run: npm run test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ ignore_missing_imports = true
 follow_imports = "skip"
 check_untyped_defs = true
 files = [
+    "scripts/architecture_fitness.py",
     "src/engine/contracts.py",
     "src/engine/luck_resolver.py",
     "src/engine/persistence.py",

--- a/scripts/architecture_fitness.py
+++ b/scripts/architecture_fitness.py
@@ -1,0 +1,222 @@
+"""Architecture debt scanners used by CI fitness-function tests.
+
+The scanners deliberately operate on dependency-bearing syntax rather than
+source snapshots.  Existing debt is recorded by the tests as an explicit
+allowlist; new files, dependency modes, concrete runtime identifiers, event
+namespaces, or concrete frontend imports therefore fail the architecture gate.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True, order=True)
+class DependencyDebt:
+    """One stable dependency-boundary violation discovered in production code."""
+
+    path: str
+    kind: str
+    target: str
+
+
+_BACKEND_GENERIC_DIRECTORIES = (
+    "src/commands",
+    "src/engine",
+    "src/llm",
+    "src/webui/services",
+)
+_PYTHON_SUFFIX = ".py"
+_FRONTEND_SUFFIXES = frozenset({".js", ".jsx", ".ts", ".tsx", ".vue"})
+_CONCRETE_RULESET_MODULE = "src.rulesets.dnd2024"
+_CONCRETE_RUNTIME_ID = "core:dnd2024"
+_CONCRETE_EVENT_PREFIX = "dnd2024."
+_CONCRETE_FRONTEND_SEGMENT = "rulesets/dnd2024/"
+_CONCRETE_FRONTEND_OWNER = "frontend-v2/src/features/rulesets/dnd2024"
+
+# These patterns only inspect module specifiers in static import/export
+# declarations and dynamic import() expressions.  They do not match arbitrary
+# strings or UI copy in Vue/TypeScript source.
+_STATIC_IMPORT = re.compile(
+    r"(?:^|[;\n])\s*(?:import|export)\s+(?:[^'\"\n]*?\s+from\s+)?['\"]([^'\"]+)['\"]",
+    re.MULTILINE,
+)
+_DYNAMIC_IMPORT = re.compile(r"\bimport\s*\(\s*['\"]([^'\"]+)['\"]\s*\)")
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _python_files(root: Path, directories: Iterable[str]) -> Iterable[Path]:
+    for directory in directories:
+        base = root / directory
+        if base.exists():
+            yield from sorted(base.rglob(f"*{_PYTHON_SUFFIX}"))
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+
+
+def _function_arguments(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterable[ast.arg]:
+    yield from node.args.posonlyargs
+    yield from node.args.args
+    yield from node.args.kwonlyargs
+    if node.args.vararg is not None:
+        yield node.args.vararg
+    if node.args.kwarg is not None:
+        yield node.args.kwarg
+
+
+def _mentions_webapi(annotation: ast.expr | None) -> bool:
+    if annotation is None:
+        return False
+    for node in ast.walk(annotation):
+        if isinstance(node, ast.Name) and node.id == "WebAPI":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "WebAPI":
+            return True
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.rsplit(".", 1)[-1] == "WebAPI":
+                return True
+    return False
+
+
+def scan_service_locator_debt(root: Path) -> set[DependencyDebt]:
+    """Find services that receive or reach back through the WebAPI facade."""
+
+    found: set[DependencyDebt] = set()
+    for path in _python_files(root, ("src/webui/services",)):
+        relative = _relative(root, path)
+        tree = _tree(path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "src.webui.api":
+                if any(alias.name == "WebAPI" for alias in node.names):
+                    found.add(DependencyDebt(relative, "webapi_import", "src.webui.api.WebAPI"))
+            elif isinstance(node, ast.Import):
+                if any(alias.name == "src.webui.api" for alias in node.names):
+                    found.add(DependencyDebt(relative, "webapi_import", "src.webui.api"))
+
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            api_arguments = {
+                argument.arg: argument
+                for argument in _function_arguments(node)
+                if argument.arg == "api"
+            }
+            if not api_arguments:
+                continue
+            if any(_mentions_webapi(argument.annotation) for argument in api_arguments.values()):
+                found.add(DependencyDebt(relative, "webapi_parameter", "WebAPI"))
+
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Attribute)
+                    and isinstance(child.value, ast.Name)
+                    and child.value.id == "api"
+                    and child.attr.startswith("_")
+                    and not child.attr.startswith("__")
+                ):
+                    found.add(DependencyDebt(relative, "private_facade_access", "api._*"))
+                elif (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Attribute)
+                    and isinstance(child.func.value, ast.Name)
+                    and child.func.value.id == "api"
+                    and not child.func.attr.startswith("_")
+                ):
+                    found.add(DependencyDebt(relative, "facade_service_call", "api.<service>()"))
+    return found
+
+
+def _import_modules(node: ast.Import | ast.ImportFrom) -> Iterable[str]:
+    if isinstance(node, ast.Import):
+        yield from (alias.name for alias in node.names)
+        return
+    if node.module:
+        yield node.module
+
+
+def scan_backend_concrete_ruleset_debt(root: Path) -> set[DependencyDebt]:
+    """Find concrete D&D knowledge in generic backend production paths."""
+
+    found: set[DependencyDebt] = set()
+    for path in _python_files(root, _BACKEND_GENERIC_DIRECTORIES):
+        relative = _relative(root, path)
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for module in _import_modules(node):
+                    if module == _CONCRETE_RULESET_MODULE or module.startswith(
+                        f"{_CONCRETE_RULESET_MODULE}."
+                    ):
+                        found.add(DependencyDebt(relative, "concrete_import", module))
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if node.value == _CONCRETE_RUNTIME_ID:
+                    found.add(DependencyDebt(relative, "runtime_id", node.value))
+                elif node.value.startswith(_CONCRETE_EVENT_PREFIX):
+                    found.add(DependencyDebt(relative, "event_type", node.value))
+    return found
+
+
+def _frontend_module_specifiers(source: str) -> Iterable[str]:
+    for pattern in (_STATIC_IMPORT, _DYNAMIC_IMPORT):
+        yield from (match.group(1) for match in pattern.finditer(source))
+
+
+def scan_frontend_concrete_ruleset_debt(root: Path) -> set[DependencyDebt]:
+    """Find concrete D&D imports outside the D&D-owned frontend feature."""
+
+    source_root = root / "frontend-v2" / "src"
+    found: set[DependencyDebt] = set()
+    if not source_root.exists():
+        return found
+    for path in sorted(source_root.rglob("*")):
+        if not path.is_file() or path.suffix not in _FRONTEND_SUFFIXES:
+            continue
+        relative = _relative(root, path)
+        if relative == _CONCRETE_FRONTEND_OWNER or relative.startswith(
+            f"{_CONCRETE_FRONTEND_OWNER}/"
+        ):
+            continue
+        source = path.read_text(encoding="utf-8-sig")
+        for module in _frontend_module_specifiers(source):
+            normalized = module.replace("\\", "/")
+            if _CONCRETE_FRONTEND_SEGMENT in normalized:
+                found.add(DependencyDebt(relative, "concrete_import", normalized))
+    return found
+
+
+def assert_debt_matches_allowlist(
+    actual: set[DependencyDebt],
+    allowed: set[DependencyDebt] | frozenset[DependencyDebt],
+    *,
+    boundary: str,
+) -> None:
+    """Require the allowlist to exactly describe current debt.
+
+    Exact matching makes stale entries fail after a migration, forcing the
+    allowlist to shrink.  Unlisted entries fail immediately when debt grows.
+    """
+
+    unexpected = sorted(actual - allowed)
+    stale = sorted(allowed - actual)
+    if not unexpected and not stale:
+        return
+    details = [f"{boundary} debt baseline changed:"]
+    details.extend(f"  unexpected: {item}" for item in unexpected)
+    details.extend(f"  stale allowlist entry: {item}" for item in stale)
+    raise AssertionError("\n".join(details))
+
+
+def debt_by_path(debt: Iterable[DependencyDebt]) -> Mapping[str, tuple[DependencyDebt, ...]]:
+    """Group debt for concise diagnostics and release/report summaries."""
+
+    grouped: dict[str, list[DependencyDebt]] = {}
+    for item in sorted(debt):
+        grouped.setdefault(item.path, []).append(item)
+    return {path: tuple(items) for path, items in grouped.items()}

--- a/tests/architecture/test_fitness_functions.py
+++ b/tests/architecture/test_fitness_functions.py
@@ -1,0 +1,231 @@
+"""Debt baselines for dependency directions that are being retired gradually.
+
+The allowlists describe the P0 repository state. They must only shrink: the
+scanner rejects both new debt and stale entries left behind after a migration.
+Synthetic regressions use ``tmp_path`` so tests never touch runtime data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.architecture_fitness import (
+    DependencyDebt,
+    assert_debt_matches_allowlist,
+    scan_backend_concrete_ruleset_debt,
+    scan_frontend_concrete_ruleset_debt,
+    scan_service_locator_debt,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+_SERVICE_TARGETS = {
+    "facade_service_call": "api.<service>()",
+    "private_facade_access": "api._*",
+    "webapi_import": "src.webui.api.WebAPI",
+    "webapi_parameter": "WebAPI",
+}
+
+
+def _service_debt(path: str, *kinds: str) -> set[DependencyDebt]:
+    return {
+        DependencyDebt(f"src/webui/services/{path}", kind, _SERVICE_TARGETS[kind])
+        for kind in kinds
+    }
+
+
+_STANDARD_WEBAPI_DEBT = (
+    "private_facade_access",
+    "webapi_import",
+    "webapi_parameter",
+)
+_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT = (
+    "facade_service_call",
+    *_STANDARD_WEBAPI_DEBT,
+)
+
+# Historical service-locator debt. Do not add entries. Remove a file or
+# category in the same PR that removes the corresponding dependency.
+SERVICE_LOCATOR_ALLOWLIST = frozenset().union(
+    _service_debt("adventures.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("assistant.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt("character_cards.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("characters.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt(
+        "content_pack_maps.py",
+        "facade_service_call",
+        "webapi_import",
+        "webapi_parameter",
+    ),
+    _service_debt("game_queries.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("generation.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("maps.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt("plugins.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt("rules.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("ruleset_advancement.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("ruleset_builder.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("ruleset_characters.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("ruleset_gameplay.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("ruleset_rest.py", *_STANDARD_WEBAPI_DEBT),
+    _service_debt("tunnel.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt("turns.py", *_STANDARD_WEBAPI_AND_SERVICE_CALL_DEBT),
+    _service_debt("updater.py", "facade_service_call"),
+    _service_debt("worlds.py", *_STANDARD_WEBAPI_DEBT),
+)
+
+# Historical concrete-ruleset knowledge in otherwise generic backend modules.
+# Each entry is a dependency semantic, not a line/function/source snapshot.
+BACKEND_CONCRETE_RULESET_ALLOWLIST = frozenset(
+    {
+        DependencyDebt("src/webui/services/adventures.py", "runtime_id", "core:dnd2024"),
+        DependencyDebt(
+            "src/webui/services/characters.py",
+            "concrete_import",
+            "src.rulesets.dnd2024.advancement_access",
+        ),
+        DependencyDebt("src/webui/services/characters.py", "runtime_id", "core:dnd2024"),
+        DependencyDebt(
+            "src/webui/services/ruleset_advancement.py",
+            "concrete_import",
+            "src.rulesets.dnd2024",
+        ),
+        DependencyDebt(
+            "src/webui/services/ruleset_advancement.py",
+            "concrete_import",
+            "src.rulesets.dnd2024.progression.catalog",
+        ),
+        DependencyDebt(
+            "src/webui/services/ruleset_advancement.py", "runtime_id", "core:dnd2024"
+        ),
+        DependencyDebt(
+            "src/webui/services/ruleset_gameplay.py", "runtime_id", "core:dnd2024"
+        ),
+        *(
+            DependencyDebt("src/webui/services/ruleset_gameplay.py", "event_type", event)
+            for event in (
+                "dnd2024.combat.ended",
+                "dnd2024.combat.started",
+                "dnd2024.party_decision.resolved",
+                "dnd2024.tutorial.choice_applied",
+                "dnd2024.tutorial.completed",
+                "dnd2024.tutorial.started",
+            )
+        ),
+    }
+)
+
+# Historical direct imports outside the D&D-owned frontend feature directory.
+FRONTEND_CONCRETE_RULESET_ALLOWLIST = frozenset(
+    {
+        DependencyDebt(
+            "frontend-v2/src/components/play/CombatMessageComposer.vue",
+            "concrete_import",
+            "@/features/rulesets/dnd2024/api",
+        ),
+        DependencyDebt(
+            "frontend-v2/src/features/admin/CharactersView.vue",
+            "concrete_import",
+            "@/features/rulesets/dnd2024/progression/Dnd2024AdvancementPanel.vue",
+        ),
+        DependencyDebt(
+            "frontend-v2/src/features/rulesets/ProfessionalCharacterCenter.vue",
+            "concrete_import",
+            "@/features/rulesets/dnd2024/api",
+        ),
+        *(
+            DependencyDebt(
+                "frontend-v2/src/features/play/PlayView.vue", "concrete_import", target
+            )
+            for target in (
+                "@/features/rulesets/dnd2024/api",
+                "@/features/rulesets/dnd2024/campaign/Dnd2024CampaignPanel.vue",
+                "@/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue",
+            )
+        ),
+    }
+)
+
+
+def test_service_locator_debt_matches_shrink_only_baseline() -> None:
+    assert_debt_matches_allowlist(
+        scan_service_locator_debt(ROOT),
+        SERVICE_LOCATOR_ALLOWLIST,
+        boundary="services -> WebAPI",
+    )
+
+
+def test_backend_concrete_ruleset_debt_matches_shrink_only_baseline() -> None:
+    assert_debt_matches_allowlist(
+        scan_backend_concrete_ruleset_debt(ROOT),
+        BACKEND_CONCRETE_RULESET_ALLOWLIST,
+        boundary="generic backend -> dnd2024",
+    )
+
+
+def test_frontend_concrete_ruleset_debt_matches_shrink_only_baseline() -> None:
+    assert_debt_matches_allowlist(
+        scan_frontend_concrete_ruleset_debt(ROOT),
+        FRONTEND_CONCRETE_RULESET_ALLOWLIST,
+        boundary="generic frontend -> dnd2024",
+    )
+
+
+def test_new_service_locator_dependency_is_rejected(tmp_path: Path) -> None:
+    service = tmp_path / "src/webui/services/new_service.py"
+    service.parent.mkdir(parents=True)
+    service.write_text(
+        "from src.webui.api import WebAPI\n"
+        "def run(api: WebAPI):\n"
+        "    return api._reg.list_all()\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError):
+        assert_debt_matches_allowlist(
+            scan_service_locator_debt(tmp_path), set(), boundary="services -> WebAPI"
+        )
+
+
+def test_removing_allowlist_entry_while_debt_remains_is_rejected() -> None:
+    actual = scan_service_locator_debt(ROOT)
+    shortened = set(SERVICE_LOCATOR_ALLOWLIST)
+    shortened.remove(next(iter(shortened)))
+
+    with pytest.raises(AssertionError):
+        assert_debt_matches_allowlist(actual, shortened, boundary="services -> WebAPI")
+
+
+def test_new_generic_backend_concrete_ruleset_import_is_rejected(tmp_path: Path) -> None:
+    module = tmp_path / "src/engine/new_runtime_bridge.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(
+        "from src.rulesets.dnd2024.runtime import Dnd2024Runtime\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError):
+        assert_debt_matches_allowlist(
+            scan_backend_concrete_ruleset_debt(tmp_path),
+            set(),
+            boundary="generic backend -> dnd2024",
+        )
+
+
+def test_new_generic_frontend_concrete_ruleset_import_is_rejected(tmp_path: Path) -> None:
+    component = tmp_path / "frontend-v2/src/components/NewPanel.vue"
+    component.parent.mkdir(parents=True)
+    component.write_text(
+        '<script setup lang="ts">\n'
+        "import { submitRulesetIntent } from '@/features/rulesets/dnd2024/api'\n"
+        "</script>\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError):
+        assert_debt_matches_allowlist(
+            scan_frontend_concrete_ruleset_debt(tmp_path),
+            set(),
+            boundary="generic frontend -> dnd2024",
+        )


### PR DESCRIPTION
## Summary

- add typed AST-based fitness functions for legacy `services -> WebAPI` coupling
- baseline concrete D&D dependencies in generic backend and frontend production paths
- prove new debt and stale/under-reported allowlists are rejected with temporary fixtures
- add the already-clean frontend lint command to CI

## P0 debt baseline

- service-locator debt: 19 files / 61 dependency categories
- generic backend -> D&D 2024: 4 files / 13 concrete dependency semantics
- generic frontend -> D&D 2024: 4 files / 6 direct imports

Existing debt remains intentionally allowed, but the exact baseline must shrink when migrations remove it and cannot grow unnoticed.

## Validation

- `python -m ruff check src/`
- `python -m ruff check scripts/architecture_fitness.py tests/architecture/test_fitness_functions.py`
- `python -m mypy`
- `python -m pytest -q` — 1743 passed, 1 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 377 passed
- `npm run build`
- `npm run test:e2e:smoke` — 69 passed, 1 skipped

## Behavior changes

None. No API, save schema, permissions, multiplayer, ruleset mechanics, or UI behavior changed.

Baseline: `d83865b259c6c9f48df0235c64b3b01d81680f69`
