### PR TITLE
fix: support cross-turn purchase quote confirmation

### DIFF
--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -336,8 +336,6 @@ def settle_purchase_quote(
 ) -> bool:
     """Turn an open quote into a typed proposal when a player confirms it."""
 
-    if has_economy_proposal(data):
-        return False
     confirming_uids = {
         str(action.get("user_id") or "")
         for action in getattr(instance, "action_queue", [])
@@ -386,7 +384,27 @@ def settle_purchase_quote(
             for key in ("equip_gain", "weapon_change"):
                 if str(player_update.get(key) or "").strip() in items:
                     player_update.pop(key, None)
-    state_update.setdefault("economy_proposals", []).append({
+    proposals = state_update.setdefault("economy_proposals", [])
+    def conflicts_with_quote(proposal: Any) -> bool:
+        if not isinstance(proposal, dict) or proposal.get("kind") != "purchase":
+            return False
+        rewards = proposal.get("rewards")
+        if isinstance(rewards, list) and any(
+            isinstance(item, dict)
+            and str(item.get("name") or item.get("item") or "").strip() in items
+            for item in rewards
+        ):
+            return True
+        proposal_items = proposal.get("items")
+        return isinstance(proposal_items, list) and any(
+            str(item).strip() in items for item in proposal_items
+        )
+
+    state_update["economy_proposals"] = [
+        proposal for proposal in proposals
+        if not conflicts_with_quote(proposal)
+    ]
+    state_update["economy_proposals"].append({
         "kind": "purchase", "uid": payer_uid, "amount": amount,
         "recipient_uid": str(quote.get("recipient_uid") or payer_uid),
         "items": items, "reason": str(quote.get("reason") or "购买商品"),
@@ -427,9 +445,25 @@ def record_purchase_quote(
         if isinstance(action, dict)
     )
     amounts = _currency_amounts(narration, currency_labels)
-    grant_uids = {uid for uid, _item in grants}
+    offer_pattern = _PURCHASE_OFFER_RE
+    sentences = re.split(r"[。！？.!?\n]+", str(narration or ""))
+    bound_grants = [
+        grant for grant in grants
+        if any(
+            grant[1].casefold() in sentence.casefold()
+            and offer_pattern.search(sentence)
+            and _currency_amount_pattern(currency_labels).search(sentence)
+            for sentence in sentences
+        )
+        or (
+            grant[1].casefold() in action_text.casefold()
+            and len(amounts) == 1
+            and bool(offer_pattern.search(narration))
+        )
+    ]
+    grant_uids = {uid for uid, _item in bound_grants}
     if (
-        len(grants) == 0
+        len(bound_grants) == 0
         or len(grant_uids) != 1
         or len(amounts) != 1
         or not (
@@ -453,19 +487,29 @@ def record_purchase_quote(
     quotes[:] = [{
         "run_id": str(getattr(instance, "run_id", "")),
         "round": int(getattr(instance, "round_number", 0) or 0),
-        "payer_uid": grants[0][0], "recipient_uid": grants[0][0],
-        "amount": amounts[0], "items": [item for _uid, item in grants],
+        "payer_uid": bound_grants[0][0], "recipient_uid": bound_grants[0][0],
+        "amount": amounts[0], "items": [item for _uid, item in bound_grants],
         "reason": "购买商品", "status": "open",
     }]
     # A quote is only an offer.  Keep its items out of the immediate state
     # update; confirmation will re-create the typed proposal and its deferred
     # effect group.
-    state_update["loot"] = []
+    bound_pairs = set(bound_grants)
+    if isinstance(state_update.get("loot"), list):
+        state_update["loot"] = [
+            entry for entry in state_update["loot"]
+            if not (
+                isinstance(entry, dict)
+                and (str(entry.get("player") or ""), str(entry.get("item") or "").strip()) in bound_pairs
+            )
+        ]
     if isinstance(players_update, dict):
-        for update in players_update.values():
-            if isinstance(update, dict):
-                update.pop("equip_gain", None)
-                update.pop("weapon_change", None)
+        for uid, update in players_update.items():
+            if not isinstance(update, dict):
+                continue
+            for key in ("equip_gain", "weapon_change"):
+                if (str(uid), str(update.get(key) or "").strip()) in bound_pairs:
+                    update.pop(key, None)
     return True
 
 

--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -46,6 +46,9 @@ _PURCHASE_CONFIRM_RE = re.compile(
     r"deal|accept|accepted|confirm|confirmed|buy it|take it|pay|yes|"
     r"成約|購入|承知|支払う|了解です|はい|了承)", re.IGNORECASE,
 )
+_PURCHASE_OFFER_RE = re.compile(
+    r"(?:需要|需|售价|价格|费用|收费|cost|price|charge)", re.IGNORECASE,
+)
 def _currency_labels(currency_labels: Iterable[str] | None = None) -> tuple[str, ...]:
     """Return canonical rule labels plus legacy aliases for text recognition.
 
@@ -363,10 +366,26 @@ def settle_purchase_quote(
     if amount <= 0 or not items:
         return False
     state_update = data.setdefault("state_update", {})
-    state_update.setdefault("loot", []).extend(
-        {"player": str(quote.get("recipient_uid") or payer_uid), "item": item}
-        for item in items
-    )
+    # The persisted quote is the only source of truth for purchased goods.
+    # Remove any model-repeated copy from ordinary LOOT/EQUIP before the
+    # proposal is queued, so confirmation cannot reintroduce double delivery.
+    loot = state_update.get("loot")
+    if isinstance(loot, list):
+        state_update["loot"] = [
+            entry for entry in loot
+            if not (
+                isinstance(entry, dict)
+                and str(entry.get("player") or "") == payer_uid
+                and str(entry.get("item") or "").strip() in items
+            )
+        ]
+    players_update = state_update.get("players")
+    if isinstance(players_update, dict):
+        player_update = players_update.get(payer_uid)
+        if isinstance(player_update, dict):
+            for key in ("equip_gain", "weapon_change"):
+                if str(player_update.get(key) or "").strip() in items:
+                    player_update.pop(key, None)
     state_update.setdefault("economy_proposals", []).append({
         "kind": "purchase", "uid": payer_uid, "amount": amount,
         "recipient_uid": str(quote.get("recipient_uid") or payer_uid),
@@ -402,11 +421,35 @@ def record_purchase_quote(
                 for key in ("equip_gain", "weapon_change"):
                     if str(update.get(key) or "").strip():
                         grants.append((str(uid), str(update[key]).strip()))
+    action_text = "\n".join(
+        str(action.get("text") or "")
+        for action in getattr(instance, "action_queue", [])
+        if isinstance(action, dict)
+    )
     amounts = _currency_amounts(narration, currency_labels)
     grant_uids = {uid for uid, _item in grants}
-    if len(grants) == 0 or len(grant_uids) != 1 or len(amounts) != 1:
+    if (
+        len(grants) == 0
+        or len(grant_uids) != 1
+        or len(amounts) != 1
+        or not (
+            (
+                _PURCHASE_OFFER_RE.search(narration)
+                and _currency_amount_pattern(currency_labels).search(narration)
+            )
+            or _PURCHASE_INTENT_RE.search(action_text)
+        )
+    ):
         return False
     quotes = _purchase_quotes(instance)
+    if any(
+        isinstance(quote, dict) and quote.get("status", "open") == "open"
+        for quote in quotes
+    ):
+        # A persisted offer is authoritative until it is confirmed or
+        # invalidated by rollback; never replace its amount/items with a
+        # later model narration.
+        return False
     quotes[:] = [{
         "run_id": str(getattr(instance, "run_id", "")),
         "round": int(getattr(instance, "round_number", 0) or 0),

--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -41,6 +41,11 @@ _PURCHASE_INTENT_RE = re.compile(
     re.IGNORECASE,
 )
 _FREE_PURCHASE_RE = re.compile(r"(?:免费|无需付费|不用钱|免费领取|free|no charge)", re.IGNORECASE)
+_PURCHASE_CONFIRM_RE = re.compile(
+    r"(?:成交|买了|买下|购买|确认购买|接受报价|就要这个|行|可以|同意|付钱|结账|"
+    r"deal|accept|accepted|confirm|confirmed|buy it|take it|pay|yes|"
+    r"成約|購入|承知|支払う|了解です|はい|了承)", re.IGNORECASE,
+)
 def _currency_labels(currency_labels: Iterable[str] | None = None) -> tuple[str, ...]:
     """Return canonical rule labels plus legacy aliases for text recognition.
 
@@ -309,6 +314,106 @@ def has_server_purchase_guard(data: dict[str, Any]) -> bool:
         isinstance(proposal, dict) and proposal.get("source") == "server_purchase_guard"
         for proposal in proposals
     )
+
+def _purchase_quotes(instance: Any) -> list[dict[str, Any]]:
+    economy = getattr(instance, "economy", None)
+    if not isinstance(economy, dict):
+        return []
+    quotes = economy.setdefault("purchase_quotes", [])
+    if not isinstance(quotes, list):
+        economy["purchase_quotes"] = []
+    return economy["purchase_quotes"]
+
+
+def settle_purchase_quote(
+    instance: Any,
+    data: dict[str, Any],
+    *,
+    currency_labels: Iterable[str] | None = None,
+) -> bool:
+    """Turn an open quote into a typed proposal when a player confirms it."""
+
+    if has_economy_proposal(data):
+        return False
+    action_text = "\n".join(
+        str(action.get("text") or "")
+        for action in getattr(instance, "action_queue", [])
+        if isinstance(action, dict)
+    )
+    if not _PURCHASE_CONFIRM_RE.search(action_text):
+        return False
+    quotes = _purchase_quotes(instance)
+    if len(quotes) != 1:
+        return False
+    quote = quotes[0]
+    payer_uid = str(quote.get("payer_uid") or "")
+    if not payer_uid or payer_uid not in getattr(instance, "players", {}):
+        return False
+    items = [str(item).strip() for item in quote.get("items", []) if str(item).strip()]
+    amount = int(quote.get("amount", 0) or 0)
+    if amount <= 0 or not items:
+        return False
+    state_update = data.setdefault("state_update", {})
+    state_update.setdefault("loot", []).extend(
+        {"player": str(quote.get("recipient_uid") or payer_uid), "item": item}
+        for item in items
+    )
+    state_update.setdefault("economy_proposals", []).append({
+        "kind": "purchase", "uid": payer_uid, "amount": amount,
+        "recipient_uid": str(quote.get("recipient_uid") or payer_uid),
+        "items": items, "reason": str(quote.get("reason") or "购买商品"),
+        "approval_policy": "payer", "source": "server_purchase_quote",
+    })
+    quotes.clear()
+    return True
+
+
+def record_purchase_quote(
+    instance: Any,
+    data: dict[str, Any],
+    narration: str,
+    *,
+    currency_labels: Iterable[str] | None = None,
+) -> bool:
+    """Persist one uncommitted shop quote for a later confirmation turn."""
+
+    if has_economy_proposal(data):
+        return False
+    state_update = data.get("state_update")
+    if not isinstance(state_update, dict):
+        return False
+    grants: list[tuple[str, str]] = []
+    for item in state_update.get("loot", []) if isinstance(state_update.get("loot"), list) else []:
+        if isinstance(item, dict) and str(item.get("player") or "").strip() and str(item.get("item") or "").strip():
+            grants.append((str(item["player"]), str(item["item"]).strip()))
+    players_update = state_update.get("players")
+    if isinstance(players_update, dict):
+        for uid, update in players_update.items():
+            if isinstance(update, dict):
+                for key in ("equip_gain", "weapon_change"):
+                    if str(update.get(key) or "").strip():
+                        grants.append((str(uid), str(update[key]).strip()))
+    amounts = _currency_amounts(narration, currency_labels)
+    if len(grants) == 0 or len(amounts) != 1:
+        return False
+    quotes = _purchase_quotes(instance)
+    quotes[:] = [{
+        "run_id": str(getattr(instance, "run_id", "")),
+        "round": int(getattr(instance, "round_number", 0) or 0),
+        "payer_uid": grants[0][0], "recipient_uid": grants[0][0],
+        "amount": amounts[0], "items": [item for _uid, item in grants],
+        "reason": "购买商品", "status": "open",
+    }]
+    # A quote is only an offer.  Keep its items out of the immediate state
+    # update; confirmation will re-create the typed proposal and its deferred
+    # effect group.
+    state_update["loot"] = []
+    if isinstance(players_update, dict):
+        for update in players_update.values():
+            if isinstance(update, dict):
+                update.pop("equip_gain", None)
+                update.pop("weapon_change", None)
+    return True
 
 
 def discard_unearned_reward_proposals(

--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -335,19 +335,28 @@ def settle_purchase_quote(
 
     if has_economy_proposal(data):
         return False
-    action_text = "\n".join(
-        str(action.get("text") or "")
+    confirming_uids = {
+        str(action.get("user_id") or "")
         for action in getattr(instance, "action_queue", [])
         if isinstance(action, dict)
-    )
-    if not _PURCHASE_CONFIRM_RE.search(action_text):
+        and _PURCHASE_CONFIRM_RE.search(str(action.get("text") or ""))
+        and str(action.get("user_id") or "")
+    }
+    if len(confirming_uids) != 1:
         return False
     quotes = _purchase_quotes(instance)
     if len(quotes) != 1:
         return False
     quote = quotes[0]
+    if quote.get("status", "open") != "open":
+        return False
     payer_uid = str(quote.get("payer_uid") or "")
-    if not payer_uid or payer_uid not in getattr(instance, "players", {}):
+    if (
+        not payer_uid
+        or payer_uid not in getattr(instance, "players", {})
+        or confirming_uids != {payer_uid}
+        or str(quote.get("run_id") or "") != str(getattr(instance, "run_id", ""))
+    ):
         return False
     items = [str(item).strip() for item in quote.get("items", []) if str(item).strip()]
     amount = int(quote.get("amount", 0) or 0)
@@ -394,7 +403,8 @@ def record_purchase_quote(
                     if str(update.get(key) or "").strip():
                         grants.append((str(uid), str(update[key]).strip()))
     amounts = _currency_amounts(narration, currency_labels)
-    if len(grants) == 0 or len(amounts) != 1:
+    grant_uids = {uid for uid, _item in grants}
+    if len(grants) == 0 or len(grant_uids) != 1 or len(amounts) != 1:
         return False
     quotes = _purchase_quotes(instance)
     quotes[:] = [{

--- a/src/commands/round_processor.py
+++ b/src/commands/round_processor.py
@@ -640,15 +640,19 @@ class RoundProcessor:
             response.narration, data, instance.language,
             currency_labels=currency_labels,
         )
-        record_purchase_quote(
-            instance, data, response.narration, currency_labels=currency_labels,
-        )
-        dropped_purchase_items, purchase_was_ambiguous = repair_unbacked_purchase(
-            instance, data, response.narration,
-            actions=instance.action_queue,
-            currency_labels=currency_labels,
-        )
-        if not purchase_was_ambiguous:
+        settled_quote = settle_purchase_quote(instance, data, currency_labels=currency_labels)
+        if not settled_quote:
+            record_purchase_quote(
+                instance, data, response.narration, currency_labels=currency_labels,
+            )
+            dropped_purchase_items, purchase_was_ambiguous = repair_unbacked_purchase(
+                instance, data, response.narration,
+                actions=instance.action_queue,
+                currency_labels=currency_labels,
+            )
+        else:
+            dropped_purchase_items, purchase_was_ambiguous = 0, False
+        if not settled_quote and not purchase_was_ambiguous:
             dropped_purchase_items += discard_unbacked_purchase_items(
                 data, response.narration, currency_labels=currency_labels,
             )
@@ -661,8 +665,6 @@ class RoundProcessor:
         # from an explicit action plus an unambiguous rule currency amount.
         # Recompute after the repair so it receives the same pending-settlement
         # barrier and deferred-effect handling as model-emitted proposals.
-        economy_pending = has_economy_proposal(data)
-        settle_purchase_quote(instance, data, currency_labels=currency_labels)
         economy_pending = has_economy_proposal(data)
         deferred_effects = defer_narrative_effects(
             data, response,

--- a/src/commands/round_processor.py
+++ b/src/commands/round_processor.py
@@ -23,6 +23,8 @@ from src.commands.economy_effects import (
     pending_decision_notice,
     repair_unbacked_purchase,
     currency_labels_for_rule,
+    record_purchase_quote,
+    settle_purchase_quote,
     unbacked_purchase_notice,
     unearned_reward_notice,
 )
@@ -638,6 +640,9 @@ class RoundProcessor:
             response.narration, data, instance.language,
             currency_labels=currency_labels,
         )
+        record_purchase_quote(
+            instance, data, response.narration, currency_labels=currency_labels,
+        )
         dropped_purchase_items, purchase_was_ambiguous = repair_unbacked_purchase(
             instance, data, response.narration,
             actions=instance.action_queue,
@@ -656,6 +661,8 @@ class RoundProcessor:
         # from an explicit action plus an unambiguous rule currency amount.
         # Recompute after the repair so it receives the same pending-settlement
         # barrier and deferred-effect handling as model-emitted proposals.
+        economy_pending = has_economy_proposal(data)
+        settle_purchase_quote(instance, data, currency_labels=currency_labels)
         economy_pending = has_economy_proposal(data)
         deferred_effects = defer_narrative_effects(
             data, response,

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -882,6 +882,20 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
     """
 
     rollback_round = int(round_number)
+    purchase_quotes = instance.economy.get("purchase_quotes", [])
+    if isinstance(purchase_quotes, list):
+        instance.economy["purchase_quotes"] = [
+            quote for quote in purchase_quotes
+            if not (
+                isinstance(quote, dict)
+                and quote.get("status", "open") == "open"
+                and int(quote.get("round", -1)) == rollback_round
+                and (
+                    not quote.get("run_id")
+                    or str(quote.get("run_id")) == str(instance.run_id)
+                )
+            )
+        ]
     proposals = [
         item for item in instance.economy.get("proposals", [])
         if isinstance(item, dict)

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -299,6 +299,53 @@ def test_persisted_purchase_quote_wins_over_later_narration() -> None:
     assert confirmation["state_update"].get("loot", []) == []
 
 
+def test_confirmed_quote_overrides_conflicting_llm_purchase() -> None:
+    instance = _instance()
+    first = {"state_update": {"loot": [{"player": "gm", "item": "护甲"}]}}
+    assert record_purchase_quote(instance, first, "护甲售价260金币。")
+    instance.action_queue = [{"user_id": "gm", "text": "成交"}]
+    confirmation = {"state_update": {
+        "economy_proposals": [
+            {"kind": "purchase", "uid": "gm", "amount": 300, "items": ["护甲"]},
+            {"kind": "purchase", "uid": "gm", "amount": 2, "items": ["药水"]},
+        ],
+        "loot": [{"player": "gm", "item": "护甲"}],
+    }}
+    assert settle_purchase_quote(instance, confirmation)
+    purchases = confirmation["state_update"]["economy_proposals"]
+    assert len(purchases) == 2
+    quoted = next(item for item in purchases if item["items"] == ["护甲"])
+    assert quoted["amount"] == 260
+    assert any(item["items"] == ["药水"] for item in purchases)
+    assert confirmation["state_update"]["loot"] == []
+
+
+def test_unrelated_shop_price_does_not_quote_other_loot() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}
+    assert not record_purchase_quote(instance, data, "你找到短剑。药水售价5金币。")
+    assert data["state_update"]["loot"] == [{"player": "gm", "item": "短剑"}]
+
+
+def test_purchase_intent_for_other_item_does_not_quote_unrelated_loot() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "我想买药水"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}
+    assert not record_purchase_quote(instance, data, "你找到一把短剑。你还有50金币。")
+    assert data["state_update"]["loot"] == [{"player": "gm", "item": "短剑"}]
+
+
+def test_item_and_price_in_same_offer_records_quote() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}
+    assert record_purchase_quote(instance, data, "商人把硬皮甲推到你面前：硬皮甲售价260金币。")
+    quote = instance.economy["purchase_quotes"][0]
+    assert quote["amount"] == 260
+    assert quote["items"] == ["硬皮甲"]
+    assert quote["payer_uid"] == "gm"
+    assert quote["run_id"] == instance.run_id
+
+
 def test_quote_confirmation_removes_model_repeated_purchase_item() -> None:
     instance = _instance()
     first = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -25,6 +25,8 @@ from src.commands.economy_effects import (
     guard_unbacked_payment_narration,
     repair_unbacked_purchase,
     defer_narrative_effects,
+    record_purchase_quote,
+    settle_purchase_quote,
 )
 from src.engine.game_instance import GameInstance, GameRegistry, restore_players, _snapshot_players
 from src.llm.client import LLMResponse
@@ -261,6 +263,19 @@ def test_purchase_guard_uses_ruleset_currency_labels() -> None:
     proposal = data["state_update"]["economy_proposals"][0]
     assert proposal["amount"] == 3
     assert proposal["items"] == ["通行证"]
+
+
+def test_purchase_quote_can_be_confirmed_on_next_turn() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}
+    assert record_purchase_quote(instance, data, "硬皮甲，260金币。")
+    instance.action_queue = [{"user_id": "gm", "text": "行成交"}]
+    confirm_data = {"state_update": {}}
+    assert settle_purchase_quote(instance, confirm_data)
+    proposal = confirm_data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 260
+    assert proposal["items"] == ["硬皮甲"]
+    assert instance.economy["purchase_quotes"] == []
 
 
 def test_personal_purchase_with_effect_group_remains_blocking() -> None:

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -268,20 +268,76 @@ def test_purchase_guard_uses_ruleset_currency_labels() -> None:
 def test_purchase_quote_can_be_confirmed_on_next_turn() -> None:
     instance = _instance()
     data = {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}
-    assert record_purchase_quote(instance, data, "硬皮甲，260金币。")
+    assert record_purchase_quote(instance, data, "硬皮甲售价260金币。")
     instance.action_queue = [{"user_id": "gm", "text": "行成交"}]
     confirm_data = {"state_update": {}}
     assert settle_purchase_quote(instance, confirm_data)
     proposal = confirm_data["state_update"]["economy_proposals"][0]
     assert proposal["amount"] == 260
     assert proposal["items"] == ["硬皮甲"]
+    assert confirm_data["state_update"].get("loot", []) == []
+    assert instance.economy["purchase_quotes"] == []
+
+
+def test_purchase_quote_requires_purchase_semantics_not_bare_currency() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}
+    assert not record_purchase_quote(instance, data, "你找到短剑。你还剩50金币。")
+    assert instance.economy.get("purchase_quotes", []) == []
+
+
+def test_persisted_purchase_quote_wins_over_later_narration() -> None:
+    instance = _instance()
+    first = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}
+    assert record_purchase_quote(instance, first, "短剑售价260金币。")
+    instance.action_queue = [{"user_id": "gm", "text": "成交"}]
+    confirmation = {"state_update": {}}
+    assert settle_purchase_quote(instance, confirmation)
+    proposal = confirmation["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 260
+    assert proposal["items"] == ["短剑"]
+    assert confirmation["state_update"].get("loot", []) == []
+
+
+def test_quote_confirmation_removes_model_repeated_purchase_item() -> None:
+    instance = _instance()
+    first = {"state_update": {"loot": [{"player": "gm", "item": "短剑"}]}}
+    assert record_purchase_quote(instance, first, "短剑售价260金币。")
+    instance.action_queue = [{"user_id": "gm", "text": "成交"}]
+    confirmation = {
+        "state_update": {
+            "loot": [{"player": "gm", "item": "短剑"}],
+            "players": {"gm": {"equip_gain": "短剑"}},
+        },
+    }
+    assert settle_purchase_quote(instance, confirmation)
+    assert confirmation["state_update"]["loot"] == []
+    assert confirmation["state_update"]["players"]["gm"] == {}
+
+
+def test_origin_round_rollback_discards_open_purchase_quote() -> None:
+    instance = _instance()
+    instance.round_number = 5
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    assert instance.economy["purchase_quotes"]
+    reverse_round_economy(instance, 5)
+    assert instance.economy["purchase_quotes"] == []
+
+
+def test_round_zero_rollback_discards_open_purchase_quote() -> None:
+    instance = _instance()
+    instance.round_number = 0
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    reverse_round_economy(instance, 0)
     assert instance.economy["purchase_quotes"] == []
 
 
 def test_purchase_quote_confirmation_requires_payer_and_current_run() -> None:
     instance = _instance()
     data = {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}
-    assert record_purchase_quote(instance, data, "硬皮甲，260金币。")
+    assert record_purchase_quote(instance, data, "硬皮甲售价260金币。")
     instance.action_queue = [{"user_id": "p2", "text": "行成交"}]
     assert not settle_purchase_quote(instance, {"state_update": {}})
     assert instance.economy["purchase_quotes"]

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -278,6 +278,28 @@ def test_purchase_quote_can_be_confirmed_on_next_turn() -> None:
     assert instance.economy["purchase_quotes"] == []
 
 
+def test_purchase_quote_confirmation_requires_payer_and_current_run() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}
+    assert record_purchase_quote(instance, data, "硬皮甲，260金币。")
+    instance.action_queue = [{"user_id": "p2", "text": "行成交"}]
+    assert not settle_purchase_quote(instance, {"state_update": {}})
+    assert instance.economy["purchase_quotes"]
+    instance.action_queue = [{"user_id": "gm", "text": "行成交"}]
+    instance.run_id = "new-run"
+    assert not settle_purchase_quote(instance, {"state_update": {}})
+
+
+def test_purchase_quote_does_not_bundle_multiple_players() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [
+        {"player": "gm", "item": "药水"},
+        {"player": "p2", "item": "卷轴"},
+    ]}}
+    assert not record_purchase_quote(instance, data, "商品共需10金币。")
+    assert instance.economy.get("purchase_quotes", []) == []
+
+
 def test_personal_purchase_with_effect_group_remains_blocking() -> None:
     instance = _instance()
     purchase = queue_proposal(


### PR DESCRIPTION
## Summary
- persist a structured purchase quote when a shop offer spans turns
- keep quoted items out of authoritative state until confirmation
- convert multilingual confirmation actions into a typed pending purchase proposal
- deliver quoted items only through the existing settlement barrier

## Validation
- 60 targeted economy/payment tests passed
- ruff and diff checks passed

No runtime data, saves, logs, or private content included.