### PR TITLE
ci: order release assets consistently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,8 @@ jobs:
           overwrite_files: false
           preserve_order: true
           files: |
-            dist/DiceFrame-${{ github.ref_name }}-windows-portable.zip
             dist/DiceFrame-${{ github.ref_name }}-windows.zip
+            dist/DiceFrame-${{ github.ref_name }}-windows-portable.zip
             dist/DiceFrame-${{ github.ref_name }}-docker-update-linux-amd64.zip
             dist/SHA256SUMS
 


### PR DESCRIPTION
Keep release asset order consistent: Windows source package, Windows portable package, Docker update package, then SHA256SUMS.