### PR TITLE
fix: finish play context load after identity restore

### DIFF
--- a/frontend-v2/src/features/play/PlayView.vue
+++ b/frontend-v2/src/features/play/PlayView.vue
@@ -803,14 +803,17 @@ async function loadPlayContext() {
   // through the connection flow.  Restore the local player identity before
   // loading actions; otherwise requests have no user query and the backend
   // correctly rejects them as "not joined".
+  let memberValidated = false
   if (!route.query.user && !hasAccessToken()) {
     const storedUid = localStorage.getItem('trpg_play_user_' + game.currentGame.value) || ''
     if (storedUid) {
       try {
         const d = await api<GameDetail>(`/games/${encodeURIComponent(game.currentGame.value)}`)
         if (isStoredPlayerMember(d, storedUid)) {
-          router.replace({ name: 'play', query: { ...route.query, game: game.currentGame.value, user: storedUid, share: '1' } })
-          return
+          memberValidated = true
+          // Fall through to the normal load below instead of returning, so
+          // ruleMeta / player-context / health load with the restored identity.
+          await router.replace({ name: 'play', query: { ...route.query, game: game.currentGame.value, user: storedUid, share: '1' } })
         }
       } catch {
         // Keep the existing page if the identity check is temporarily unavailable.
@@ -821,7 +824,7 @@ async function loadPlayContext() {
   // 先独立校验一次成员资格（不依赖 refresh，因其 private-log 403 会中断整组请求），
   // 失效则清掉本地身份缓存，送回加入页走重新加入（GM 有 access_token，不受影响）。
   const linkUid = queryString(route.query.user)
-  if (linkUid && !hasAccessToken()) {
+  if (linkUid && !hasAccessToken() && !memberValidated) {
     try {
       const d = await api<GameDetail>(`/games/${encodeURIComponent(game.currentGame.value)}`)
       if (!isStoredPlayerMember(d, linkUid)) {


### PR DESCRIPTION
## 背景
#210 恢复本地玩家身份后，`loadPlayContext()` 在 `router.replace()` 后直接 `return`。`useGame` 对 `route.query.user` 的 watcher 会重新 refresh / 重连 SSE，但 PlayView 自己额外加载的 ruleMeta / player-context / health 不会执行，恢复身份进入页面时局部 UI（如自定义经济货币标签）保持默认值。

## 改动
- 恢复路径改为 `await router.replace(...)` 后不再提前 return，继续走 `loadPlayContext()` 的正常加载尾部（refresh / connect / characters / player-context / health）
- 用 `memberValidated` 标记跳过对同一 UID 的重复成员资格校验，避免恢复路径多发一次 GameDetail 请求

## 行为保持不变
- 非成员的本地缓存 UID、校验请求失败、share 链接跳转、被踢玩家清理、GM（access_token）路径均与之前一致

## 风险面
UI only（frontend 行为修复），不触碰 persisted data / API / 权限契约。

## 验证
- frontend-v2: npm run typecheck
- frontend-v2: npm run lint -- --no-warn-ignored
- frontend-v2: npm run test（79 files / 382 tests passed）