### PR TITLE
feat: economy PR1 — explicit offer confirmation contract

### DIFF
--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -381,6 +381,17 @@ def close_purchase_quote(
     return quote
 
 
+def link_purchase_quote_proposal(instance: Any, quote_id: str, proposal_id: str) -> None:
+    """Record the derived proposal id on the audit copy of a converted offer."""
+
+    if not quote_id or not proposal_id:
+        return
+    for quote in _purchase_quotes(instance):
+        if isinstance(quote, dict) and str(quote.get("id") or "") == str(quote_id):
+            quote["proposal_id"] = str(proposal_id)
+            return
+
+
 def settle_purchase_quote(
     instance: Any,
     data: dict[str, Any],
@@ -460,6 +471,9 @@ def settle_purchase_quote(
         "recipient_uid": str(quote.get("recipient_uid") or payer_uid),
         "items": items, "reason": str(quote.get("reason") or "购买商品"),
         "approval_policy": "payer", "source": "server_purchase_quote",
+        # Keep the offer's origin round authoritative after conversion so a
+        # rollback of that round can reverse the later settlement.
+        "quote_id": str(quote.get("id") or ""),
     })
     # Retire the offer, keeping the audit entry; the queued proposal above is
     # now the only path to settlement.

--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -10,10 +10,14 @@ decision group.
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timezone
 import re
 from typing import Any, Iterable
+from uuid import uuid4
 
 from src.engine.language import localized_text
+
+_MAX_PURCHASE_QUOTE_HISTORY = 24
 
 _ECONOMY_STATE_KEYS = {"pending_payments", "economy_proposals"}
 _DEFERRED_DATA_KEYS = {
@@ -328,6 +332,55 @@ def _purchase_quotes(instance: Any) -> list[dict[str, Any]]:
     return economy["purchase_quotes"]
 
 
+def _open_purchase_quote(quotes: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the single actionable offer; history entries are not open."""
+
+    open_quotes = [
+        quote for quote in quotes
+        if isinstance(quote, dict) and quote.get("status", "open") == "open"
+    ]
+    return open_quotes[0] if len(open_quotes) == 1 else None
+
+
+def _trim_purchase_quote_history(quotes: list[dict[str, Any]]) -> None:
+    open_entries = [
+        quote for quote in quotes
+        if isinstance(quote, dict) and quote.get("status", "open") == "open"
+    ]
+    resolved = [
+        quote for quote in quotes
+        if not (isinstance(quote, dict) and quote.get("status", "open") == "open")
+    ]
+    budget = max(0, _MAX_PURCHASE_QUOTE_HISTORY - len(open_entries))
+    quotes[:] = (resolved[-budget:] if budget else []) + open_entries
+
+
+def close_purchase_quote(
+    instance: Any,
+    quote_id: str,
+    *,
+    status: str,
+    resolution_code: str,
+) -> dict[str, Any] | None:
+    """Retire one persisted offer by id, keeping the audit entry in place."""
+
+    quote = next(
+        (
+            quote for quote in _purchase_quotes(instance)
+            if isinstance(quote, dict) and str(quote.get("id") or "") == str(quote_id)
+        ),
+        None,
+    )
+    if quote is None:
+        return None
+    if quote.get("status", "open") != "open":
+        return None
+    quote["status"] = status
+    quote["resolution_code"] = resolution_code
+    quote["resolved_at"] = datetime.now(timezone.utc).isoformat()
+    return quote
+
+
 def settle_purchase_quote(
     instance: Any,
     data: dict[str, Any],
@@ -346,10 +399,8 @@ def settle_purchase_quote(
     if len(confirming_uids) != 1:
         return False
     quotes = _purchase_quotes(instance)
-    if len(quotes) != 1:
-        return False
-    quote = quotes[0]
-    if quote.get("status", "open") != "open":
+    quote = _open_purchase_quote(quotes)
+    if quote is None:
         return False
     payer_uid = str(quote.get("payer_uid") or "")
     if (
@@ -410,7 +461,11 @@ def settle_purchase_quote(
         "items": items, "reason": str(quote.get("reason") or "购买商品"),
         "approval_policy": "payer", "source": "server_purchase_quote",
     })
-    quotes.clear()
+    # Retire the offer, keeping the audit entry; the queued proposal above is
+    # now the only path to settlement.
+    quote["status"] = "confirmed"
+    quote["resolved_at"] = datetime.now(timezone.utc).isoformat()
+    _trim_purchase_quote_history(quotes)
     return True
 
 
@@ -484,13 +539,19 @@ def record_purchase_quote(
         # invalidated by rollback; never replace its amount/items with a
         # later model narration.
         return False
-    quotes[:] = [{
+    payer_uid = bound_grants[0][0]
+    if payer_uid not in getattr(instance, "players", {}):
+        # An offer for a payer outside the current game can never settle.
+        return False
+    quotes.append({
+        "id": f"quote_{uuid4().hex}",
         "run_id": str(getattr(instance, "run_id", "")),
         "round": int(getattr(instance, "round_number", 0) or 0),
-        "payer_uid": bound_grants[0][0], "recipient_uid": bound_grants[0][0],
+        "payer_uid": payer_uid, "recipient_uid": payer_uid,
         "amount": amounts[0], "items": [item for _uid, item in bound_grants],
         "reason": "购买商品", "status": "open",
-    }]
+    })
+    _trim_purchase_quote_history(quotes)
     # A quote is only an offer.  Keep its items out of the immediate state
     # update; confirmation will re-create the typed proposal and its deferred
     # effect group.

--- a/src/commands/game_handler.py
+++ b/src/commands/game_handler.py
@@ -274,6 +274,11 @@ class GameHandler:
         """兼容旧内部调用；实际逻辑已拆到 StateUpdateApplier。"""
         self._state_applier.apply_state_update(instance, update)
 
+    def load_item_categories(self, instance: GameInstance) -> dict[str, list[str]]:
+        """Expose the narrative pipeline's item category table to injected services."""
+
+        return self._state_applier.load_item_categories(instance)
+
     async def commit_deferred_economy_effects(
         self,
         instance: GameInstance,

--- a/src/commands/state_items.py
+++ b/src/commands/state_items.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
+from typing import Iterable
+
+
+def normalized_reward_entries(
+    item_names: Iterable[str],
+    categories: dict[str, list[str]],
+) -> list[dict[str, str]]:
+    """Normalize offer item names into classified proposal rewards.
+
+    Every transport that converts a persisted offer into a proposal must go
+    through this helper so the delivery destination never depends on how the
+    offer was confirmed.
+    """
+
+    rewards: list[dict[str, str]] = []
+    for item_name in item_names:
+        name = str(item_name or "").strip()[:120]
+        if not name:
+            continue
+        rewards.append({"name": name, "category": classify_item(name, categories)})
+    return rewards[:8]
+
 
 def classify_item(item_name: str, categories: dict[str, list[str]]) -> str:
     if not item_name:

--- a/src/commands/state_update_applier.py
+++ b/src/commands/state_update_applier.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 from src.compat.callbacks import load_world_template as load_world_template_compat
 from src.engine.game_instance import GameInstance
+from src.commands.economy_effects import link_purchase_quote_proposal
 from src.commands.item_category_resolver import ItemCategoryResolver
 from src.commands.madness_tracker import MadnessTracker
 from src.commands.npc_state_applier import NpcStateApplier
@@ -91,6 +92,11 @@ class StateUpdateApplier:
         except Exception:
             logger.warning("STAT 规则加载失败: world_id=%s", instance.world_id, exc_info=True)
             return None
+
+    def load_item_categories(self, instance: GameInstance) -> dict[str, list[str]]:
+        """Expose the same category table the narrative pipeline classifies with."""
+
+        return self._item_cats.load_categories(instance)
 
     def apply_state_update(
         self,
@@ -248,7 +254,13 @@ class StateUpdateApplier:
                 ),
                 contributors=contributors if is_team_fee else None,
                 visibility="party" if is_team_fee else "private",
+                quote_id=str(proposal.get("quote_id") or ""),
             ))
+            quote_id = str(proposal.get("quote_id") or "")
+            if quote_id:
+                link_purchase_quote_proposal(
+                    instance, quote_id, str(queued_proposals[-1].get("id") or ""),
+                )
         return queued_proposals
 
     def apply_madness(self, instance: GameInstance, uid: str, cs: dict, loss: int) -> None:

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -1026,11 +1026,7 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
         )
     ]
     for transaction in reversed(quote_origin_transactions):
-        _undo_transaction_state(
-            transaction,
-            get_sheet=instance.get_character_sheet,
-            set_sheet=instance.set_character_sheet,
-        )
+        _undo_live_transaction_delta(instance, transaction)
 
     # A settlement-only rollback keeps an earlier valid offer actionable. Do
     # not resurrect proposals whose origin round is itself being erased.
@@ -1097,33 +1093,14 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
     _advance_revision(instance)
 
 
-def _undo_transaction_state(
+def _undo_transaction_rewards(
     transaction: dict[str, Any],
     *,
     get_sheet: Callable[[str], Any],
     set_sheet: Callable[[str, dict[str, Any]], None],
 ) -> None:
-    """Restore one committed settlement's before-images onto character sheets.
+    """Remove only the reward entries one committed settlement introduced."""
 
-    Shared by snapshot reconciliation and quote-origin rollback so both paths
-    undo balance entries and reward deltas identically.
-    """
-
-    for entry in transaction.get("entries", []):
-        if not isinstance(entry, dict):
-            continue
-        account = str(entry.get("account") or "")
-        if not account.startswith("character:") or entry.get("before") is None:
-            continue
-        uid = account.removeprefix("character:")
-        target = get_sheet(uid)
-        if not isinstance(target, dict):
-            continue
-        before = int(entry.get("before", 0) or 0)
-        if isinstance(target.get("currency"), dict):
-            target["currency"] = {**target["currency"], "amount": before}
-        target["gold"] = before
-        set_sheet(uid, target)
     for reward_snapshot in transaction.get("reward_snapshots", []):
         if not isinstance(reward_snapshot, dict):
             continue
@@ -1141,6 +1118,73 @@ def _undo_transaction_state(
                 continue
             target[key] = _remove_reward_delta(current, before[key], after[key])
             set_sheet(uid, target)
+
+
+def _undo_transaction_before_images(
+    transaction: dict[str, Any],
+    *,
+    get_sheet: Callable[[str], Any],
+    set_sheet: Callable[[str, dict[str, Any]], None],
+) -> None:
+    """Restore one settlement's absolute before-images.
+
+    Valid for snapshot reconciliation, which rebuilds historical state by
+    undoing settlements in strict reverse commit order.  Not valid for
+    selective single-transaction reversal, where writing the before-image
+    would erase later unrelated activity.
+    """
+
+    for entry in transaction.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        account = str(entry.get("account") or "")
+        if not account.startswith("character:") or entry.get("before") is None:
+            continue
+        uid = account.removeprefix("character:")
+        target = get_sheet(uid)
+        if not isinstance(target, dict):
+            continue
+        before = int(entry.get("before", 0) or 0)
+        if isinstance(target.get("currency"), dict):
+            target["currency"] = {**target["currency"], "amount": before}
+        target["gold"] = before
+        set_sheet(uid, target)
+    _undo_transaction_rewards(transaction, get_sheet=get_sheet, set_sheet=set_sheet)
+
+
+def _undo_live_transaction_delta(instance: Any, transaction: dict[str, Any]) -> None:
+    """Selectively reverse one committed settlement against the live state.
+
+    Quote-origin rollback removes one earlier transaction while preserving
+    later unrelated ones, so every character currency entry applies its
+    inverse delta (``-delta``) to the current balance instead of writing the
+    absolute before-image.  System/world balancing entries have no character
+    sheet and remain audit-only.
+    """
+
+    for entry in transaction.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        account = str(entry.get("account") or "")
+        if not account.startswith("character:"):
+            continue
+        try:
+            delta = int(entry.get("delta", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if delta == 0:
+            continue
+        uid = account.removeprefix("character:")
+        sheet = instance.get_character_sheet(uid)
+        if not isinstance(sheet, dict) or not sheet:
+            continue
+        apply_currency_delta(sheet, -delta)
+        instance.set_character_sheet(uid, sheet)
+    _undo_transaction_rewards(
+        transaction,
+        get_sheet=instance.get_character_sheet,
+        set_sheet=instance.set_character_sheet,
+    )
 
 
 def reconcile_rollback_snapshot(
@@ -1179,7 +1223,7 @@ def reconcile_rollback_snapshot(
     # earlier transaction after a later one reconstructs the round's original
     # balance and correctly removes stacked rewards.
     for transaction in reversed(transactions):
-        _undo_transaction_state(
+        _undo_transaction_before_images(
             transaction,
             get_sheet=lambda uid: (
                 reconciled.get(uid) if isinstance(reconciled.get(uid), dict) else None

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -18,6 +18,29 @@ MAX_ECONOMY_OUTCOMES = 50
 MAX_EFFECT_GROUPS = 50
 MAX_EXTERNAL_EFFECT_DELIVERIES = 50
 
+# Explicit transition whitelist for the persisted offer state machine.  A
+# proposal starts at "pending"; "committed" may only be reversed by a rollback
+# (or reopened by a settlement-only rollback).  Everything else is terminal and
+# must never be re-resolved.
+PAYER_ECONOMY_KINDS = {"payment", "purchase", "fee", "transfer"}
+PROPOSAL_TRANSITIONS: dict[str, frozenset[str]] = {
+    "pending": frozenset({"committed", "declined", "cancelled", "rejected", "superseded"}),
+    "committed": frozenset({"reversed", "pending"}),
+}
+
+
+def proposal_transition_allowed(current_status: Any, next_status: str) -> bool:
+    return next_status in PROPOSAL_TRANSITIONS.get(str(current_status or "pending"), frozenset())
+
+
+def set_proposal_status(proposal: dict[str, Any], next_status: str) -> None:
+    """Move a persisted proposal along the whitelisted state machine."""
+
+    current = str(proposal.get("status") or "pending")
+    if not proposal_transition_allowed(current, next_status):
+        raise ValueError(f"illegal economy proposal transition: {current} -> {next_status}")
+    proposal["status"] = next_status
+
 
 def economy_revision(instance: Any) -> int:
     economy = getattr(instance, "economy", {})
@@ -345,7 +368,7 @@ def cancel_proposals_for_player(
         }
         if uid not in participant_uids:
             continue
-        proposal["status"] = "cancelled"
+        set_proposal_status(proposal, "cancelled")
         proposal["resolved_at"] = now
         proposal["resolution_code"] = resolution_code
         proposal_id = str(proposal.get("id") or "")
@@ -524,6 +547,11 @@ def queue_proposal(
         raise ValueError("unsupported economy proposal kind")
     if approval_policy not in APPROVAL_POLICIES:
         raise ValueError("unsupported economy approval policy")
+    payer_uid = str(payer_uid)
+    if payer_uid and kind in PAYER_ECONOMY_KINDS and payer_uid not in instance.players:
+        # Fail closed at the proposal layer: a payer outside the current game
+        # can never be settled, so the offer must not become pending.
+        raise ValueError("economy payer is not part of the current game")
     normalized_contributors = deepcopy(list(contributors or []))
     if approval_policy == "all_contributors":
         contributor_uids = [
@@ -659,7 +687,10 @@ def resolve_proposal(
 
     now = datetime.now(timezone.utc).isoformat()
     if not accepted:
-        proposal["status"] = "cancelled" if is_gm and actor_uid != payer_uid else "declined"
+        set_proposal_status(
+            proposal,
+            "cancelled" if is_gm and actor_uid != payer_uid else "declined",
+        )
         proposal["resolved_at"] = now
         instance.pending_payments = [
             item for item in instance.pending_payments if item.get("id") != proposal_id
@@ -708,7 +739,7 @@ def resolve_proposal(
             currency = sheet.get("currency") if isinstance(sheet.get("currency"), dict) else {}
             balances[uid] = int(currency.get("amount", sheet.get("gold", 0)) or 0)
             if balances[uid] < contribution_amount:
-                proposal["status"] = "rejected"
+                set_proposal_status(proposal, "rejected")
                 proposal["resolved_at"] = now
                 instance.pending_payments = [
                     item for item in instance.pending_payments
@@ -754,7 +785,7 @@ def resolve_proposal(
         currency = payer.get("currency") if isinstance(payer.get("currency"), dict) else {}
         current = int(currency.get("amount", payer.get("gold", 0)) or 0)
         if current < amount:
-            proposal["status"] = "rejected"
+            set_proposal_status(proposal, "rejected")
             proposal["resolved_at"] = now
             instance.pending_payments = [
                 item for item in instance.pending_payments if item.get("id") != proposal_id
@@ -834,7 +865,7 @@ def resolve_proposal(
     else:
         return {"ok": False, "code": "UNSUPPORTED_KIND", "error": "不支持的经济提案类型"}
 
-    proposal["status"] = "committed"
+    set_proposal_status(proposal, "committed")
     proposal["resolved_at"] = now
     transaction = {
         "id": f"tx_{uuid4().hex}",
@@ -884,8 +915,7 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
     rollback_round = int(round_number)
     purchase_quotes = instance.economy.get("purchase_quotes", [])
     if isinstance(purchase_quotes, list):
-        instance.economy["purchase_quotes"] = [
-            quote for quote in purchase_quotes
+        for quote in purchase_quotes:
             if not (
                 isinstance(quote, dict)
                 and quote.get("status", "open") == "open"
@@ -894,8 +924,13 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
                     not quote.get("run_id")
                     or str(quote.get("run_id")) == str(instance.run_id)
                 )
-            )
-        ]
+            ):
+                continue
+            # Retire the offer for audit instead of deleting it; only open
+            # quotes are actionable, so the cancelled mark is sufficient.
+            quote["status"] = "cancelled"
+            quote["resolved_at"] = datetime.now(timezone.utc).isoformat()
+            quote["resolution_code"] = "ORIGIN_ROLLED_BACK"
     proposals = [
         item for item in instance.economy.get("proposals", [])
         if isinstance(item, dict)
@@ -932,9 +967,9 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
         if proposal_id not in origin_ids:
             continue
         if proposal.get("status") == "committed":
-            proposal["status"] = "reversed"
+            set_proposal_status(proposal, "reversed")
         elif proposal.get("status") == "pending":
-            proposal["status"] = "superseded"
+            set_proposal_status(proposal, "superseded")
         proposal.pop("resolved_at", None)
         source_ref = str(proposal.get("source_ref") or "")
         if source_ref:
@@ -955,7 +990,7 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
         if proposal_id not in settlement_ids or proposal_id in origin_ids:
             continue
         if proposal.get("status") == "committed" and proposal.get("run_id") == instance.run_id:
-            proposal["status"] = "pending"
+            set_proposal_status(proposal, "pending")
             proposal.pop("resolved_at", None)
             proposal.pop("resolution_code", None)
             if str(proposal.get("kind") or "payment") in {"payment", "purchase", "fee"}:

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -537,6 +537,7 @@ def queue_proposal(
     rewards: list[dict[str, Any]] | None = None,
     contributors: list[dict[str, Any]] | None = None,
     visibility: str = "private",
+    quote_id: str = "",
 ) -> dict[str, Any]:
     """Queue one idempotent proposal; no balance is changed here."""
 
@@ -589,6 +590,9 @@ def queue_proposal(
         "reason": str(reason or "经济提案")[:240],
         "source": str(source),
         "source_ref": str(source_ref),
+        # Origin linkage for offers converted from a persisted purchase quote;
+        # empty for proposals that did not come from a quote.
+        "quote_id": str(quote_id),
         "approval_policy": str(approval_policy),
         "rewards": deepcopy(list(rewards or [])),
         "contributors": normalized_contributors,
@@ -914,23 +918,40 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
 
     rollback_round = int(round_number)
     purchase_quotes = instance.economy.get("purchase_quotes", [])
+    quote_origin_proposal_ids: set[str] = set()
+    erased_quote_ids: set[str] = set()
     if isinstance(purchase_quotes, list):
+        quote_resolved_at = datetime.now(timezone.utc).isoformat()
         for quote in purchase_quotes:
+            if not isinstance(quote, dict):
+                continue
+            try:
+                quote_round = int(quote.get("round", -1))
+            except (TypeError, ValueError):
+                quote_round = -1
             if not (
-                isinstance(quote, dict)
-                and quote.get("status", "open") == "open"
-                and int(quote.get("round", -1)) == rollback_round
+                quote_round == rollback_round
                 and (
                     not quote.get("run_id")
                     or str(quote.get("run_id")) == str(instance.run_id)
                 )
             ):
                 continue
-            # Retire the offer for audit instead of deleting it; only open
-            # quotes are actionable, so the cancelled mark is sufficient.
-            quote["status"] = "cancelled"
-            quote["resolved_at"] = datetime.now(timezone.utc).isoformat()
+            status = str(quote.get("status") or "open")
+            if status not in {"open", "confirmed"}:
+                continue
+            # Retire the offer for audit instead of deleting it.  Only open
+            # quotes are actionable, and a confirmed offer's purchase chain
+            # dies with its erased origin round.
+            quote["status"] = "cancelled" if status == "open" else "superseded"
+            quote["resolved_at"] = quote_resolved_at
             quote["resolution_code"] = "ORIGIN_ROLLED_BACK"
+            quote_id = str(quote.get("id") or "")
+            if quote_id:
+                erased_quote_ids.add(quote_id)
+            proposal_id = str(quote.get("proposal_id") or "")
+            if proposal_id:
+                quote_origin_proposal_ids.add(proposal_id)
     proposals = [
         item for item in instance.economy.get("proposals", [])
         if isinstance(item, dict)
@@ -940,6 +961,15 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
         for proposal in proposals
         if int(proposal.get("round", -1) or -1) == rollback_round
     }
+    # A proposal converted from a purchase quote inherits the quote's origin
+    # round as its authoritative narrative origin, even when the conversion
+    # and settlement happened in a later round.
+    quote_origin_proposal_ids |= {
+        str(proposal.get("id") or "")
+        for proposal in proposals
+        if str(proposal.get("quote_id") or "") in erased_quote_ids
+    }
+    origin_ids |= quote_origin_proposal_ids
     transactions = [
         item for item in instance.economy.get("transactions", [])
         if isinstance(item, dict)
@@ -982,6 +1012,25 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
         ):
             transaction["status"] = "reversed"
             transaction["reversed_at"] = now
+
+    # A quote's origin round stays authoritative after confirmation: rolling
+    # back that round must also undo a later-round settlement's balance and
+    # delivered goods, not only flip the ledger status.  Same-round
+    # settlements are restored by the caller's snapshot reconciliation.
+    quote_origin_transactions = [
+        transaction for transaction in transactions
+        if (
+            transaction.get("status") == "reversed"
+            and str(transaction.get("proposal_id") or "") in quote_origin_proposal_ids
+            and int(transaction.get("round", -1) or -1) != rollback_round
+        )
+    ]
+    for transaction in reversed(quote_origin_transactions):
+        _undo_transaction_state(
+            transaction,
+            get_sheet=instance.get_character_sheet,
+            set_sheet=instance.set_character_sheet,
+        )
 
     # A settlement-only rollback keeps an earlier valid offer actionable. Do
     # not resurrect proposals whose origin round is itself being erased.
@@ -1048,6 +1097,52 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
     _advance_revision(instance)
 
 
+def _undo_transaction_state(
+    transaction: dict[str, Any],
+    *,
+    get_sheet: Callable[[str], Any],
+    set_sheet: Callable[[str, dict[str, Any]], None],
+) -> None:
+    """Restore one committed settlement's before-images onto character sheets.
+
+    Shared by snapshot reconciliation and quote-origin rollback so both paths
+    undo balance entries and reward deltas identically.
+    """
+
+    for entry in transaction.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        account = str(entry.get("account") or "")
+        if not account.startswith("character:") or entry.get("before") is None:
+            continue
+        uid = account.removeprefix("character:")
+        target = get_sheet(uid)
+        if not isinstance(target, dict):
+            continue
+        before = int(entry.get("before", 0) or 0)
+        if isinstance(target.get("currency"), dict):
+            target["currency"] = {**target["currency"], "amount": before}
+        target["gold"] = before
+        set_sheet(uid, target)
+    for reward_snapshot in transaction.get("reward_snapshots", []):
+        if not isinstance(reward_snapshot, dict):
+            continue
+        uid = str(reward_snapshot.get("recipient_uid") or "")
+        target = get_sheet(uid)
+        before = reward_snapshot.get("before")
+        after = reward_snapshot.get("after")
+        if not isinstance(target, dict) or not isinstance(before, dict) or not isinstance(after, dict):
+            continue
+        for key in ("inventory", "equipment", "key_items"):
+            if key not in before or key not in after:
+                continue
+            current = target.get(key)
+            if not isinstance(current, list):
+                continue
+            target[key] = _remove_reward_delta(current, before[key], after[key])
+            set_sheet(uid, target)
+
+
 def reconcile_rollback_snapshot(
     instance: Any,
     snapshot: dict[str, Any],
@@ -1084,36 +1179,13 @@ def reconcile_rollback_snapshot(
     # earlier transaction after a later one reconstructs the round's original
     # balance and correctly removes stacked rewards.
     for transaction in reversed(transactions):
-        for entry in transaction.get("entries", []):
-            if not isinstance(entry, dict):
-                continue
-            account = str(entry.get("account") or "")
-            if not account.startswith("character:") or entry.get("before") is None:
-                continue
-            uid = account.removeprefix("character:")
-            target = reconciled.get(uid)
-            if isinstance(target, dict):
-                before = int(entry.get("before", 0) or 0)
-                if isinstance(target.get("currency"), dict):
-                    target["currency"] = deepcopy(target["currency"])
-                    target["currency"]["amount"] = before
-                target["gold"] = before
-        for reward_snapshot in transaction.get("reward_snapshots", []):
-            if not isinstance(reward_snapshot, dict):
-                continue
-            uid = str(reward_snapshot.get("recipient_uid") or "")
-            target = reconciled.get(uid)
-            before = reward_snapshot.get("before")
-            after = reward_snapshot.get("after")
-            if not isinstance(target, dict) or not isinstance(before, dict) or not isinstance(after, dict):
-                continue
-            for key in ("inventory", "equipment", "key_items"):
-                if key not in before or key not in after:
-                    continue
-                current = target.get(key)
-                if not isinstance(current, list):
-                    continue
-                target[key] = _remove_reward_delta(current, before[key], after[key])
+        _undo_transaction_state(
+            transaction,
+            get_sheet=lambda uid: (
+                reconciled.get(uid) if isinstance(reconciled.get(uid), dict) else None
+            ),
+            set_sheet=lambda uid, sheet: reconciled.__setitem__(uid, sheet),
+        )
     return reconciled
 
 

--- a/src/engine/game_instance.py
+++ b/src/engine/game_instance.py
@@ -110,7 +110,7 @@ class GameInstance:
     """
 
     game_key: tuple[str, str, str]      # (platform, target_id, account_id)
-    instance_schema_version: int = 3
+    instance_schema_version: int = 4
     run_id: str = field(default_factory=lambda: f"run_{uuid4().hex}")
     memory_namespace: str = ""
     economy: dict[str, Any] = field(default_factory=dict)

--- a/src/engine/game_instance.py
+++ b/src/engine/game_instance.py
@@ -273,6 +273,7 @@ class GameInstance:
             self.economy.setdefault("effect_groups", [])
             self.economy.setdefault("external_effects_outbox", [])
             self.economy.setdefault("outcomes", [])
+            self.economy.setdefault("purchase_quotes", [])
             self.economy.setdefault("decision_revision", 0)
 
     def _fresh_economy_state(self) -> dict[str, Any]:
@@ -286,6 +287,7 @@ class GameInstance:
             "effect_groups": [],
             "external_effects_outbox": [],
             "outcomes": [],
+            "purchase_quotes": [],
             "decision_revision": 0,
         }
 

--- a/src/engine/game_state_codec.py
+++ b/src/engine/game_state_codec.py
@@ -120,7 +120,7 @@ class GameStateCodec:
         )
         instance = instance_type(
             game_key=tuple(data["game_key"]),
-            instance_schema_version=int(data.get("instance_schema_version", 3) or 3),
+            instance_schema_version=int(data.get("instance_schema_version", 4) or 4),
             run_id=str(data.get("run_id") or ""),
             memory_namespace=str(data.get("memory_namespace") or ""),
             economy=data.get("economy") or {},

--- a/src/migrations/instance.py
+++ b/src/migrations/instance.py
@@ -17,7 +17,7 @@ from src.compat.dnd2024_adventure_bindings import apply_unreleased_adventure_bin
 
 logger = logging.getLogger("trpg")
 
-CURRENT_INSTANCE_SCHEMA_VERSION = 3
+CURRENT_INSTANCE_SCHEMA_VERSION = 4
 
 
 def _legacy_run_id(payload: Mapping[str, Any]) -> str:
@@ -111,6 +111,42 @@ def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _migrate_v3_to_v4(payload: dict[str, Any]) -> dict[str, Any]:
+    """Give legacy id-less purchase quotes a stable server identity.
+
+    Pre-offer-contract saves persisted open purchase quotes without an ``id``,
+    which left them unaddressable by the explicit confirm/cancel endpoints.
+    The identity is a deterministic uuid5 over the quote's own coordinates, so
+    the same save always loads with the same id and the migration is
+    idempotent; quotes that already carry an id are left untouched.
+    """
+
+    economy = payload.get("economy")
+    if isinstance(economy, dict):
+        run_id = str(payload.get("run_id") or "")
+        quotes = economy.get("purchase_quotes")
+        if isinstance(quotes, list):
+            for index, quote in enumerate(quotes):
+                if not isinstance(quote, dict) or str(quote.get("id") or ""):
+                    continue
+                items = "|".join(str(item) for item in (quote.get("items") or []))
+                digest = uuid5(
+                    NAMESPACE_URL,
+                    "diceframe:{run_id}:purchase-quote:{index}:{round}:{payer}:{recipient}:{amount}:{items}".format(
+                        run_id=run_id,
+                        index=index,
+                        round=str(quote.get("round") or ""),
+                        payer=str(quote.get("payer_uid") or ""),
+                        recipient=str(quote.get("recipient_uid") or ""),
+                        amount=str(quote.get("amount") or ""),
+                        items=items,
+                    ),
+                ).hex
+                quote["id"] = f"quote_{digest}"
+    payload["instance_schema_version"] = 4
+    return payload
+
+
 def migrate_game_state_payload(data: Mapping[str, Any]) -> dict[str, Any]:
     """Apply sequential, idempotent migrations to one persisted save payload."""
 
@@ -124,6 +160,9 @@ def migrate_game_state_payload(data: Mapping[str, Any]) -> dict[str, Any]:
     if version == 2:
         payload = _migrate_v2_to_v3(payload)
         version = 3
+    if version == 3:
+        payload = _migrate_v3_to_v4(payload)
+        version = 4
     payload["instance_schema_version"] = version
     return payload
 

--- a/src/migrations/instance.py
+++ b/src/migrations/instance.py
@@ -163,6 +163,7 @@ def rebind_imported_game_state_payload(
             "effect_groups",
             "external_effects_outbox",
             "outcomes",
+            "purchase_quotes",
         ):
             for item in economy.get(collection_name, []) or []:
                 if isinstance(item, dict):

--- a/src/webui/access_control.py
+++ b/src/webui/access_control.py
@@ -308,6 +308,14 @@ class WebAccessControl:
                 return uid or request.get("user_id", "")
             if (
                 request.method == "POST"
+                and tail == "purchase-quotes"
+                and len(parts) == 6
+                and parts[5] in {"confirm", "cancel"}
+                and bool(parts[4])
+            ):
+                return uid or request.get("user_id", "")
+            if (
+                request.method == "POST"
                 and tail == "checks"
                 and len(parts) >= 6
                 and parts[5] == "luck"

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -1548,6 +1548,22 @@ class WebAPI:
             items=items,
         )
 
+    async def confirm_purchase_quote(self, game_key: str, quote_id: str, session_uid: str = "") -> dict[str, Any]:
+        return await characters.confirm_purchase_quote(
+            self._character_dependencies,
+            game_key,
+            quote_id,
+            session_uid,
+        )
+
+    async def cancel_purchase_quote(self, game_key: str, quote_id: str, session_uid: str = "") -> dict[str, Any]:
+        return await characters.cancel_purchase_quote(
+            self._character_dependencies,
+            game_key,
+            quote_id,
+            session_uid,
+        )
+
     async def _drain_economy_outbox(self, instance: Any) -> bool:
         return await characters.drain_economy_outbox(
             self._character_dependencies, instance,

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -199,6 +199,12 @@ class WebAPI:
             reverse_economy_memory=(
                 self._mem.reverse_economy_delta if self._mem is not None else None
             ),
+            load_item_categories=(
+                handler.load_item_categories
+                if handler is not None
+                and callable(getattr(handler, "load_item_categories", None))
+                else None
+            ),
         )
         self._ruleset_character_dependencies = (
             ruleset_characters.RulesetCharacterDependencies(

--- a/src/webui/routes/game_gameplay_routes.py
+++ b/src/webui/routes/game_gameplay_routes.py
@@ -382,6 +382,48 @@ async def api_payment_create(request: web.Request) -> web.Response:
     return web.json_response(result, status=200 if result.get("ok") else 400)
 
 
+async def api_purchase_quote_confirm(request: web.Request) -> web.Response:
+    """Payer explicitly accepts one persisted purchase offer."""
+
+    api = _get_api(request)
+    gk = request.match_info["game_key"]
+    quote_id = request.match_info["quote_id"]
+    inst = api.get_game_instance(gk)
+    if not inst:
+        return web.json_response({"error": "游戏不存在"}, status=404)
+    result = await api.confirm_purchase_quote(gk, quote_id, request.get("user_id", ""))
+    code = str(result.get("code") or "")
+    status = (
+        200 if result.get("ok")
+        else 404 if code in {"GAME_NOT_FOUND", "QUOTE_NOT_FOUND"}
+        else 403 if code in {"FORBIDDEN", "PAYMENT_FORBIDDEN"}
+        else 409 if code in {"ALREADY_RESOLVED", "STALE_RUN", "REWRITE_IN_PROGRESS"}
+        else 400
+    )
+    return web.json_response(result, status=status)
+
+
+async def api_purchase_quote_cancel(request: web.Request) -> web.Response:
+    """Close one persisted purchase offer without settling it."""
+
+    api = _get_api(request)
+    gk = request.match_info["game_key"]
+    quote_id = request.match_info["quote_id"]
+    inst = api.get_game_instance(gk)
+    if not inst:
+        return web.json_response({"error": "游戏不存在"}, status=404)
+    result = await api.cancel_purchase_quote(gk, quote_id, request.get("user_id", ""))
+    code = str(result.get("code") or "")
+    status = (
+        200 if result.get("ok")
+        else 404 if code in {"GAME_NOT_FOUND", "QUOTE_NOT_FOUND"}
+        else 403 if code in {"FORBIDDEN", "PAYMENT_FORBIDDEN"}
+        else 409 if code in {"ALREADY_RESOLVED", "STALE_RUN", "REWRITE_IN_PROGRESS"}
+        else 400
+    )
+    return web.json_response(result, status=status)
+
+
 async def api_swipe(request: web.Request) -> web.Response:
     game_key = request.match_info["game_key"]
     round_num = int(request.match_info["round"])

--- a/src/webui/routes/games.py
+++ b/src/webui/routes/games.py
@@ -55,6 +55,8 @@ from src.webui.routes.game_gameplay_routes import (
     api_advance,
     api_payment_create,
     api_payment_resolve,
+    api_purchase_quote_confirm,
+    api_purchase_quote_cancel,
     api_swipe,
 )
 from src.webui.routes.game_character_routes import (
@@ -151,6 +153,14 @@ def register_games(app: web.Application) -> None:
         "/api/games/{game_key}/payments/{payment_id}", api_payment_resolve
     )
     app.router.add_post("/api/games/{game_key}/payments", api_payment_create)
+    app.router.add_post(
+        "/api/games/{game_key}/purchase-quotes/{quote_id}/confirm",
+        api_purchase_quote_confirm,
+    )
+    app.router.add_post(
+        "/api/games/{game_key}/purchase-quotes/{quote_id}/cancel",
+        api_purchase_quote_cancel,
+    )
     app.router.add_get("/api/games/{game_key}/characters", api_chars)
     app.router.add_get("/api/games/{game_key}/log", api_log)
     app.router.add_route("DELETE", "/api/games/{game_key}", api_delete_game)

--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -32,8 +32,14 @@ from src.engine.economy import (
     resolve_proposal,
 )
 from src.engine.game_instance import GameInstance
-from src.commands.state_items import grant_classified_item
-from src.commands.economy_effects import close_purchase_quote
+from src.commands.state_items import (
+    grant_classified_item,
+    normalized_reward_entries,
+)
+from src.commands.economy_effects import (
+    close_purchase_quote,
+    link_purchase_quote_proposal,
+)
 from src.rulesets.contracts import GameDetailProjectionRuntime
 from src.webui.character_contracts import MAX_BIO_CHARS
 
@@ -136,6 +142,7 @@ class CharacterDependencies:
     schedule_economy_scene_image: Callable[[Any, dict[str, Any]], Any] | None = None
     apply_economy_memory: Callable[[str, str, dict[str, Any], int], Awaitable[None]] | None = None
     reverse_economy_memory: Callable[[str, str], Awaitable[bool]] | None = None
+    load_item_categories: Callable[[Any], dict[str, list[str]]] | None = None
 
 
 async def create_payment_proposal(
@@ -274,6 +281,13 @@ async def confirm_purchase_quote(
         amount = int(quote.get("amount", 0) or 0)
         if amount <= 0 or not items:
             return {"ok": False, "code": "QUOTE_INVALID", "error": "报价缺少有效商品或金额"}
+        # Explicit confirmation must classify exactly like the narration path:
+        # the transport never decides where a purchased item lands.
+        categories = (
+            dependencies.load_item_categories(inst)
+            if dependencies.load_item_categories is not None
+            else {}
+        )
         try:
             proposal = queue_proposal(
                 inst,
@@ -281,11 +295,12 @@ async def confirm_purchase_quote(
                 payer_uid=str(quote.get("payer_uid") or ""),
                 recipient_uid=str(quote.get("recipient_uid") or quote.get("payer_uid") or ""),
                 amount=amount,
-                rewards=[{"name": item, "category": ""} for item in items],
+                rewards=normalized_reward_entries(items, categories),
                 reason=str(quote.get("reason") or "购买商品"),
                 source="server_purchase_quote",
                 source_ref=f"purchase_quote:{quote.get('id')}",
                 approval_policy="payer",
+                quote_id=str(quote.get("id") or ""),
             )
         except ValueError as exc:
             return {"ok": False, "code": "QUOTE_INVALID", "error": str(exc)}
@@ -293,7 +308,7 @@ async def confirm_purchase_quote(
             inst, quote_id, status="confirmed", resolution_code="CONFIRMED_BY_PAYER",
         ) is None:
             return {"ok": False, "code": "ALREADY_RESOLVED", "error": "购买报价已处理"}
-        quote["proposal_id"] = str(proposal.get("id") or "")
+        link_purchase_quote_proposal(inst, quote_id, str(proposal.get("id") or ""))
         await dependencies.games.save_instance(inst)
     return {"ok": True, "proposal": proposal}
 

--- a/src/webui/services/characters.py
+++ b/src/webui/services/characters.py
@@ -33,6 +33,7 @@ from src.engine.economy import (
 )
 from src.engine.game_instance import GameInstance
 from src.commands.state_items import grant_classified_item
+from src.commands.economy_effects import close_purchase_quote
 from src.rulesets.contracts import GameDetailProjectionRuntime
 from src.webui.character_contracts import MAX_BIO_CHARS
 
@@ -206,6 +207,150 @@ async def create_payment_proposal(
         )
         await dependencies.games.save_instance(inst)
     return {"ok": True, "proposal": proposal}
+
+
+def _find_purchase_quote(inst: GameInstance, quote_id: str) -> dict[str, Any] | None:
+    quotes = [
+        quote for quote in inst.economy.get("purchase_quotes", [])
+        if isinstance(quote, dict) and str(quote.get("id") or "") == str(quote_id)
+    ]
+    return quotes[0] if len(quotes) == 1 else None
+
+
+async def confirm_purchase_quote(
+    dependencies: CharacterDependencies,
+    game_key: str,
+    quote_id: str,
+    session_uid: str = "",
+) -> dict[str, Any]:
+    """Payer explicitly accepts one persisted offer.
+
+    Confirmation only converts the offer into a pending typed proposal; the
+    balance is charged later through the standard payment confirmation path.
+    """
+
+    inst = dependencies.games.get_instance(
+        dependencies.games.parse_game_key(game_key),
+    )
+    if inst is None:
+        return {"ok": False, "error": "游戏不存在"}
+    actor_uid = str(session_uid or "").strip()
+    async with inst.authoritative_write() as write_entered, inst._lock:
+        if not write_entered:
+            return {
+                "ok": False,
+                "code": "REWRITE_IN_PROGRESS",
+                "error": "GM 正在重写历史回合，请稍后再确认报价",
+            }
+        current = dependencies.games.get_instance(inst.game_key)
+        if current is None or current is not inst:
+            return {
+                "ok": False,
+                "code": "STALE_RUN",
+                "error": "游戏已重开或重置，请刷新后再确认报价",
+            }
+        quote = _find_purchase_quote(inst, quote_id)
+        if quote is None:
+            return {"ok": False, "code": "QUOTE_NOT_FOUND", "error": "购买报价不存在"}
+        if (
+            quote.get("status", "open") == "open"
+            and str(quote.get("run_id") or "") != str(inst.run_id)
+        ):
+            return {"ok": False, "code": "STALE_RUN", "error": "这是上一局的购买报价"}
+        if quote.get("status", "open") != "open":
+            # Idempotent repeat for a confirmed offer; a cancelled offer can
+            # never be accepted afterwards.
+            if quote.get("status") == "confirmed":
+                return {
+                    "ok": True,
+                    "already_resolved": True,
+                    "status": "confirmed",
+                    "proposal_id": str(quote.get("proposal_id") or ""),
+                }
+            return {"ok": False, "code": "ALREADY_RESOLVED", "error": "购买报价已处理"}
+        if not actor_uid or actor_uid != str(quote.get("payer_uid") or ""):
+            return {"ok": False, "code": "FORBIDDEN", "error": "只有报价中的付款人可以确认"}
+        items = [str(item).strip() for item in quote.get("items", []) if str(item).strip()]
+        amount = int(quote.get("amount", 0) or 0)
+        if amount <= 0 or not items:
+            return {"ok": False, "code": "QUOTE_INVALID", "error": "报价缺少有效商品或金额"}
+        try:
+            proposal = queue_proposal(
+                inst,
+                kind="purchase",
+                payer_uid=str(quote.get("payer_uid") or ""),
+                recipient_uid=str(quote.get("recipient_uid") or quote.get("payer_uid") or ""),
+                amount=amount,
+                rewards=[{"name": item, "category": ""} for item in items],
+                reason=str(quote.get("reason") or "购买商品"),
+                source="server_purchase_quote",
+                source_ref=f"purchase_quote:{quote.get('id')}",
+                approval_policy="payer",
+            )
+        except ValueError as exc:
+            return {"ok": False, "code": "QUOTE_INVALID", "error": str(exc)}
+        if close_purchase_quote(
+            inst, quote_id, status="confirmed", resolution_code="CONFIRMED_BY_PAYER",
+        ) is None:
+            return {"ok": False, "code": "ALREADY_RESOLVED", "error": "购买报价已处理"}
+        quote["proposal_id"] = str(proposal.get("id") or "")
+        await dependencies.games.save_instance(inst)
+    return {"ok": True, "proposal": proposal}
+
+
+async def cancel_purchase_quote(
+    dependencies: CharacterDependencies,
+    game_key: str,
+    quote_id: str,
+    session_uid: str = "",
+) -> dict[str, Any]:
+    """Close one persisted offer without any balance or item change."""
+
+    inst = dependencies.games.get_instance(
+        dependencies.games.parse_game_key(game_key),
+    )
+    if inst is None:
+        return {"ok": False, "error": "游戏不存在"}
+    actor_uid = str(session_uid or "").strip()
+    async with inst.authoritative_write() as write_entered, inst._lock:
+        if not write_entered:
+            return {
+                "ok": False,
+                "code": "REWRITE_IN_PROGRESS",
+                "error": "GM 正在重写历史回合，请稍后再处理报价",
+            }
+        current = dependencies.games.get_instance(inst.game_key)
+        if current is None or current is not inst:
+            return {
+                "ok": False,
+                "code": "STALE_RUN",
+                "error": "游戏已重开或重置，请刷新后再处理报价",
+            }
+        quote = _find_purchase_quote(inst, quote_id)
+        if quote is None:
+            return {"ok": False, "code": "QUOTE_NOT_FOUND", "error": "购买报价不存在"}
+        if quote.get("status", "open") != "open":
+            return {
+                "ok": True,
+                "already_resolved": True,
+                "status": str(quote.get("status")),
+            }
+        if actor_uid not in {
+            str(quote.get("payer_uid") or ""),
+            str(inst.gm_uid or ""),
+        }:
+            return {"ok": False, "code": "FORBIDDEN", "error": "只有付款人或 GM 可以取消报价"}
+        resolution_code = (
+            "CANCELLED_BY_GM"
+            if actor_uid == str(inst.gm_uid or "") and actor_uid != str(quote.get("payer_uid") or "")
+            else "CANCELLED_BY_PAYER"
+        )
+        if close_purchase_quote(
+            inst, quote_id, status="cancelled", resolution_code=resolution_code,
+        ) is None:
+            return {"ok": False, "code": "ALREADY_RESOLVED", "error": "购买报价已处理"}
+        await dependencies.games.save_instance(inst)
+    return {"ok": True, "quote": deepcopy(quote)}
 
 _ATTR_NAME_EN = {
     "str": "STR",

--- a/src/webui/services/game_queries.py
+++ b/src/webui/services/game_queries.py
@@ -124,6 +124,29 @@ def game_detail(
             }
         )
     ]
+    open_purchase_quotes = [
+        {
+            "id": str(quote.get("id") or ""),
+            "payer_uid": str(quote.get("payer_uid") or ""),
+            "recipient_uid": str(
+                quote.get("recipient_uid") or quote.get("payer_uid") or ""
+            ),
+            "amount": int(quote.get("amount", 0) or 0),
+            "items": [str(item) for item in (quote.get("items") or []) if str(item)],
+            "reason": str(quote.get("reason") or ""),
+            "round": int(quote.get("round", 0) or 0),
+            "status": "open",
+        }
+        for quote in (getattr(instance, "economy", {}).get("purchase_quotes", []) or [])
+        if isinstance(quote, dict)
+        and quote.get("status", "open") == "open"
+        and str(quote.get("run_id") or "") == str(instance.run_id)
+        and (
+            not viewer_uid
+            or viewer_uid == instance.gm_uid
+            or viewer_uid == str(quote.get("payer_uid") or "")
+        )
+    ]
     detail = {
         "game_key": _GAME_KEY_SEP.join(instance.game_key),
         "run_id": instance.run_id,
@@ -168,6 +191,7 @@ def game_detail(
             )
         ],
         "economy_proposals": economy_proposals,
+        "purchase_quotes": open_purchase_quotes,
         "pending_luck_decisions": instance.pending_luck_checks(),
         "round_check_results": (
             [dict(item) for item in instance.last_checks]

--- a/tests/test_game_instance.py
+++ b/tests/test_game_instance.py
@@ -651,6 +651,11 @@ class TestGameRegistry:
                     "id": "outcome_declined", "run_id": "run_exported",
                     "status": "declined",
                 }],
+                "purchase_quotes": [{
+                    "id": "quote_open", "run_id": "run_exported",
+                    "status": "open", "round": 5,
+                    "payer_uid": "p1", "amount": 5, "items": ["通行证"],
+                }],
                 "idempotency_records": {},
             },
         }
@@ -674,10 +679,12 @@ class TestGameRegistry:
             item["run_id"] == imported.run_id
             for key in (
                 "proposals", "transactions", "effect_groups",
-                "external_effects_outbox", "outcomes",
+                "external_effects_outbox", "outcomes", "purchase_quotes",
             )
             for item in imported.economy[key]
         )
+        # open 报价随新 run 收养，导入后仍可确认，不会卡死新报价。
+        assert imported.economy["purchase_quotes"][0]["status"] == "open"
         assert [
             item["id"] for item in imported.economy["external_effects_outbox"]
         ] == ["memory:pending"]

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -22,14 +23,18 @@ from src.engine.economy import (
     _remove_reward_delta,
 )
 from src.commands.economy_effects import (
+    close_purchase_quote,
     discard_unearned_reward_proposals,
     discard_unbacked_purchase_items,
     guard_unbacked_payment_narration,
+    link_purchase_quote_proposal,
     repair_unbacked_purchase,
     defer_narrative_effects,
     record_purchase_quote,
     settle_purchase_quote,
 )
+from src.commands.state_items import append_key_item
+from src.commands.state_update_applier import StateUpdateApplier
 from src.engine.game_instance import GameInstance, GameRegistry, restore_players, _snapshot_players
 from src.llm.client import LLMResponse
 from src.llm.context_builder import build_context
@@ -488,7 +493,7 @@ def test_save_migration_assigns_stable_run_and_imports_pending_payment() -> None
     second = migrate_game_state_payload(first)
 
     assert first == second
-    assert first["instance_schema_version"] == 3
+    assert first["instance_schema_version"] == 4
     assert first["economy"]["external_effects_outbox"] == []
     assert first["run_id"].startswith("run_")
     assert first["memory_namespace"] == "('web', 'legacy', 'bot')"
@@ -524,6 +529,159 @@ def test_narrative_reward_requires_gm_and_commits_once() -> None:
 def _grant_inventory_reward(sheet: dict, reward: dict) -> None:
     inventory = sheet.setdefault("inventory", [])
     inventory.append({"name": str(reward.get("name") or ""), "qty": 1})
+
+
+def _grant_key_item_reward(sheet: dict, reward: dict) -> None:
+    append_key_item(sheet, str(reward.get("name") or ""))
+
+
+def test_quote_origin_rollback_reverses_late_confirmed_purchase() -> None:
+    """R5 报价 → R6 显式确认并支付；回滚 R5 必须级联撤销 R6 结算。"""
+
+    instance = _instance()
+    instance.round_number = 5
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    quote = instance.economy["purchase_quotes"][0]
+    instance.round_number = 6
+    proposal = queue_proposal(
+        instance,
+        kind="purchase",
+        payer_uid="gm",
+        recipient_uid="gm",
+        amount=5,
+        rewards=[{"name": "通行证", "category": "key_item"}],
+        source="server_purchase_quote",
+        source_ref=f"purchase_quote:{quote['id']}",
+        approval_policy="payer",
+        quote_id=quote["id"],
+    )
+    link_purchase_quote_proposal(instance, quote["id"], proposal["id"])
+    assert close_purchase_quote(
+        instance, quote["id"], status="confirmed", resolution_code="CONFIRMED_BY_PAYER",
+    ) is not None
+    settled = resolve_proposal(
+        instance,
+        proposal["id"],
+        actor_uid="gm",
+        accepted=True,
+        grant_reward=_grant_key_item_reward,
+    )
+    assert settled["ok"] is True
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 25
+    assert any(
+        item.get("name") == "通行证"
+        for item in instance.get_character_sheet("gm").get("key_items", [])
+    )
+
+    reverse_round_economy(instance, 5)
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 30
+    assert not any(
+        item.get("name") == "通行证"
+        for item in instance.get_character_sheet("gm").get("key_items", [])
+    )
+    assert all(
+        transaction["status"] == "reversed"
+        for transaction in instance.economy["transactions"]
+    )
+    assert proposal["status"] == "reversed"
+    assert quote["status"] == "superseded"
+    assert quote["resolution_code"] == "ORIGIN_ROLLED_BACK"
+    assert quote["id"]
+
+
+def test_quote_origin_rollback_reverses_narration_confirmed_purchase() -> None:
+    """叙事确认路径必须与显式路径共享同一 origin 回滚语义。"""
+
+    instance = _instance()
+    instance.round_number = 5
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    quote = instance.economy["purchase_quotes"][0]
+    instance.round_number = 6
+    instance.action_queue = [{"user_id": "gm", "text": "行，成交"}]
+    confirm_payload = {"state_update": {}}
+    assert settle_purchase_quote(instance, confirm_payload)
+    applier = StateUpdateApplier(Path("nonexistent-rules"), None, lambda world_id, language: {})
+    queued = applier.apply_state_update(instance, confirm_payload["state_update"])
+    assert len(queued) == 1
+    assert queued[0]["quote_id"] == quote["id"]
+    assert quote["proposal_id"] == queued[0]["id"]
+    settled = resolve_proposal(
+        instance,
+        queued[0]["id"],
+        actor_uid="gm",
+        accepted=True,
+        grant_reward=_grant_key_item_reward,
+    )
+    assert settled["ok"] is True
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 25
+
+    reverse_round_economy(instance, 5)
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 30
+    assert not any(
+        item.get("name") == "通行证"
+        for item in instance.get_character_sheet("gm").get("key_items", [])
+    )
+    assert queued[0]["status"] == "reversed"
+    assert quote["status"] == "superseded"
+    assert quote["resolution_code"] == "ORIGIN_ROLLED_BACK"
+
+
+def test_legacy_open_purchase_quote_gets_stable_id_on_load() -> None:
+    legacy = {
+        "game_key": ["web", "legacy", "quote"],
+        "instance_schema_version": 3,
+        "run_id": "run_legacy",
+        "state": "paused",
+        "started_at": "2025-01-01T00:00:00+00:00",
+        "players": {
+            "p1": {
+                "character_name": "付款人",
+                "character_sheet": {"gold": 30, "currency": {"amount": 30}},
+            },
+        },
+        "economy": {
+            "schema_version": 2,
+            "run_id": "run_legacy",
+            "purchase_quotes": [{
+                "run_id": "run_legacy",
+                "round": 5,
+                "payer_uid": "p1",
+                "recipient_uid": "p1",
+                "amount": 5,
+                "items": ["通行证"],
+                "reason": "购买商品",
+                "status": "open",
+            }],
+        },
+    }
+    migrated = migrate_game_state_payload(legacy)
+    quote = migrated["economy"]["purchase_quotes"][0]
+    assert quote["id"].startswith("quote_")
+    # 同一存档重复迁移得到同一身份，save/reload 后不变。
+    assert migrate_game_state_payload(migrated)["economy"]["purchase_quotes"][0]["id"] == quote["id"]
+    instance = GameInstance.from_dict(migrated)
+    assert instance.economy["purchase_quotes"][0]["id"] == quote["id"]
+    reloaded = GameInstance.from_dict(instance.to_dict())
+    assert reloaded.economy["purchase_quotes"][0]["id"] == quote["id"]
+    # 迁移后的报价可被显式确认契约寻址并转换。
+    proposal = queue_proposal(
+        reloaded,
+        kind="purchase",
+        payer_uid="p1",
+        recipient_uid="p1",
+        amount=5,
+        rewards=[{"name": "通行证", "category": "key_item"}],
+        source="server_purchase_quote",
+        source_ref=f"purchase_quote:{quote['id']}",
+        approval_policy="payer",
+        quote_id=quote["id"],
+    )
+    assert close_purchase_quote(
+        reloaded, quote["id"], status="confirmed", resolution_code="CONFIRMED_BY_PAYER",
+    ) is not None
+    assert proposal["status"] == "pending"
 
 
 def test_late_personal_purchase_reopens_when_settlement_round_is_rolled_back() -> None:

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -590,6 +590,81 @@ def test_quote_origin_rollback_reverses_late_confirmed_purchase() -> None:
     assert quote["id"]
 
 
+def test_quote_origin_rollback_preserves_later_unrelated_currency_change() -> None:
+    """选择性回滚只撤销目标交易：30 → 买-5 → 无关-2 → 回滚 R5 应为 28。
+
+    反向 delta 叠加到当前余额，而不是写绝对 before 快照——否则后发生的
+    合法交易效果会被一并抹掉。
+    """
+
+    instance = _instance()
+    instance.round_number = 5
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    quote = instance.economy["purchase_quotes"][0]
+    instance.round_number = 6
+    proposal = queue_proposal(
+        instance,
+        kind="purchase",
+        payer_uid="gm",
+        recipient_uid="gm",
+        amount=5,
+        rewards=[{"name": "通行证", "category": "key_item"}],
+        source="server_purchase_quote",
+        source_ref=f"purchase_quote:{quote['id']}",
+        approval_policy="payer",
+        quote_id=quote["id"],
+    )
+    link_purchase_quote_proposal(instance, quote["id"], proposal["id"])
+    assert close_purchase_quote(
+        instance, quote["id"], status="confirmed", resolution_code="CONFIRMED_BY_PAYER",
+    ) is not None
+    settled = resolve_proposal(
+        instance,
+        proposal["id"],
+        actor_uid="gm",
+        accepted=True,
+        grant_reward=_grant_key_item_reward,
+    )
+    assert settled["ok"] is True
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 25
+
+    # R7：与报价无关的合法支出。
+    instance.round_number = 7
+    unrelated = queue_proposal(
+        instance,
+        kind="fee",
+        payer_uid="gm",
+        amount=2,
+        reason="客栈住宿",
+    )
+    unrelated_settled = resolve_proposal(
+        instance, unrelated["id"], actor_uid="gm", accepted=True,
+    )
+    assert unrelated_settled["ok"] is True
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 23
+
+    reverse_round_economy(instance, 5)
+
+    # 只撤销目标购买：23 + 5 = 28，不是绝对 before 的 30。
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 28
+    assert proposal["status"] == "reversed"
+    assert quote["status"] == "superseded"
+    assert quote["resolution_code"] == "ORIGIN_ROLLED_BACK"
+    assert not any(
+        item.get("name") == "通行证"
+        for item in instance.get_character_sheet("gm").get("key_items", [])
+    )
+    # R7 无关交易保持已结算，未受波及。
+    assert unrelated["status"] == "committed"
+    statuses = {
+        transaction["id"]: transaction["status"]
+        for transaction in instance.economy["transactions"]
+    }
+    assert statuses[settled["transaction"]["id"]] == "reversed"
+    assert statuses[unrelated_settled["transaction"]["id"]] == "committed"
+
+
 def test_quote_origin_rollback_reverses_narration_confirmed_purchase() -> None:
     """叙事确认路径必须与显式路径共享同一 origin 回滚语义。"""
 

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -12,11 +12,13 @@ from src.engine.economy import (
     is_nonblocking_personal_purchase,
     pending_memory_deliveries,
     pending_memory_reversals,
+    proposal_transition_allowed,
     queue_effect_group,
     queue_proposal,
     reconcile_rollback_snapshot,
     reverse_round_economy,
     resolve_proposal,
+    set_proposal_status,
     _remove_reward_delta,
 )
 from src.commands.economy_effects import (
@@ -276,7 +278,8 @@ def test_purchase_quote_can_be_confirmed_on_next_turn() -> None:
     assert proposal["amount"] == 260
     assert proposal["items"] == ["硬皮甲"]
     assert confirm_data["state_update"].get("loot", []) == []
-    assert instance.economy["purchase_quotes"] == []
+    # 确认后报价保留为审计条目，只有 open 报价可再次结算。
+    assert instance.economy["purchase_quotes"][0]["status"] == "confirmed"
 
 
 def test_purchase_quote_requires_purchase_semantics_not_bare_currency() -> None:
@@ -369,7 +372,9 @@ def test_origin_round_rollback_discards_open_purchase_quote() -> None:
     assert record_purchase_quote(instance, data, "通行证售价5金币。")
     assert instance.economy["purchase_quotes"]
     reverse_round_economy(instance, 5)
-    assert instance.economy["purchase_quotes"] == []
+    quote = instance.economy["purchase_quotes"][0]
+    assert quote["status"] == "cancelled"
+    assert quote["resolution_code"] == "ORIGIN_ROLLED_BACK"
 
 
 def test_round_zero_rollback_discards_open_purchase_quote() -> None:
@@ -378,7 +383,61 @@ def test_round_zero_rollback_discards_open_purchase_quote() -> None:
     data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
     assert record_purchase_quote(instance, data, "通行证售价5金币。")
     reverse_round_economy(instance, 0)
-    assert instance.economy["purchase_quotes"] == []
+    assert instance.economy["purchase_quotes"][0]["status"] == "cancelled"
+
+
+def test_purchase_quote_keeps_single_open_offer_over_history() -> None:
+    instance = _instance()
+    data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
+    assert record_purchase_quote(instance, data, "通行证售价5金币。")
+    quote = instance.economy["purchase_quotes"][0]
+    assert quote["id"].startswith("quote_")
+    # 历史条目（已确认/已取消）不会阻止新报价，但同一时刻仍最多一个 open。
+    instance.action_queue = [{"user_id": "gm", "text": "行，成交"}]
+    assert settle_purchase_quote(instance, {"state_update": {}})
+    assert quote["status"] == "confirmed"
+    assert not settle_purchase_quote(instance, {"state_update": {}})
+    assert record_purchase_quote(instance, {"state_update": {"loot": [{"player": "gm", "item": "硬皮甲"}]}}, "硬皮甲售价260金币。")
+    open_quotes = [
+        item for item in instance.economy["purchase_quotes"]
+        if item.get("status", "open") == "open"
+    ]
+    assert len(open_quotes) == 1
+
+
+def test_proposal_status_transitions_are_whitelisted() -> None:
+    instance = _instance()
+    assert proposal_transition_allowed("pending", "committed")
+    assert proposal_transition_allowed("committed", "reversed")
+    assert proposal_transition_allowed("committed", "pending")
+    for terminal in ("declined", "cancelled", "rejected", "reversed", "superseded"):
+        assert not proposal_transition_allowed(terminal, "committed")
+        assert not proposal_transition_allowed(terminal, "pending")
+        assert not proposal_transition_allowed(terminal, "cancelled")
+    with pytest.raises(ValueError):
+        set_proposal_status({"status": "declined"}, "committed")
+
+    proposal = queue_proposal(
+        instance, kind="payment", payer_uid="gm", recipient_uid="gm", amount=1,
+    )
+    declined = resolve_proposal(instance, proposal["id"], actor_uid="gm", accepted=False)
+    assert declined["ok"] is True
+    for accepted in (True, False):
+        repeat = resolve_proposal(instance, proposal["id"], actor_uid="gm", accepted=accepted)
+        assert repeat["code"] == "ALREADY_RESOLVED"
+
+
+def test_queue_proposal_rejects_payer_outside_game() -> None:
+    instance = _instance()
+    with pytest.raises(ValueError):
+        queue_proposal(instance, kind="purchase", payer_uid="ghost", amount=5)
+    with pytest.raises(ValueError):
+        queue_proposal(instance, kind="transfer", payer_uid="ghost", amount=5)
+    # 奖励类提案没有付款人；收款人资格在结算时校验。
+    reward = queue_proposal(
+        instance, kind="reward", recipient_uid="p2", amount=5, approval_policy="gm",
+    )
+    assert reward["status"] == "pending"
 
 
 def test_purchase_quote_confirmation_requires_payer_and_current_run() -> None:

--- a/tests/test_webui_purchase_quotes.py
+++ b/tests/test_webui_purchase_quotes.py
@@ -13,7 +13,10 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 import web_server
-from src.commands.economy_effects import record_purchase_quote
+from src.commands.economy_effects import (
+    record_purchase_quote,
+    settle_purchase_quote,
+)
 from src.webui.routes.game_gameplay_routes import (
     api_payment_resolve,
     api_purchase_quote_cancel,
@@ -117,12 +120,74 @@ async def test_quote_confirm_creates_single_pending_proposal_for_payer(web_api):
         assert settled.status == 200
         sheet = instance.get_character_sheet(payer_uid)
         assert sheet["currency"]["amount"] == 25
+        # 分类与叙事路径一致：通行证是关键物品，不落普通背包。
         granted = [
-            item for item in sheet.get("inventory", [])
+            item for item in sheet.get("key_items", [])
             if item.get("name") == "通行证"
         ]
         assert len(granted) == 1
+        assert not [
+            item for item in sheet.get("inventory", [])
+            if item.get("name") == "通行证"
+        ]
         assert len(instance.economy["transactions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_confirm_matches_narration_confirm_delivery(web_api):
+    """同一报价，显式确认与叙事确认的权威角色状态必须一致。"""
+
+    api, _lorebook, registry, _llm, _worlds = web_api
+
+    async def _make_game(name: str):
+        created = await api.create_game(
+            "template_world",
+            name,
+            players=[
+                {"character_name": "付款人", "attributes": {"str": 10}, "gold": 30},
+            ],
+        )
+        instance = registry.get(api._parse_key(created["game_key"]))
+        uid = next(iter(instance.players))
+        return created["game_key"], instance, uid
+
+    def _record(instance, uid: str):
+        instance.action_queue = [{"user_id": uid, "text": "我想买通行证"}]
+        data = {"state_update": {"loot": [{"player": uid, "item": "通行证"}]}}
+        assert record_purchase_quote(instance, data, "通行证售价5金币。")
+        return instance.economy["purchase_quotes"][-1]
+
+    # 叙事路径：下一轮文本确认 → state_update 提案 → 支付结算。
+    narration_key, narration_inst, narration_uid = await _make_game("叙事确认")
+    _record(narration_inst, narration_uid)
+    narration_inst.action_queue = [{"user_id": narration_uid, "text": "行，成交"}]
+    confirm_payload = {"state_update": {}}
+    assert settle_purchase_quote(narration_inst, confirm_payload)
+    api._handler._apply_state_update(narration_inst, confirm_payload["state_update"])
+    narration_proposal = narration_inst.economy["proposals"][-1]
+    assert narration_proposal["quote_id"]
+    settled = await api.resolve_payment(
+        narration_key, narration_proposal["id"], True, narration_uid,
+    )
+    assert settled["ok"] is True
+
+    # 显式路径：HTTP 确认 → 支付结算。
+    explicit_key, explicit_inst, explicit_uid = await _make_game("显式确认")
+    quote = _record(explicit_inst, explicit_uid)
+    confirmed = await api.confirm_purchase_quote(explicit_key, quote["id"], explicit_uid)
+    assert confirmed["ok"] is True
+    explicit_proposal = confirmed["proposal"]
+    settled = await api.resolve_payment(
+        explicit_key, explicit_proposal["id"], True, explicit_uid,
+    )
+    assert settled["ok"] is True
+
+    narration_sheet = narration_inst.get_character_sheet(narration_uid)
+    explicit_sheet = explicit_inst.get_character_sheet(explicit_uid)
+    assert narration_sheet["currency"]["amount"] == 25
+    assert explicit_sheet["currency"]["amount"] == narration_sheet["currency"]["amount"]
+    assert narration_sheet.get("key_items") == explicit_sheet.get("key_items")
+    assert narration_sheet.get("inventory") == explicit_sheet.get("inventory")
 
 
 @pytest.mark.asyncio
@@ -196,3 +261,73 @@ async def test_quote_confirm_rejects_stale_run(web_api):
         assert stale.status == 409
         assert (await stale.json())["code"] == "STALE_RUN"
         assert not instance.economy.get("proposals")
+
+
+@pytest.mark.asyncio
+async def test_imported_legacy_open_quote_keeps_usable_id(web_api, tmp_path):
+    """导入的无 id 旧报价经迁移获得稳定 id，且在导入后仍可显式确认。"""
+
+    import io
+    import json as _json
+    import zipfile
+
+    api, _lorebook, registry, _llm, _worlds = web_api
+    state = {
+        "game_key": ["web", "legacy", "quote"],
+        "instance_schema_version": 3,
+        "run_id": "run_exported",
+        "memory_namespace": "source-memory",
+        "world_id": "template_world",
+        "state": "paused",
+        "started_at": "2025-01-01T00:00:00+00:00",
+        "round_number": 5,
+        "log": [],
+        "players": {
+            "p1": {
+                "character_name": "付款人",
+                "character_sheet": {"gold": 30, "currency": {"amount": 30}},
+            },
+        },
+        "economy": {
+            "schema_version": 2,
+            "run_id": "run_exported",
+            "purchase_quotes": [{
+                "run_id": "run_exported",
+                "round": 5,
+                "payer_uid": "p1",
+                "recipient_uid": "p1",
+                "amount": 5,
+                "items": ["通行证"],
+                "reason": "购买商品",
+                "status": "open",
+            }],
+        },
+    }
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("state.json", _json.dumps(state))
+        zf.writestr("chatlog.jsonl", _json.dumps({"round": 1, "content": "a"}) + "\n")
+    result = await registry.import_save_zip(buffer.getvalue())
+    assert result["ok"] is True
+    game_key = result["game_key"]
+    game_key = game_key if isinstance(game_key, str) else "|".join(game_key)
+    instance = registry.get(api._parse_key(game_key))
+    quote = instance.economy["purchase_quotes"][0]
+    assert quote["id"].startswith("quote_")
+    assert quote["run_id"] == instance.run_id != "run_exported"
+
+    confirmed = await api.confirm_purchase_quote(game_key, quote["id"], "p1")
+    assert confirmed["ok"] is True
+    proposal = confirmed["proposal"]
+    assert proposal["status"] == "pending"
+    assert proposal["amount"] == 5
+    assert quote["status"] == "confirmed"
+    assert not instance.economy["transactions"]
+
+    settled = await api.resolve_payment(game_key, proposal["id"], True, "p1")
+    assert settled["ok"] is True
+    sheet = instance.get_character_sheet("p1")
+    assert sheet["currency"]["amount"] == 25
+    assert any(
+        item.get("name") == "通行证" for item in sheet.get("key_items", [])
+    )

--- a/tests/test_webui_purchase_quotes.py
+++ b/tests/test_webui_purchase_quotes.py
@@ -1,0 +1,198 @@
+"""购买报价（purchase quote）显式确认契约测试。
+
+覆盖 PR1 的核心差距：持久化报价必须有服务端 offer id，确认/取消是显式的
+带身份端点，且结算仍只经由标准支付确认路径（一笔交易一次发货）。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import web_server
+from src.commands.economy_effects import record_purchase_quote
+from src.webui.routes.game_gameplay_routes import (
+    api_payment_resolve,
+    api_purchase_quote_cancel,
+    api_purchase_quote_confirm,
+)
+from src.webui.routes.game_query_routes import api_detail
+
+from webapi_harness import web_api  # noqa: F401
+
+
+def _quote_app(api, registry) -> web.Application:
+    app = web.Application(middlewares=[web_server.auth_middleware])
+    app["api"] = api
+    app["subsystems"] = SimpleNamespace(registry=registry)
+    app["plugin_host"] = None
+    app.router.add_get("/api/games/{game_key}", api_detail)
+    app.router.add_post(
+        "/api/games/{game_key}/payments/{payment_id}",
+        api_payment_resolve,
+    )
+    app.router.add_post(
+        "/api/games/{game_key}/purchase-quotes/{quote_id}/confirm",
+        api_purchase_quote_confirm,
+    )
+    app.router.add_post(
+        "/api/games/{game_key}/purchase-quotes/{quote_id}/cancel",
+        api_purchase_quote_cancel,
+    )
+    return app
+
+
+def _record_quote(instance, payer_uid: str, *, item: str = "通行证", amount: int = 5):
+    instance.action_queue = [{"user_id": payer_uid, "text": f"我想买{item}"}]
+    data = {"state_update": {"loot": [{"player": payer_uid, "item": item}]}}
+    assert record_purchase_quote(instance, data, f"{item}售价{amount}金币。")
+    return instance.economy["purchase_quotes"][-1]
+
+
+@pytest.mark.asyncio
+async def test_quote_confirm_creates_single_pending_proposal_for_payer(web_api):
+    api, _lorebook, registry, _llm, _worlds = web_api
+    created = await api.create_game(
+        "template_world",
+        "购买报价确认",
+        players=[
+            {"character_name": "付款人", "attributes": {"str": 10}, "gold": 30},
+            {"character_name": "旁观者", "attributes": {"str": 10}, "gold": 30},
+        ],
+    )
+    game_key = created["game_key"]
+    instance = registry.get(api._parse_key(game_key))
+    payer_uid, other_uid = list(instance.players)
+    quote = _record_quote(instance, payer_uid)
+    assert quote["id"].startswith("quote_")
+    assert instance.get_character_sheet(payer_uid)["currency"]["amount"] == 30
+
+    app = _quote_app(api, registry)
+    async with TestClient(TestServer(app)) as client:
+        payer_query = {"user": payer_uid, "share": "1"}
+
+        detail = await client.get(f"/api/games/{game_key}", params=payer_query)
+        assert detail.status == 200
+        projected = (await detail.json()).get("purchase_quotes", [])
+        assert [item["id"] for item in projected] == [quote["id"]]
+        assert projected[0]["amount"] == 5
+
+        # 旁观者带玩家身份也不能确认他人的报价。
+        denied = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/confirm",
+            params={"user": other_uid, "share": "1"},
+        )
+        assert denied.status == 403
+        assert not instance.economy.get("proposals")
+
+        confirmed = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/confirm",
+            params=payer_query,
+        )
+        assert confirmed.status == 200
+        proposal = (await confirmed.json())["proposal"]
+        assert proposal["status"] == "pending"
+        assert proposal["amount"] == 5
+        assert quote["status"] == "confirmed"
+        assert quote["proposal_id"] == proposal["id"]
+        # 确认只创建待确认提案，不扣款、不发货。
+        assert instance.get_character_sheet(payer_uid)["currency"]["amount"] == 30
+
+        repeat = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/confirm",
+            params=payer_query,
+        )
+        assert repeat.status == 200
+        assert (await repeat.json())["already_resolved"] is True
+        assert len(instance.economy["proposals"]) == 1
+
+        settled = await client.post(
+            f"/api/games/{game_key}/payments/{proposal['id']}",
+            params=payer_query,
+            json={"accepted": True},
+        )
+        assert settled.status == 200
+        sheet = instance.get_character_sheet(payer_uid)
+        assert sheet["currency"]["amount"] == 25
+        granted = [
+            item for item in sheet.get("inventory", [])
+            if item.get("name") == "通行证"
+        ]
+        assert len(granted) == 1
+        assert len(instance.economy["transactions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_quote_cancel_is_explicit_and_blocks_later_confirm(web_api):
+    api, _lorebook, registry, _llm, _worlds = web_api
+    created = await api.create_game(
+        "template_world",
+        "购买报价取消",
+        players=[
+            {"character_name": "付款人", "attributes": {"str": 10}, "gold": 30},
+            {"character_name": "GM 主持", "attributes": {"str": 10}, "gold": 30},
+        ],
+    )
+    game_key = created["game_key"]
+    instance = registry.get(api._parse_key(game_key))
+    payer_uid, gm_uid = list(instance.players)
+    instance.gm_uid = gm_uid
+    quote = _record_quote(instance, payer_uid)
+
+    app = _quote_app(api, registry)
+    async with TestClient(TestServer(app)) as client:
+        payer_query = {"user": payer_uid, "share": "1"}
+        cancelled = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/cancel",
+            params=payer_query,
+        )
+        assert cancelled.status == 200
+        assert quote["status"] == "cancelled"
+        assert quote["resolution_code"] == "CANCELLED_BY_PAYER"
+        assert instance.get_character_sheet(payer_uid)["currency"]["amount"] == 30
+
+        late = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/confirm",
+            params=payer_query,
+        )
+        assert late.status == 409
+        assert not instance.economy.get("proposals")
+
+        # GM 也能取消 open 报价。
+        second = _record_quote(instance, payer_uid, item="硬皮甲", amount=260)
+        gm_cancel = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{second['id']}/cancel",
+            params={"user": gm_uid, "share": "1"},
+        )
+        assert gm_cancel.status == 200
+        assert second["resolution_code"] == "CANCELLED_BY_GM"
+
+
+@pytest.mark.asyncio
+async def test_quote_confirm_rejects_stale_run(web_api):
+    api, _lorebook, registry, _llm, _worlds = web_api
+    created = await api.create_game(
+        "template_world",
+        "购买报价跨局拒绝",
+        players=[
+            {"character_name": "付款人", "attributes": {"str": 10}, "gold": 30},
+        ],
+    )
+    game_key = created["game_key"]
+    instance = registry.get(api._parse_key(game_key))
+    payer_uid = next(iter(instance.players))
+    quote = _record_quote(instance, payer_uid)
+
+    app = _quote_app(api, registry)
+    async with TestClient(TestServer(app)) as client:
+        instance.run_id = "run_new_run"
+        stale = await client.post(
+            f"/api/games/{game_key}/purchase-quotes/{quote['id']}/confirm",
+            params={"user": payer_uid, "share": "1"},
+        )
+        assert stale.status == 409
+        assert (await stale.json())["code"] == "STALE_RUN"
+        assert not instance.economy.get("proposals")


### PR DESCRIPTION
## 背景
按《经济系统 PR1 实施计划》实施。盘点结论：现有 `economy.py` / `economy_effects.py` / round 管线已满足 PR1 验收标准的大部分（服务端 proposal/transaction id、AI 输入仅进 proposal 层、单次结算幂等、rollback 审计、run_id fence、reset/restart/swipe 生命周期、故障注入测试）。按计划 §14.9 不重命名、不重写已满足项，本 PR 只收口真实差距。

## 改动（对应验收标准差距）
1. **显式报价确认契约**：purchase quote 获得服务端生成的 `quote_*` offer id；新增
   `POST /api/games/{gk}/purchase-quotes/{quote_id}/confirm|cancel`（付款人确认 / 付款人或 GM 取消），
   确认只把 persisted offer 转成 pending typed proposal，扣款仍只经由标准 `payments/{id}` 结算路径
   （Web/Bot 同一经济路径）。重复确认幂等返回已建 proposal；已取消报价确认显式 409。
   叙事正则确认路径保留为兼容，行为不变。
2. **状态迁移白名单**：`PROPOSAL_TRANSITIONS` + `set_proposal_status` 单一入口（沿用现有状态词汇，
   含 settlement-only 回滚的 `committed → pending` 重开）；终态不可再迁移，重复确认返回 `ALREADY_RESOLVED`。
3. **审计保留**：rollback/swipe 时 open 报价从「删除」改为「标记 `cancelled` + `ORIGIN_ROLLED_BACK`」；
   quote 历史限界（open 不限，closed 保留最近 24 条）；导入存档 rebind 收养 open 报价，消除
   「不可确认又阻挡新报价」的卡死状态。
4. **canonical 校验收紧**：`queue_proposal` 对 payer 类提案 fail-closed 校验付款人必须在对局；
   quote 创建时同样校验付款人。
5. **投影与访问边界**：`game_detail` 投影 open 报价（仅付款人/GM 可见）；新端点加入玩家分享访问白名单
   （付款人/GM 身份语义与 payments 一致）。

## 不在本 PR（按计划边界）
Web UI 卡片（PR2）、Bot/SSE/多规则 catalog（PR3）、多币种账本、canonical 商品目录。

## 风险面
- Multiplayer / authority：确认端点复用 authoritative_write + 聚合锁 + run fence + 幂等 source_ref；
- Persisted data：`purchase_quotes` 为 setdefault 兼容字段（旧存档加载自动补齐），无 schema_version 提升；
  已发布迁移语义未改，仅 rebind 集合增补。

## 验收标准对照
- [x] AI proposal 从未直接改变权威余额/物品（既有 + 测试）
- [x] offer_id 全部服务端生成（新增 quote id）
- [x] 状态迁移白名单 + 终态不可重复确认（新增）
- [x] reversal 审计不删除原记录（报价 rollback 改标记；transaction 原有）
- [x] persisted offer 是确认时价格/商品唯一来源（确认只读 persisted quote）
- [x] 多人 payer/item/amount 不串线（既有测试）
- [x] JSON 错误不卡剧情不伪造成功（既有 guards）
- [x] reset/restart/swipe/stale run 生命周期（既有 + 新增 quote STALE_RUN/导入测试）
- [x] 核心测试全绿；changed-file list 无 data/存档/日志/其它任务残留

## 验证
- `python -m pytest -q`：1845 passed, 1 skipped
- `ruff check src tests`：通过；mypy 无新增错误（economy.py 既有 3 处与 main 相同）