### PR TITLE
feat: economy recovery layer — merchant offers, evidence ladder, clarifications

### DIFF
--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -18,8 +18,16 @@ from uuid import uuid4
 from src.engine.language import localized_text
 
 _MAX_PURCHASE_QUOTE_HISTORY = 24
+_MAX_MERCHANT_OFFER_HISTORY = 24
+_MAX_CLARIFICATION_HISTORY = 24
 
-_ECONOMY_STATE_KEYS = {"pending_payments", "economy_proposals"}
+# Price evidence ladder for repair: the seller's persisted quote outranks the
+# current narration, which outranks the acting player's own stated amount.
+AMOUNT_SOURCE_NARRATION = "narration"
+AMOUNT_SOURCE_PLAYER_ACTION = "player_action"
+AMOUNT_SOURCE_MERCHANT_OFFER = "merchant_offer"
+
+_ECONOMY_STATE_KEYS = {"pending_payments", "economy_proposals", "merchant_offers"}
 _DEFERRED_DATA_KEYS = {
     "confirmed",
     "growth_skills",
@@ -197,6 +205,13 @@ def repair_unbacked_purchase(
     priced_narrative = bool(charge_re.search(narrative_text) or completed_payment_re.search(narrative_text))
     if not explicit_purchase and not priced_narrative:
         return 0, False
+    actor_uids = {
+        str(action.get("user_id") or "")
+        for action in action_records
+        if isinstance(action, dict)
+        and str(action.get("user_id") or "") in getattr(instance, "players", {})
+        and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
+    }
 
     grants: list[tuple[str, str]] = []
     players_update = state_update.get("players")
@@ -217,6 +232,16 @@ def repair_unbacked_purchase(
                 if uid and name:
                     grants.append((uid, name))
     if not grants:
+        # An explicit purchase intent whose sale the model narrated without any
+        # structured grant cannot bind an item or a seller acceptance.  Keep
+        # the intent as a clarification instead of silently dropping it.
+        if explicit_purchase and priced_narrative:
+            record_purchase_clarification(
+                instance,
+                reason="MISSING_SELLER_PRICE_CONFIRMATION",
+                payer_uid=next(iter(actor_uids)) if len(actor_uids) == 1 else "",
+                amount_candidates=_currency_amounts(narrative_text, currency_labels),
+            )
         return 0, False
     if _FREE_PURCHASE_RE.search(narrative_text) and not priced_narrative:
         return 0, False
@@ -232,16 +257,10 @@ def repair_unbacked_purchase(
     bound_grants = named_grants or grants
 
     amounts = _currency_amounts(narrative_text, currency_labels)
-    actor_uids = {
-        str(action.get("user_id") or "")
-        for action in action_records
-        if isinstance(action, dict)
-        and str(action.get("user_id") or "") in getattr(instance, "players", {})
-        and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
-    }
     grant_uids = {uid for uid, _item in bound_grants}
     payer_candidates = actor_uids & grant_uids
-    if len(amounts) != 1 or len(payer_candidates) != 1:
+
+    def _drop_bound_grants() -> None:
         if isinstance(players_update, dict):
             for update in players_update.values():
                 if isinstance(update, dict):
@@ -249,19 +268,73 @@ def repair_unbacked_purchase(
                     update.pop("weapon_change", None)
         if isinstance(loot, list):
             state_update["loot"] = []
+
+    # Price evidence ladder: the seller's narration is the primary source; the
+    # acting player's own stated amount only fills a missing price field.  A
+    # player amount is evidence, never an override of a seller quote.
+    amount = 0
+    amount_source = ""
+    if len(amounts) == 1:
+        amount, amount_source = amounts[0], AMOUNT_SOURCE_NARRATION
+    elif not amounts and len(payer_candidates) == 1:
+        payer_uid = next(iter(payer_candidates))
+        intent_amounts = [
+            parsed
+            for action in action_records
+            if isinstance(action, dict)
+            and str(action.get("user_id") or "") == payer_uid
+            and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
+            for parsed in _currency_amounts(str(action.get("text") or ""), currency_labels)
+        ]
+        unique_intent_amounts = sorted(set(intent_amounts))
+        if len(unique_intent_amounts) == 1:
+            amount, amount_source = unique_intent_amounts[0], AMOUNT_SOURCE_PLAYER_ACTION
+
+    if len(payer_candidates) != 1 or not amount or amount > 100_000:
+        _drop_bound_grants()
+        reason = (
+            "AMBIGUOUS_PAYER"
+            if len(payer_candidates) > 1
+            else "INVALID_AMOUNT"
+            if amount > 100_000
+            else "AMBIGUOUS_PRICE"
+        )
+        record_purchase_clarification(
+            instance,
+            reason=reason,
+            payer_uid=next(iter(payer_candidates)) if len(payer_candidates) == 1 else "",
+            item_candidates=[item for _uid, item in bound_grants],
+            amount_candidates=amounts,
+        )
         return len(grants), True
     payer_uid = next(iter(payer_candidates))
-    amount = amounts[0]
-    if amount > 100_000:
-        if isinstance(players_update, dict):
-            for update in players_update.values():
-                if isinstance(update, dict):
-                    update.pop("equip_gain", None)
-                    update.pop("weapon_change", None)
-        if isinstance(loot, list):
-            state_update["loot"] = []
-        return len(grants), True
     items = [item for uid, item in bound_grants if uid == payer_uid]
+
+    offers = match_open_merchant_offers(instance, items)
+    if len(offers) > 1:
+        _drop_bound_grants()
+        record_purchase_clarification(
+            instance,
+            reason="AMBIGUOUS_OFFER",
+            payer_uid=payer_uid,
+            item_candidates=items,
+            amount_candidates=[amount],
+        )
+        return len(grants), True
+    if len(offers) == 1:
+        offer_amount = int(offers[0].get("amount") or 0)
+        if amount != offer_amount:
+            _drop_bound_grants()
+            record_purchase_clarification(
+                instance,
+                reason="OFFER_PRICE_CONFLICT",
+                payer_uid=payer_uid,
+                item_candidates=items,
+                amount_candidates=sorted({amount, offer_amount}),
+            )
+            return len(grants), True
+        amount, amount_source = offer_amount, AMOUNT_SOURCE_MERCHANT_OFFER
+
     proposal = {
         "kind": "purchase",
         "uid": payer_uid,
@@ -271,6 +344,7 @@ def repair_unbacked_purchase(
         "reason": f"购买 {'、'.join(items)}",
         "approval_policy": "payer",
         "source": "server_purchase_guard",
+        "amount_source": amount_source,
     }
     data.setdefault("state_update", {}).setdefault("economy_proposals", []).append(proposal)
     # The proposal's rewards are the sole authoritative delivery path. Consume
@@ -321,6 +395,171 @@ def has_server_purchase_guard(data: dict[str, Any]) -> bool:
         isinstance(proposal, dict) and proposal.get("source") == "server_purchase_guard"
         for proposal in proposals
     )
+
+def _bounded_economy_collection(instance: Any, key: str) -> list[dict[str, Any]]:
+    economy = getattr(instance, "economy", None)
+    if not isinstance(economy, dict):
+        return []
+    entries = economy.setdefault(key, [])
+    if not isinstance(entries, list):
+        economy[key] = []
+    return economy[key]
+
+
+def _trim_open_history(entries: list[dict[str, Any]], *, max_history: int) -> None:
+    open_entries = [
+        entry for entry in entries
+        if isinstance(entry, dict) and entry.get("status") == "open"
+    ]
+    resolved = [
+        entry for entry in entries
+        if not (isinstance(entry, dict) and entry.get("status") == "open")
+    ]
+    budget = max(0, max_history - len(open_entries))
+    entries[:] = (resolved[-budget:] if budget else []) + open_entries
+
+
+def record_merchant_offer(
+    instance: Any,
+    *,
+    item_display: str,
+    amount: int,
+    seller_id: str = "",
+    currency_id: str = "",
+) -> dict[str, Any] | None:
+    """Persist one world-side merchant offer from a typed payload.
+
+    Offers are world facts, not decisions: they never bind a payer and can
+    never settle, charge, or deliver anything.  The amount is the seller's
+    statement and stays authoritative — a player-stated price may conflict
+    with it, but never overwrite it.
+    """
+
+    name = str(item_display or "").strip()[:120]
+    try:
+        price = int(amount)
+    except (TypeError, ValueError):
+        return None
+    if not name or not 0 < price <= 100_000:
+        return None
+    offers = _bounded_economy_collection(instance, "merchant_offers")
+    for offer in offers:
+        if (
+            isinstance(offer, dict)
+            and offer.get("status") == "open"
+            and str(offer.get("item_display") or "") == name
+            and (
+                not offer.get("run_id")
+                or str(offer.get("run_id")) == str(getattr(instance, "run_id", ""))
+            )
+        ):
+            # A persisted seller quote stands until it is resolved or rolled
+            # back; a re-narrated identical quote never moves its price.
+            return offer
+    offer = {
+        "id": f"offer_{uuid4().hex}",
+        "run_id": str(getattr(instance, "run_id", "")),
+        "origin_round": int(getattr(instance, "round_number", 0) or 0),
+        "item_display": name,
+        "amount": price,
+        "currency_id": str(currency_id or "")[:40],
+        "seller_id": str(seller_id or "")[:120],
+        "status": "open",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    offers.append(offer)
+    _trim_open_history(offers, max_history=_MAX_MERCHANT_OFFER_HISTORY)
+    return offer
+
+
+def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list[dict[str, Any]]:
+    """Open offers whose item reference matches any purchase item name.
+
+    Matching is deliberately conservative substring containment in either
+    direction with a minimum length, so "精钢剑" binds to "矮人精钢剑" while
+    single-character generic mentions never do.
+    """
+
+    names = [str(name or "").strip() for name in item_names if str(name or "").strip()]
+    if not names:
+        return []
+    matches: list[dict[str, Any]] = []
+    for offer in _bounded_economy_collection(instance, "merchant_offers"):
+        if not isinstance(offer, dict) or offer.get("status") != "open":
+            continue
+        if (
+            offer.get("run_id")
+            and str(offer.get("run_id")) != str(getattr(instance, "run_id", ""))
+        ):
+            continue
+        display = str(offer.get("item_display") or "").strip()
+        if len(display) < 2:
+            continue
+        if any(display in name or name in display for name in names):
+            matches.append(offer)
+    return matches
+
+
+def record_purchase_clarification(
+    instance: Any,
+    *,
+    reason: str,
+    payer_uid: str = "",
+    item_candidates: Iterable[str] = (),
+    amount_candidates: Iterable[int] = (),
+) -> dict[str, Any] | None:
+    """Persist an unresolvable purchase intent as structured pending state.
+
+    A clarification is a business state, not an error: it can never settle,
+    charge, or deliver anything.  It keeps the structure of a failed
+    fail-closed binding available for GM/player resolution instead of
+    degrading it into a prose-only notice.
+    """
+
+    items: list[str] = []
+    for candidate in item_candidates:
+        name = str(candidate or "").strip()[:120]
+        if name and name not in items:
+            items.append(name)
+    amounts: list[int] = []
+    for amount_candidate in amount_candidates:
+        try:
+            parsed = int(amount_candidate)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0 and parsed not in amounts:
+            amounts.append(parsed)
+    if not items and not amounts:
+        return None
+    clarifications = _bounded_economy_collection(instance, "clarifications")
+    signature = (
+        str(payer_uid or ""), tuple(items), tuple(amounts), str(reason)[:60],
+    )
+    for entry in clarifications:
+        if not isinstance(entry, dict) or entry.get("status") != "open":
+            continue
+        entry_signature = (
+            str(entry.get("payer_uid") or ""),
+            tuple(str(item) for item in (entry.get("item_candidates") or [])),
+            tuple(int(value) for value in (entry.get("amount_candidates") or [])),
+            str(entry.get("reason") or ""),
+        )
+        if entry_signature == signature:
+            return entry
+    clarification = {
+        "id": f"clarify_{uuid4().hex}",
+        "run_id": str(getattr(instance, "run_id", "")),
+        "origin_round": int(getattr(instance, "round_number", 0) or 0),
+        "payer_uid": str(payer_uid or ""),
+        "item_candidates": items,
+        "amount_candidates": amounts,
+        "reason": str(reason)[:60],
+        "status": "open",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    clarifications.append(clarification)
+    _trim_open_history(clarifications, max_history=_MAX_CLARIFICATION_HISTORY)
+    return clarification
 
 def _purchase_quotes(instance: Any) -> list[dict[str, Any]]:
     economy = getattr(instance, "economy", None)
@@ -690,6 +929,7 @@ def guard_unbacked_payment_narration(
 
 
 def discard_unbacked_purchase_items(
+    instance: Any,
     data: dict[str, Any],
     narration: str,
     *,
@@ -712,9 +952,15 @@ def discard_unbacked_purchase_items(
     if not isinstance(state_update, dict):
         return 0
     dropped = 0
+    dropped_items: list[str] = []
     loot = state_update.get("loot")
     if isinstance(loot, list) and loot:
         dropped += len(loot)
+        dropped_items.extend(
+            str(entry.get("item") or "").strip()
+            for entry in loot
+            if isinstance(entry, dict) and str(entry.get("item") or "").strip()
+        )
         state_update["loot"] = []
     players_update = state_update.get("players")
     if isinstance(players_update, dict):
@@ -724,7 +970,17 @@ def discard_unbacked_purchase_items(
             for key in ("equip_gain", "weapon_change"):
                 if key in player_update:
                     dropped += 1
+                    name = str(player_update.get(key) or "").strip()
+                    if name:
+                        dropped_items.append(name)
                     player_update.pop(key, None)
+    if dropped:
+        record_purchase_clarification(
+            instance,
+            reason="MISSING_SELLER_PRICE_CONFIRMATION",
+            item_candidates=dropped_items,
+            amount_candidates=_currency_amounts(narration_text, currency_labels),
+        )
     return dropped
 
 

--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -472,15 +472,25 @@ def record_merchant_offer(
     return offer
 
 
-def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list[dict[str, Any]]:
-    """Open offers whose item reference matches any purchase item name.
+def _normalized_item_name(name: str) -> str:
+    """Casefolded name without whitespace so decoration variants compare stably."""
 
-    Matching is deliberately conservative substring containment in either
-    direction with a minimum length, so "精钢剑" binds to "矮人精钢剑" while
-    single-character generic mentions never do.
+    return "".join(str(name or "").split()).casefold()
+
+
+def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list[dict[str, Any]]:
+    """Open offers whose item reference matches a purchase item name.
+
+    Binding requires the purchase name to equal the offer's item reference or
+    extend it as a suffix (Chinese variants put modifiers before the head
+    noun: "矮人精钢剑" extends "精钢剑").  Bidirectional substring matching is
+    deliberately not used — "长剑鞘" must not inherit a "长剑" quote and
+    "铁剑碎片" must not inherit "铁剑"; uncertain matches fall through to
+    clarification instead of silently inheriting a price.
     """
 
-    names = [str(name or "").strip() for name in item_names if str(name or "").strip()]
+    names = [_normalized_item_name(name) for name in item_names]
+    names = [name for name in names if name]
     if not names:
         return []
     matches: list[dict[str, Any]] = []
@@ -492,10 +502,10 @@ def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list
             and str(offer.get("run_id")) != str(getattr(instance, "run_id", ""))
         ):
             continue
-        display = str(offer.get("item_display") or "").strip()
+        display = _normalized_item_name(str(offer.get("item_display") or ""))
         if len(display) < 2:
             continue
-        if any(display in name or name in display for name in names):
+        if any(name == display or name.endswith(display) for name in names):
             matches.append(offer)
     return matches
 

--- a/src/commands/game_lifecycle.py
+++ b/src/commands/game_lifecycle.py
@@ -327,7 +327,7 @@ class GameLifecycle:
             currency_labels=currency_labels,
         )
         dropped_purchase_items = discard_unbacked_purchase_items(
-            start_data, narration, currency_labels=currency_labels,
+            instance, start_data, narration, currency_labels=currency_labels,
         )
         if dropped_purchase_items:
             narration = f"{narration}\n\n{unbacked_purchase_notice(instance.language)}".strip()

--- a/src/commands/round_processor.py
+++ b/src/commands/round_processor.py
@@ -654,7 +654,7 @@ class RoundProcessor:
             dropped_purchase_items, purchase_was_ambiguous = 0, False
         if not settled_quote and not purchase_was_ambiguous:
             dropped_purchase_items += discard_unbacked_purchase_items(
-                data, response.narration, currency_labels=currency_labels,
+                instance, data, response.narration, currency_labels=currency_labels,
             )
         if dropped_purchase_items:
             response.narration = (

--- a/src/commands/state_update_applier.py
+++ b/src/commands/state_update_applier.py
@@ -13,7 +13,10 @@ from typing import Any, Callable
 
 from src.compat.callbacks import load_world_template as load_world_template_compat
 from src.engine.game_instance import GameInstance
-from src.commands.economy_effects import link_purchase_quote_proposal
+from src.commands.economy_effects import (
+    link_purchase_quote_proposal,
+    record_merchant_offer,
+)
 from src.commands.item_category_resolver import ItemCategoryResolver
 from src.commands.madness_tracker import MadnessTracker
 from src.commands.npc_state_applier import NpcStateApplier
@@ -255,13 +258,39 @@ class StateUpdateApplier:
                 contributors=contributors if is_team_fee else None,
                 visibility="party" if is_team_fee else "private",
                 quote_id=str(proposal.get("quote_id") or ""),
+                # AI payloads never set the price source; only the server
+                # guard records which evidence produced the amount.
+                amount_source=(
+                    str(proposal.get("amount_source") or "")
+                    if source == "server_purchase_guard"
+                    else ""
+                ),
             ))
             quote_id = str(proposal.get("quote_id") or "")
             if quote_id:
                 link_purchase_quote_proposal(
                     instance, quote_id, str(queued_proposals[-1].get("id") or ""),
                 )
+        self._apply_merchant_offers(instance, update)
         return queued_proposals
+
+    def _apply_merchant_offers(self, instance: GameInstance, update: dict) -> None:
+        """Persist typed world-side merchant offers; they never bind a payer."""
+
+        for offer_payload in update.get("merchant_offers", []) or []:
+            if not isinstance(offer_payload, dict):
+                continue
+            record_merchant_offer(
+                instance,
+                item_display=str(
+                    offer_payload.get("item_display")
+                    or offer_payload.get("item")
+                    or ""
+                ),
+                amount=offer_payload.get("amount", 0),
+                seller_id=str(offer_payload.get("seller_id") or ""),
+                currency_id=str(offer_payload.get("currency_id") or ""),
+            )
 
     def apply_madness(self, instance: GameInstance, uid: str, cs: dict, loss: int) -> None:
         """兼容旧内部调用；实际逻辑已拆到 MadnessTracker。"""

--- a/src/commands/swipe_generator.py
+++ b/src/commands/swipe_generator.py
@@ -199,7 +199,7 @@ class SwipeGenerator:
         )
         if not purchase_was_ambiguous:
             dropped_purchase_items += discard_unbacked_purchase_items(
-                data, narration, currency_labels=currency_labels,
+                instance, data, narration, currency_labels=currency_labels,
             )
         if dropped_purchase_items:
             narration = f"{narration}\n\n{unbacked_purchase_notice(instance.language)}".strip()

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -23,6 +23,7 @@ MAX_EXTERNAL_EFFECT_DELIVERIES = 50
 # (or reopened by a settlement-only rollback).  Everything else is terminal and
 # must never be re-resolved.
 PAYER_ECONOMY_KINDS = {"payment", "purchase", "fee", "transfer"}
+VALID_AMOUNT_SOURCES = {"", "narration", "player_action", "merchant_offer"}
 PROPOSAL_TRANSITIONS: dict[str, frozenset[str]] = {
     "pending": frozenset({"committed", "declined", "cancelled", "rejected", "superseded"}),
     "committed": frozenset({"reversed", "pending"}),
@@ -554,6 +555,10 @@ def queue_proposal(
         # Fail closed at the proposal layer: a payer outside the current game
         # can never be settled, so the offer must not become pending.
         raise ValueError("economy payer is not part of the current game")
+    if str(amount_source) not in VALID_AMOUNT_SOURCES:
+        # The audit field records which evidence produced the amount; an
+        # unknown value would make that provenance untrustworthy.
+        raise ValueError("unsupported economy amount source")
     normalized_contributors = deepcopy(list(contributors or []))
     if approval_policy == "all_contributors":
         contributor_uids = [

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -538,6 +538,7 @@ def queue_proposal(
     contributors: list[dict[str, Any]] | None = None,
     visibility: str = "private",
     quote_id: str = "",
+    amount_source: str = "",
 ) -> dict[str, Any]:
     """Queue one idempotent proposal; no balance is changed here."""
 
@@ -593,6 +594,9 @@ def queue_proposal(
         # Origin linkage for offers converted from a persisted purchase quote;
         # empty for proposals that did not come from a quote.
         "quote_id": str(quote_id),
+        # Audit of which evidence produced the amount (server guard paths
+        # only): narration / player_action / merchant_offer.
+        "amount_source": str(amount_source)[:40],
         "approval_policy": str(approval_policy),
         "rewards": deepcopy(list(rewards or [])),
         "contributors": normalized_contributors,
@@ -952,6 +956,31 @@ def reverse_round_economy(instance: Any, round_number: int) -> None:
             proposal_id = str(quote.get("proposal_id") or "")
             if proposal_id:
                 quote_origin_proposal_ids.add(proposal_id)
+
+    # Merchant offers and clarifications are world-side purchase context, not
+    # decisions.  Erasing their origin round retires them the same way so a
+    # rollback never leaves ghost quotes or ghost intents actionable.
+    for collection_name in ("merchant_offers", "clarifications"):
+        entries = instance.economy.get(collection_name, [])
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict) or entry.get("status") != "open":
+                continue
+            try:
+                origin_round = int(entry.get("origin_round", -1))
+            except (TypeError, ValueError):
+                origin_round = -1
+            if origin_round != rollback_round:
+                continue
+            if (
+                entry.get("run_id")
+                and str(entry.get("run_id")) != str(instance.run_id)
+            ):
+                continue
+            entry["status"] = "superseded"
+            entry["resolved_at"] = datetime.now(timezone.utc).isoformat()
+            entry["resolution_code"] = "ORIGIN_ROLLED_BACK"
     proposals = [
         item for item in instance.economy.get("proposals", [])
         if isinstance(item, dict)

--- a/src/engine/game_instance.py
+++ b/src/engine/game_instance.py
@@ -274,6 +274,8 @@ class GameInstance:
             self.economy.setdefault("external_effects_outbox", [])
             self.economy.setdefault("outcomes", [])
             self.economy.setdefault("purchase_quotes", [])
+            self.economy.setdefault("merchant_offers", [])
+            self.economy.setdefault("clarifications", [])
             self.economy.setdefault("decision_revision", 0)
 
     def _fresh_economy_state(self) -> dict[str, Any]:
@@ -288,6 +290,8 @@ class GameInstance:
             "external_effects_outbox": [],
             "outcomes": [],
             "purchase_quotes": [],
+            "merchant_offers": [],
+            "clarifications": [],
             "decision_revision": 0,
         }
 

--- a/src/migrations/instance.py
+++ b/src/migrations/instance.py
@@ -203,6 +203,8 @@ def rebind_imported_game_state_payload(
             "external_effects_outbox",
             "outcomes",
             "purchase_quotes",
+            "merchant_offers",
+            "clarifications",
         ):
             for item in economy.get(collection_name, []) or []:
                 if isinstance(item, dict):

--- a/src/webui/services/game_queries.py
+++ b/src/webui/services/game_queries.py
@@ -147,6 +147,47 @@ def game_detail(
             or viewer_uid == str(quote.get("payer_uid") or "")
         )
     ]
+    open_merchant_offers = [
+        {
+            "id": str(offer.get("id") or ""),
+            "item_display": str(offer.get("item_display") or ""),
+            "amount": int(offer.get("amount", 0) or 0),
+            "currency_id": str(offer.get("currency_id") or ""),
+            "origin_round": int(offer.get("origin_round", 0) or 0),
+            "status": "open",
+        }
+        for offer in (getattr(instance, "economy", {}).get("merchant_offers", []) or [])
+        if isinstance(offer, dict)
+        and offer.get("status") == "open"
+        and str(offer.get("run_id") or "") == str(instance.run_id)
+    ]
+    open_clarifications = [
+        {
+            "id": str(entry.get("id") or ""),
+            "payer_uid": str(entry.get("payer_uid") or ""),
+            "item_candidates": [
+                str(item) for item in (entry.get("item_candidates") or []) if str(item)
+            ],
+            "amount_candidates": [
+                int(value) for value in (entry.get("amount_candidates") or [])
+            ],
+            "reason": str(entry.get("reason") or ""),
+            "origin_round": int(entry.get("origin_round", 0) or 0),
+            "status": "open",
+        }
+        for entry in (getattr(instance, "economy", {}).get("clarifications", []) or [])
+        if isinstance(entry, dict)
+        and entry.get("status") == "open"
+        and str(entry.get("run_id") or "") == str(instance.run_id)
+        and (
+            not viewer_uid
+            or viewer_uid == instance.gm_uid
+            or (
+                entry.get("payer_uid")
+                and viewer_uid == str(entry.get("payer_uid") or "")
+            )
+        )
+    ]
     detail = {
         "game_key": _GAME_KEY_SEP.join(instance.game_key),
         "run_id": instance.run_id,
@@ -192,6 +233,8 @@ def game_detail(
         ],
         "economy_proposals": economy_proposals,
         "purchase_quotes": open_purchase_quotes,
+        "merchant_offers": open_merchant_offers,
+        "clarifications": open_clarifications,
         "pending_luck_decisions": instance.pending_luck_checks(),
         "round_check_results": (
             [dict(item) for item in instance.last_checks]

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -28,6 +28,8 @@ from src.commands.economy_effects import (
     discard_unbacked_purchase_items,
     guard_unbacked_payment_narration,
     link_purchase_quote_proposal,
+    record_merchant_offer,
+    record_purchase_clarification,
     repair_unbacked_purchase,
     defer_narrative_effects,
     record_purchase_quote,
@@ -142,23 +144,32 @@ def test_narrated_payment_with_proposal_keeps_pending_notice_path() -> None:
 
 
 def test_unbacked_shop_price_does_not_grant_loot() -> None:
+    instance = _instance()
     data = {"state_update": {"loot": [{"player": "gm", "item": "通行证"}]}}
     dropped = discard_unbacked_purchase_items(
-        data, "城门卫兵说通行证需要支付5金币。"
+        instance, data, "城门卫兵说通行证需要支付5金币。"
     )
     assert dropped == 1
     assert data["state_update"]["loot"] == []
+    # fail-closed 的结构保留：澄清记录包含候选商品与叙事价格。
+    clarification = instance.economy["clarifications"][0]
+    assert clarification["status"] == "open"
+    assert clarification["item_candidates"] == ["通行证"]
+    assert clarification["amount_candidates"] == [5]
+    assert clarification["reason"] == "MISSING_SELLER_PRICE_CONFIRMATION"
 
 
 def test_purchase_loot_is_kept_when_proposal_exists() -> None:
+    instance = _instance()
     data = {
         "state_update": {
             "loot": [{"player": "gm", "item": "通行证"}],
             "economy_proposals": [{"kind": "purchase", "uid": "gm", "amount": 5}],
         },
     }
-    assert discard_unbacked_purchase_items(data, "通行证需要支付5金币。") == 0
+    assert discard_unbacked_purchase_items(instance, data, "通行证需要支付5金币。") == 0
     assert data["state_update"]["loot"]
+    assert not instance.economy.get("clarifications")
 
 
 def test_explicit_purchase_with_omitted_pay_tag_becomes_pending_proposal() -> None:
@@ -443,6 +454,151 @@ def test_queue_proposal_rejects_payer_outside_game() -> None:
         instance, kind="reward", recipient_uid="p2", amount=5, approval_policy="gm",
     )
     assert reward["status"] == "pending"
+
+
+def test_typed_merchant_offer_persists_without_grant() -> None:
+    instance = _instance()
+    applier = StateUpdateApplier(Path("nonexistent-rules"), None, lambda world_id, language: {})
+    applier.apply_state_update(instance, {
+        "merchant_offers": [
+            {
+                "item_display": "矮人精钢剑", "amount": 30,
+                "seller_id": "npc_hogen", "currency_id": "gold",
+            },
+            {"item_display": "", "amount": 5},
+            {"item_display": "药膏", "amount": -1},
+        ],
+    })
+    offers = instance.economy["merchant_offers"]
+    assert len(offers) == 1
+    offer = offers[0]
+    assert offer["id"].startswith("offer_")
+    assert offer["item_display"] == "矮人精钢剑"
+    assert offer["amount"] == 30
+    assert offer["run_id"] == instance.run_id
+    assert offer["status"] == "open"
+    # 已持久化的卖家报价不会被重新叙述覆盖价格。
+    applier.apply_state_update(instance, {
+        "merchant_offers": [{"item_display": "矮人精钢剑", "amount": 99}],
+    })
+    assert len(instance.economy["merchant_offers"]) == 1
+    assert instance.economy["merchant_offers"][0]["amount"] == 30
+
+
+def test_player_action_price_synthesizes_pending_proposal() -> None:
+    """叙事没复述价格、玩家行动自带唯一金额：出待确认提案，确认前不动钱。"""
+
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "掏30金币买下精钢剑"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根接过金币，转身取下那柄矮人精钢剑，递到你面前。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert proposal["amount_source"] == "player_action"
+    assert proposal["items"] == ["矮人精钢剑"]
+    assert data["state_update"]["loot"] == []
+    assert instance.get_character_sheet("gm")["currency"]["amount"] == 30
+
+
+def test_narration_price_outranks_action_price() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "掏20金币买下精钢剑"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根咧嘴：“这剑三十金币。”你把钱放下了。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert proposal["amount_source"] == "narration"
+
+
+def test_merchant_offer_price_is_authoritative_when_it_matches() -> None:
+    instance = _instance()
+    record_merchant_offer(instance, item_display="矮人精钢剑", amount=30)
+    instance.action_queue = [{"user_id": "gm", "text": "掏30金币买下精钢剑"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根收了钱，把剑递到你面前。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert proposal["amount_source"] == "merchant_offer"
+
+
+def test_player_amount_conflicting_with_offer_clarifies() -> None:
+    """stored offer=30，玩家喊 20：不出 20 的提案，进澄清（还价语义）。"""
+
+    instance = _instance()
+    record_merchant_offer(instance, item_display="矮人精钢剑", amount=30)
+    instance.action_queue = [{"user_id": "gm", "text": "掏20金币买下精钢剑"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根皱起了眉头。",
+    )
+    assert (dropped, ambiguous) == (1, True)
+    assert not data["state_update"].get("economy_proposals")
+    assert data["state_update"]["loot"] == []
+    clarification = instance.economy["clarifications"][0]
+    assert clarification["reason"] == "OFFER_PRICE_CONFLICT"
+    assert clarification["payer_uid"] == "gm"
+    assert clarification["item_candidates"] == ["矮人精钢剑"]
+    assert clarification["amount_candidates"] == [20, 30]
+
+
+def test_prose_sale_without_grants_persists_clarification() -> None:
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "我买下这把剑"}]
+    data = {"state_update": {}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "你掏出三十金币递了过去，商家点头把剑包好。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    assert not data["state_update"].get("economy_proposals")
+    clarification = instance.economy["clarifications"][0]
+    assert clarification["reason"] == "MISSING_SELLER_PRICE_CONFIRMATION"
+    assert clarification["payer_uid"] == "gm"
+    assert clarification["amount_candidates"] == [30]
+    assert clarification["status"] == "open"
+
+
+def test_clarification_dedupes_identical_open_entries() -> None:
+    instance = _instance()
+    first = record_purchase_clarification(
+        instance, reason="AMBIGUOUS_PRICE", payer_uid="gm",
+        item_candidates=["矮人精钢剑"], amount_candidates=[20],
+    )
+    second = record_purchase_clarification(
+        instance, reason="AMBIGUOUS_PRICE", payer_uid="gm",
+        item_candidates=["矮人精钢剑"], amount_candidates=[20],
+    )
+    assert first["id"] == second["id"]
+    assert len(instance.economy["clarifications"]) == 1
+
+
+def test_rollback_supersedes_open_offers_and_clarifications() -> None:
+    instance = _instance()
+    instance.round_number = 5
+    record_merchant_offer(instance, item_display="矮人精钢剑", amount=30)
+    record_purchase_clarification(
+        instance, reason="AMBIGUOUS_PRICE", payer_uid="gm",
+        item_candidates=["矮人精钢剑"], amount_candidates=[20],
+    )
+    reverse_round_economy(instance, 5)
+    assert instance.economy["merchant_offers"][0]["status"] == "superseded"
+    assert instance.economy["merchant_offers"][0]["resolution_code"] == "ORIGIN_ROLLED_BACK"
+    assert instance.economy["clarifications"][0]["status"] == "superseded"
+    # 其他轮次的 open 条目不受影响。
+    instance.round_number = 6
+    later_offer = record_merchant_offer(instance, item_display="硬皮甲", amount=260)
+    assert later_offer["status"] == "open"
+    reverse_round_economy(instance, 6)
+    assert later_offer["status"] == "superseded"
+    assert instance.economy["merchant_offers"][0]["status"] == "superseded"
 
 
 def test_purchase_quote_confirmation_requires_payer_and_current_run() -> None:

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -28,6 +28,7 @@ from src.commands.economy_effects import (
     discard_unbacked_purchase_items,
     guard_unbacked_payment_narration,
     link_purchase_quote_proposal,
+    match_open_merchant_offers,
     record_merchant_offer,
     record_purchase_clarification,
     repair_unbacked_purchase,
@@ -578,6 +579,39 @@ def test_clarification_dedupes_identical_open_entries() -> None:
     )
     assert first["id"] == second["id"]
     assert len(instance.economy["clarifications"]) == 1
+
+
+def test_merchant_offer_matching_requires_exact_or_suffix() -> None:
+    """绑定只认精确匹配或后缀变体；包含关系不得误继承商家价格。"""
+
+    instance = _instance()
+    variant = record_merchant_offer(instance, item_display="精钢剑", amount=30)
+    sword_sheath = record_merchant_offer(instance, item_display="长剑鞘", amount=5)
+    assert record_merchant_offer(instance, item_display="铁剑", amount=25) is not None
+
+    # 精确匹配与后缀变体（修饰语在前、中心语在后）可绑定。
+    assert [offer["id"] for offer in match_open_merchant_offers(instance, ["精钢剑"])] == [variant["id"]]
+    assert [offer["id"] for offer in match_open_merchant_offers(instance, ["矮人精钢剑"])] == [variant["id"]]
+    # "长剑鞘" 精确命中自己的报价，且不得因包含关系再命中 "长剑"。
+    assert [offer["id"] for offer in match_open_merchant_offers(instance, ["长剑鞘"])] == [sword_sheath["id"]]
+    # 典型误绑定陷阱：碎片/鞘类 purchase 不得继承武器报价。
+    assert match_open_merchant_offers(instance, ["铁剑碎片"]) == []
+    assert match_open_merchant_offers(instance, ["长剑"]) == []
+    assert match_open_merchant_offers(instance, ["圣剑"]) == []
+
+
+def test_queue_proposal_rejects_unknown_amount_source() -> None:
+    instance = _instance()
+    with pytest.raises(ValueError):
+        queue_proposal(
+            instance, kind="payment", payer_uid="gm", amount=1,
+            amount_source="fabricated",
+        )
+    proposal = queue_proposal(
+        instance, kind="payment", payer_uid="gm", amount=1,
+        amount_source="merchant_offer",
+    )
+    assert proposal["amount_source"] == "merchant_offer"
 
 
 def test_rollback_supersedes_open_offers_and_clarifications() -> None:

--- a/tests/test_webui_purchase_quotes.py
+++ b/tests/test_webui_purchase_quotes.py
@@ -14,6 +14,8 @@ from aiohttp.test_utils import TestClient, TestServer
 
 import web_server
 from src.commands.economy_effects import (
+    record_merchant_offer,
+    record_purchase_clarification,
     record_purchase_quote,
     settle_purchase_quote,
 )
@@ -261,6 +263,48 @@ async def test_quote_confirm_rejects_stale_run(web_api):
         assert stale.status == 409
         assert (await stale.json())["code"] == "STALE_RUN"
         assert not instance.economy.get("proposals")
+
+
+@pytest.mark.asyncio
+async def test_game_detail_projects_offers_and_clarifications(web_api):
+    """商家报价全桌可见；澄清只对 GM 和对应付款人可见。"""
+
+    api, _lorebook, registry, _llm, _worlds = web_api
+    created = await api.create_game(
+        "template_world",
+        "报价与澄清投影",
+        players=[
+            {"character_name": "付款人", "attributes": {"str": 10}, "gold": 30},
+            {"character_name": "旁观者", "attributes": {"str": 10}, "gold": 30},
+        ],
+    )
+    game_key = created["game_key"]
+    instance = registry.get(api._parse_key(game_key))
+    payer_uid, other_uid = list(instance.players)
+    record_merchant_offer(instance, item_display="矮人精钢剑", amount=30)
+    record_purchase_clarification(
+        instance, reason="OFFER_PRICE_CONFLICT", payer_uid=payer_uid,
+        item_candidates=["矮人精钢剑"], amount_candidates=[20, 30],
+    )
+
+    app = _quote_app(api, registry)
+    async with TestClient(TestServer(app)) as client:
+        payer_view = await client.get(
+            f"/api/games/{game_key}", params={"user": payer_uid, "share": "1"},
+        )
+        body = await payer_view.json()
+        assert [offer["item_display"] for offer in body["merchant_offers"]] == ["矮人精钢剑"]
+        assert body["merchant_offers"][0]["amount"] == 30
+        assert len(body["clarifications"]) == 1
+        assert body["clarifications"][0]["reason"] == "OFFER_PRICE_CONFLICT"
+
+        other_view = await client.get(
+            f"/api/games/{game_key}", params={"user": other_uid, "share": "1"},
+        )
+        other_body = await other_view.json()
+        # 报价是世界事实，全桌可见；他人澄清不可见。
+        assert len(other_body["merchant_offers"]) == 1
+        assert other_body["clarifications"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景
真实对局（铁匠铺买剑）暴露的问题：AI 只写散文交付、未发提案标签、价格只在玩家行动里时，fail-closed 直接丢弃全部结构，只剩一句"由于没有生成支付提案，本次购买物品未发放"，玩家只能靠 GM 凭记忆手动补提案。本 PR 建在 #214 报价契约之上，补齐"安全失败之后的优雅恢复"，不放松任何权威边界。

## 改动（对应评审方案的 1～3 条；第 4 条物品系统按约定单独做）

### 1. `economy.merchant_offers` — 商家报价沉淀（不再依赖同轮 grant）
- 新 typed payload `state_update.merchant_offers`（AI/world 结构化输出，服务端校验：商品名非空 ≤120、金额 1..100000），服务端生成 `offer_*` id、绑定 run_id + origin_round
- 报价是世界事实：不绑 payer、不可结算、不可扣款、不可发货；同商品已存在 open 报价时重述不覆盖价格（持久化卖家报价是权威）
- origin 回滚同 quote 一样标 `superseded` + `ORIGIN_ROLLED_BACK`（评审图未覆盖、实现时补上的边界）；导入 rebind 一并收养

### 2. repair 价格证据阶梯（替代"搜到一个数字就用"）
按优先级：
1. 已持久化 merchant offer（金额权威）
2. 当前 AI 叙事唯一绑定价格（原路径）
3. 玩家行动中自报的唯一金额 —— **仅在**商品唯一绑定 + 同轮结构化 grant（卖方接受证据）同时成立时使用，且写入 `amount_source: "player_action"` 供审计；AI 载荷永远不能自设 amount_source
4. 仍无法唯一确认 → needs_clarification
- 已持久化 offer 与玩家金额冲突（如 offer=30、玩家喊 20）→ **不出 20 的提案**，进 clarification（还价语义）
- 合成的仍然是 pending 提案：付款人确认前不扣款、不发货

### 3. `economy.clarifications` — 结构化待澄清（业务状态，不是 error）
- 不可结算/扣款/发货；记录 `payer_uid` / `item_candidates` / `amount_candidates` / `reason`（MISSING_SELLER_PRICE_CONFIRMATION、AMBIGUOUS_PRICE、AMBIGUOUS_PAYER、AMBIGUOUS_OFFER、OFFER_PRICE_CONFLICT、INVALID_AMOUNT）/ origin_round
- 同签名去重、open 优先的限界（24 条）；origin 回滚标 superseded
- game_detail 投影：商家报价全桌可见；澄清仅 GM 与对应付款人可见
- prose 提示保留不变；clarification 是额外结构，不影响既有 notice

## 边界（不在本 PR）
- PR B：澄清/报价的 UI 卡片、GM 修正入口、玩家放弃/重新询价；prompt 侧让模型学会输出 `merchant_offers` 键
- PR C：canonical item id、规则集 catalog adapter、物品属性与落位（与本 PR 完全解耦；`currency_id` 仅作展示/审计字段，结算仍走单一 `currency.amount`）

## 风险面
UI 之外的经济入口加固；不触碰权限模型（确认权不变：付款人确认、GM 可取消）；持久化字段均为 setdefault 兼容，无 schema 版本提升；不修改已发布迁移语义（仅 rebind 集合增补）。

## 验证
- `python -m pytest -q`：1860 passed / 1 skipped（新增 9 个引擎回归 + 1 个投影回归；#214 全部行为不回归）
- `ruff check src tests`：通过
- mypy：无新增错误（与 main 基线逐条 diff 一致，14 条均为存量）
- 前端未触碰（后端 only）；CI 全套（含 browser smoke）以 PR CI 为准