### PR TITLE
chore: prepare 2.5.1-beta.2 preview release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,8 @@ jobs:
           overwrite_files: false
           preserve_order: true
           files: |
-            dist/DiceFrame-${{ github.ref_name }}-windows-portable.zip
             dist/DiceFrame-${{ github.ref_name }}-windows.zip
+            dist/DiceFrame-${{ github.ref_name }}-windows-portable.zip
             dist/DiceFrame-${{ github.ref_name }}-docker-update-linux-amd64.zip
             dist/SHA256SUMS
 

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.5.1-beta.1"
+__version__ = "2.5.1-beta.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
Prepare the 2.5.1-beta.2 preview release after PR205. Includes the agreed release asset order: Windows portable, Windows source, Docker update, SHA256SUMS.