### PR TITLE
fix: close economy purchase authority gaps

### DIFF
--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -157,6 +157,7 @@ def repair_unbacked_purchase(
     data: dict[str, Any],
     narration: str,
     *,
+    actions: Iterable[dict[str, Any]] | None = None,
     currency_labels: Iterable[str] | None = None,
 ) -> tuple[int, bool]:
     """Bind an explicit purchase to an economy proposal before state apply.
@@ -171,9 +172,10 @@ def repair_unbacked_purchase(
     state_update = data.get("state_update")
     if not isinstance(state_update, dict) or has_economy_proposal(data):
         return 0, False
+    action_records = list(actions) if actions is not None else list(getattr(instance, "action_queue", []))
     action_text = "\n".join(
         str(action.get("text") or "")
-        for action in getattr(instance, "action_queue", [])
+        for action in action_records
         if isinstance(action, dict)
     )
     narrative_text = str(narration or "")
@@ -207,15 +209,25 @@ def repair_unbacked_purchase(
     if _FREE_PURCHASE_RE.search(narrative_text) and not priced_narrative:
         return 0, False
 
+    # Bind only grants named by the purchase context.  If the narration does
+    # not name an item (legacy responses), retain the conservative behavior of
+    # treating all grants for the sole payer as transaction-bound.
+    context_text = f"{action_text}\n{narrative_text}"
+    named_grants = [
+        grant for grant in grants
+        if grant[1].casefold() in context_text.casefold()
+    ]
+    bound_grants = named_grants or grants
+
     amounts = _currency_amounts(narrative_text, currency_labels)
     actor_uids = {
         str(action.get("user_id") or "")
-        for action in getattr(instance, "action_queue", [])
+        for action in action_records
         if isinstance(action, dict)
         and str(action.get("user_id") or "") in getattr(instance, "players", {})
         and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
     }
-    grant_uids = {uid for uid, _item in grants}
+    grant_uids = {uid for uid, _item in bound_grants}
     payer_candidates = actor_uids & grant_uids
     if len(amounts) != 1 or len(payer_candidates) != 1:
         if isinstance(players_update, dict):
@@ -237,8 +249,8 @@ def repair_unbacked_purchase(
         if isinstance(loot, list):
             state_update["loot"] = []
         return len(grants), True
-    items = [item for uid, item in grants if uid == payer_uid]
-    data.setdefault("state_update", {}).setdefault("economy_proposals", []).append({
+    items = [item for uid, item in bound_grants if uid == payer_uid]
+    proposal = {
         "kind": "purchase",
         "uid": payer_uid,
         "amount": amount,
@@ -247,7 +259,26 @@ def repair_unbacked_purchase(
         "reason": f"购买 {'、'.join(items)}",
         "approval_policy": "payer",
         "source": "server_purchase_guard",
-    })
+    }
+    data.setdefault("state_update", {}).setdefault("economy_proposals", []).append(proposal)
+    # The proposal's rewards are the sole authoritative delivery path. Consume
+    # only grants bound to this payer/items; unrelated loot remains intact.
+    if isinstance(loot, list):
+        state_update["loot"] = [
+            entry for entry in loot
+            if not (
+                isinstance(entry, dict)
+                and str(entry.get("player") or "") == payer_uid
+                and str(entry.get("item") or "").strip() in items
+            )
+        ]
+    if isinstance(players_update, dict):
+        for uid, update in players_update.items():
+            if str(uid) != payer_uid or not isinstance(update, dict):
+                continue
+            for key in ("equip_gain", "weapon_change"):
+                if str(update.get(key) or "").strip() in items:
+                    update.pop(key, None)
     return 0, False
 
 
@@ -266,6 +297,17 @@ def has_economy_proposal(data: dict[str, Any]) -> bool:
     return bool(
         state_update.get("pending_payments")
         or state_update.get("economy_proposals")
+    )
+
+
+def has_server_purchase_guard(data: dict[str, Any]) -> bool:
+    """Whether this response contains a server-repaired purchase proposal."""
+
+    state_update = data.get("state_update")
+    proposals = state_update.get("economy_proposals") if isinstance(state_update, dict) else None
+    return isinstance(proposals, list) and any(
+        isinstance(proposal, dict) and proposal.get("source") == "server_purchase_guard"
+        for proposal in proposals
     )
 
 
@@ -420,22 +462,70 @@ def unbacked_purchase_notice(language: str) -> str:
 def defer_narrative_effects(
     data: dict[str, Any],
     response: Any,
+    *,
+    defer_state_update: bool = True,
 ) -> dict[str, Any]:
     """Remove decision-dependent effects from the immediate round response."""
 
     if not has_economy_proposal(data):
         return {}
     state_update = dict(data.get("state_update") or {})
-    immediate_state = {
-        key: deepcopy(value)
-        for key, value in state_update.items()
-        if key in _ECONOMY_STATE_KEYS
-    }
-    deferred_state = {
-        key: deepcopy(value)
-        for key, value in state_update.items()
-        if key not in _ECONOMY_STATE_KEYS and _meaningful(value)
-    }
+    if not defer_state_update and has_server_purchase_guard(data):
+        # A repaired purchase only proves that the purchased item is
+        # settlement-dependent.  Keep the explicitly remaining item grants on
+        # the normal pipeline, but fail closed for every other state field.
+        immediate_state = {
+            key: deepcopy(value)
+            for key, value in state_update.items()
+            if key in _ECONOMY_STATE_KEYS or key == "loot"
+        }
+        deferred_state = {
+            key: deepcopy(value)
+            for key, value in state_update.items()
+            if key not in _ECONOMY_STATE_KEYS and key != "loot" and _meaningful(value)
+        }
+        players = state_update.get("players")
+        if isinstance(players, dict):
+            immediate_players: dict[str, dict[str, Any]] = {}
+            deferred_players: dict[str, dict[str, Any]] = {}
+            for uid, raw_update in players.items():
+                if not isinstance(raw_update, dict):
+                    if _meaningful(raw_update):
+                        deferred_players[str(uid)] = deepcopy(raw_update)
+                    continue
+                immediate_update = {
+                    key: deepcopy(value)
+                    for key, value in raw_update.items()
+                    if key in {"equip_gain", "weapon_change"} and _meaningful(value)
+                }
+                deferred_update = {
+                    key: deepcopy(value)
+                    for key, value in raw_update.items()
+                    if key not in {"equip_gain", "weapon_change"} and _meaningful(value)
+                }
+                if immediate_update:
+                    immediate_players[str(uid)] = immediate_update
+                if deferred_update:
+                    deferred_players[str(uid)] = deferred_update
+            if immediate_players:
+                immediate_state["players"] = immediate_players
+            else:
+                immediate_state.pop("players", None)
+            if deferred_players:
+                deferred_state["players"] = deferred_players
+            else:
+                deferred_state.pop("players", None)
+    else:
+        immediate_state = {
+            key: deepcopy(value)
+            for key, value in state_update.items()
+            if not defer_state_update or key in _ECONOMY_STATE_KEYS
+        }
+        deferred_state = {
+            key: deepcopy(value)
+            for key, value in state_update.items()
+            if defer_state_update and key not in _ECONOMY_STATE_KEYS and _meaningful(value)
+        }
     deferred: dict[str, Any] = {}
     if deferred_state:
         deferred["state_update"] = deferred_state

--- a/src/commands/round_processor.py
+++ b/src/commands/round_processor.py
@@ -19,6 +19,7 @@ from src.commands.economy_effects import (
     defer_narrative_effects,
     guard_unbacked_payment_narration,
     has_economy_proposal,
+    has_server_purchase_guard,
     pending_decision_notice,
     repair_unbacked_purchase,
     currency_labels_for_rule,
@@ -455,6 +456,8 @@ class RoundProcessor:
                 item.get("round") == round_number for item in current.log
             ):
                 return  # 该回合已被回滚删除，放弃本次生图
+            if self._image_generation is None:
+                return
             result = await self._image_generation.generate(ImageGenerationRequest(
                 prompt=prompt,
                 purpose="scene",
@@ -636,7 +639,9 @@ class RoundProcessor:
             currency_labels=currency_labels,
         )
         dropped_purchase_items, purchase_was_ambiguous = repair_unbacked_purchase(
-            instance, data, response.narration, currency_labels=currency_labels,
+            instance, data, response.narration,
+            actions=instance.action_queue,
+            currency_labels=currency_labels,
         )
         if not purchase_was_ambiguous:
             dropped_purchase_items += discard_unbacked_purchase_items(
@@ -652,7 +657,10 @@ class RoundProcessor:
         # Recompute after the repair so it receives the same pending-settlement
         # barrier and deferred-effect handling as model-emitted proposals.
         economy_pending = has_economy_proposal(data)
-        deferred_effects = defer_narrative_effects(data, response)
+        deferred_effects = defer_narrative_effects(
+            data, response,
+            defer_state_update=not has_server_purchase_guard(data),
+        )
         if economy_pending:
             notice = pending_decision_notice(instance.language)
             response.narration = f"{response.narration or ''}\n\n{notice}".strip()

--- a/src/commands/swipe_generator.py
+++ b/src/commands/swipe_generator.py
@@ -14,6 +14,7 @@ from src.commands.economy_effects import (
     defer_narrative_effects,
     guard_unbacked_payment_narration,
     has_economy_proposal,
+    has_server_purchase_guard,
     pending_decision_notice,
     repair_unbacked_purchase,
     unearned_reward_notice,
@@ -192,7 +193,9 @@ class SwipeGenerator:
         if dropped_rewards:
             narration = f"{narration}\n\n{unearned_reward_notice(instance.language)}".strip()
         dropped_purchase_items, purchase_was_ambiguous = repair_unbacked_purchase(
-            instance, data, narration, currency_labels=currency_labels,
+            instance, data, narration,
+            actions=target_entry.get("actions", []),
+            currency_labels=currency_labels,
         )
         if not purchase_was_ambiguous:
             dropped_purchase_items += discard_unbacked_purchase_items(
@@ -200,7 +203,10 @@ class SwipeGenerator:
             )
         if dropped_purchase_items:
             narration = f"{narration}\n\n{unbacked_purchase_notice(instance.language)}".strip()
-        deferred_effects = defer_narrative_effects(data, response)
+        deferred_effects = defer_narrative_effects(
+            data, response,
+            defer_state_update=not has_server_purchase_guard(data),
+        )
         economy_pending = has_economy_proposal(data)
         if economy_pending:
             narration = f"{narration}\n\n{pending_decision_notice(instance.language)}".strip()

--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -185,6 +185,13 @@ async def create_payment_proposal(
                 "code": "REWRITE_IN_PROGRESS",
                 "error": "GM 正在重写历史回合，请稍后再发起支付",
             }
+        current = dependencies.games.get_instance(inst.game_key)
+        if current is None or current is not inst:
+            return {
+                "ok": False,
+                "code": "STALE_RUN",
+                "error": "游戏已重开或重置，请刷新后再发起支付",
+            }
         proposal = queue_proposal(
             inst,
             kind="purchase" if rewards else "payment",

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -24,6 +24,7 @@ from src.commands.economy_effects import (
     discard_unbacked_purchase_items,
     guard_unbacked_payment_narration,
     repair_unbacked_purchase,
+    defer_narrative_effects,
 )
 from src.engine.game_instance import GameInstance, GameRegistry, restore_players, _snapshot_players
 from src.llm.client import LLMResponse
@@ -168,6 +169,69 @@ def test_explicit_purchase_with_omitted_pay_tag_becomes_pending_proposal() -> No
     assert proposal["kind"] == "purchase"
     assert proposal["amount"] == 25
     assert proposal["items"] == ["硬皮甲"]
+
+
+def test_repaired_purchase_consumes_bound_grant_for_single_delivery() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "买下治疗药水"}]
+    data = {
+        "state_update": {
+            "loot": [
+                {"player": "gm", "item": "治疗药水"},
+                {"player": "gm", "item": "任务赠品"},
+            ],
+        },
+    }
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "治疗药水需要5金币。", actions=instance.action_queue,
+    )
+    assert dropped == 0 and ambiguous is False
+    assert data["state_update"]["economy_proposals"][0]["items"] == ["治疗药水"]
+    assert data["state_update"]["loot"] == [{"player": "gm", "item": "任务赠品"}]
+
+
+def test_repaired_purchase_defers_dependent_player_state_but_keeps_item_grants() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "买下治疗药水并喝掉"}]
+    data = {
+        "state_update": {
+            "economy_proposals": [{
+                "kind": "purchase", "uid": "gm", "amount": 5,
+                "source": "server_purchase_guard",
+            }],
+            "loot": [{"player": "gm", "item": "任务赠品"}],
+            "players": {"gm": {"hp_change": 10, "equip_gain": "无关护符"}},
+            "scene_change": "不应立即进入",
+        },
+    }
+
+    class Response:
+        state_update = data["state_update"]
+        memory_delta = {}
+        info_asymmetry = {}
+        plot_update = {}
+
+    deferred = defer_narrative_effects(data, Response(), defer_state_update=False)
+
+    assert data["state_update"]["loot"] == [{"player": "gm", "item": "任务赠品"}]
+    assert data["state_update"]["players"] == {"gm": {"equip_gain": "无关护符"}}
+    assert "scene_change" not in data["state_update"]
+    assert deferred["state_update"]["players"] == {"gm": {"hp_change": 10}}
+    assert deferred["state_update"]["scene_change"] == "不应立即进入"
+
+
+def test_purchase_repair_uses_explicit_historical_actions() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "p2", "text": "买下另一件物品"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "治疗药水"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance,
+        data,
+        "治疗药水需要5金币。",
+        actions=[{"user_id": "gm", "text": "买下治疗药水"}],
+    )
+    assert dropped == 0 and ambiguous is False
+    assert data["state_update"]["economy_proposals"][0]["uid"] == "gm"
 
 
 def test_ambiguous_purchase_without_pay_tag_drops_item_fail_closed() -> None:


### PR DESCRIPTION
## Scope (Phase 1 of closeout plan)
- ensure repaired purchase grants have one delivery path through proposal rewards
- make Swipe purchase repair use target historical actions explicitly
- revalidate the live aggregate after the GM payment writer acquires authority
- preserve unrelated loot when binding a named purchase

## Validation
- targeted economy/payment tests: 61 passed
- ruff and diff checks passed

No runtime data, saves, logs, credentials, or private content included.