### PR TITLE
fix: batch lorebook import (50+ entries no longer fails)

### DIFF
--- a/frontend-v2/src/features/lorebook/LorebookView.vue
+++ b/frontend-v2/src/features/lorebook/LorebookView.vue
@@ -365,11 +365,17 @@ async function importLore(e: Event) {
     const text = await file.text()
     const imported = JSON.parse(text) as unknown
     if (!Array.isArray(imported)) throw new Error(t('jsonArrayRequired'))
-    for (const en of imported) {
-      if (!en || typeof en !== 'object') continue
-      await api<unknown>('/lorebook', { method: 'POST', body: JSON.stringify({ ...en, world_id: currentWorldId.value, id: undefined }) })
-    }
-    toast.success(t('importedEntries', { count: imported.length }))
+    // 一次批量请求：逐条 POST 会触发写操作频控，导致大世界书导入中途失败。
+    const entries = imported.filter((en): en is Record<string, unknown> => !!en && typeof en === 'object')
+    const r = await api<{ imported?: number; failed?: { index: number; error: string }[] }>(
+      `/lorebook/${encodeURIComponent(currentWorldId.value)}/import`,
+      { method: 'POST', body: JSON.stringify({ entries }) },
+    )
+    const importedCount = r.imported ?? 0
+    const failedCount = r.failed?.length ?? 0
+    if (failedCount && importedCount) toast.error(t('importedWithFailures', { imported: importedCount, failed: failedCount }))
+    else if (failedCount) toast.error(t('importFailed'))
+    else toast.success(t('importedEntries', { count: importedCount }))
     await loadLore()
     await loadWorlds()
     await refreshPreview()

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -1602,6 +1602,7 @@ export const en = {
   worldDeleted: 'World deleted',
   jsonArrayRequired: 'Invalid JSON: expected an array',
   importedEntries: 'Imported {count} entries',
+  importedWithFailures: 'Imported {imported} entries; {failed} failed (empty name or oversized content)',
   standaloneLorebookHint: 'Manage lorebook entries independently.',
   chooseWorldEllipsis: 'Choose world...',
   newWorld: 'New World',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -1602,6 +1602,7 @@ export const ja = {
   worldDeleted: '世界を削除しました',
   jsonArrayRequired: 'JSON の形式エラー：配列が必要です',
   importedEntries: '{count} 件インポートしました',
+  importedWithFailures: '{imported} 件インポート、{failed} 件失敗（名前が空、または内容が長すぎます）',
   standaloneLorebookHint: '世界書エントリを独立して管理します。',
   chooseWorldEllipsis: '世界を選択...',
   newWorld: '新しい世界',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -1602,6 +1602,7 @@ export const zhCN = {
   worldDeleted: '已删除世界',
   jsonArrayRequired: 'JSON 格式错误：需要数组',
   importedEntries: '已导入 {count} 条',
+  importedWithFailures: '已导入 {imported} 条，{failed} 条失败：条目名称为空或内容超长',
   standaloneLorebookHint: '独立管理世界书条目。',
   chooseWorldEllipsis: '选择世界...',
   newWorld: '新建世界',

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -1431,6 +1431,9 @@ class WebAPI:
     def save_entry(self, entry: dict) -> dict[str, Any]:
         return worlds.save_entry(self._world_dependencies, entry)
 
+    def import_entries(self, world_id: str, entries: list) -> dict[str, Any]:
+        return worlds.import_entries(self._world_dependencies, world_id, entries)
+
     async def generate_lorebook_entries(self, world_id: str, prompt: str, language: str = "") -> dict[str, Any]:
         return await worlds.generate_lorebook_entries(
             self._world_dependencies, world_id, prompt, language,

--- a/src/webui/routes/worlds.py
+++ b/src/webui/routes/worlds.py
@@ -84,6 +84,21 @@ async def api_lorebook_create(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+async def api_lorebook_import(request: web.Request) -> web.Response:
+    """Batch-import lorebook entries; one request instead of one per entry."""
+
+    world_id = request.match_info["world_id"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"ok": False, "error": "条目列表不能为空"}, status=400)
+    entries = body.get("entries") if isinstance(body, dict) else None
+    result = _get_api(request).import_entries(
+        world_id, entries if isinstance(entries, list) else [],
+    )
+    return web.json_response(result, status=200 if result.get("ok") else 400)
+
+
 async def api_lorebook_generate(request: web.Request) -> web.Response:
     body = await request.json()
     prompt = str(body.get("prompt", "")).strip()
@@ -126,6 +141,7 @@ def register_worlds(app: web.Application) -> None:
     app.router.add_get("/api/lorebook/{world_id}", api_lorebook)
     app.router.add_get("/api/lorebook/{world_id}/preview", api_lorebook_preview)
     app.router.add_post("/api/lorebook", api_lorebook_create)
+    app.router.add_post("/api/lorebook/{world_id}/import", api_lorebook_import)
     app.router.add_post("/api/lorebook/{world_id}/generate", api_lorebook_generate)
     app.router.add_route("PUT", "/api/lorebook/{entry_id}", api_lorebook_update)
     app.router.add_route("DELETE", "/api/lorebook/{entry_id}", api_lorebook_delete)

--- a/src/webui/services/worlds.py
+++ b/src/webui/services/worlds.py
@@ -19,6 +19,7 @@ from src.content.worlds import load_world_template as load_content_world
 from src.generation import creator
 from src.lorebook.bootstrap import ensure_world_from_template
 from src.template_catalog import is_user_template_file
+from src.webui.services._common import MAX_LOREBOOK_CHARS
 
 logger = logging.getLogger("trpg")
 
@@ -392,16 +393,87 @@ def save_entry(
 ) -> dict[str, Any]:
     # 导入/新增入口的防御性校验：缺键时生成 id 或返回 400 级错误，
     # 不让 KeyError 漏成 500（UI 导入的 body 可能完全不带 id 键）。
+    prepared, error = _prepare_entry(dependencies, entry, existing_ids=None)
+    if error:
+        return {"ok": False, "error": error}
+    dependencies.lorebook.add_entry(prepared)
+    rebuild_lorebook_index(dependencies, prepared["world_id"])
+    _sync_user_template_lorebook(dependencies, prepared["world_id"])
+    return {"ok": True, "entry_id": prepared["id"]}
+
+
+MAX_LOREBOOK_IMPORT_ENTRIES = 500
+
+
+def import_entries(
+    dependencies: WorldDependencies,
+    world_id: str,
+    entries: list,
+) -> dict[str, Any]:
+    """Batch-import lorebook entries in one request.
+
+    Importing entry-by-entry makes one write request per entry, which the
+    write flood guard legitimately rejects for large lorebooks (issue #213).
+    One batched request keeps that guard meaningful; index rebuild and user
+    template sync run once for the whole batch.  Best-effort per entry: data
+    problems are reported per index instead of aborting the batch.
+    """
+
+    world_id = str(world_id or "").strip()
+    if dependencies.lorebook.get_world(world_id) is None:
+        return {"ok": False, "error": "世界不存在"}
+    if not isinstance(entries, list) or not entries:
+        return {"ok": False, "error": "条目列表不能为空"}
+    if len(entries) > MAX_LOREBOOK_IMPORT_ENTRIES:
+        return {"ok": False, "error": f"单次导入条目过多（上限 {MAX_LOREBOOK_IMPORT_ENTRIES} 条）"}
+    existing_ids = {
+        str(e.get("id")) for e in dependencies.lorebook.list_entries(world_id)
+    }
+    imported = 0
+    failures: list[dict[str, Any]] = []
+    for index, raw in enumerate(entries):
+        if not isinstance(raw, dict):
+            failures.append({"index": index, "error": "世界书条目必须是对象"})
+            continue
+        if len(str(raw.get("content", ""))) > MAX_LOREBOOK_CHARS:
+            failures.append({
+                "index": index,
+                "error": f"世界书条目过长（上限 {MAX_LOREBOOK_CHARS} 字）",
+            })
+            continue
+        # world_id 来自路径参数：批量端点替客户端统一盖章，避免逐条重复。
+        prepared, error = _prepare_entry(
+            dependencies, {**raw, "world_id": world_id}, existing_ids=existing_ids,
+        )
+        if error:
+            failures.append({"index": index, "error": error})
+            continue
+        dependencies.lorebook.add_entry(prepared)
+        imported += 1
+    if imported:
+        rebuild_lorebook_index(dependencies, world_id)
+        _sync_user_template_lorebook(dependencies, world_id)
+    return {"ok": True, "imported": imported, "failed": failures}
+
+
+def _prepare_entry(
+    dependencies: WorldDependencies,
+    entry: dict,
+    *,
+    existing_ids: set[str] | None,
+) -> tuple[dict[str, Any] | None, str]:
+    """Validate and normalize one entry; returns (entry, error)."""
+
     if not isinstance(entry, dict):
-        return {"ok": False, "error": "世界书条目必须是对象"}
+        return None, "世界书条目必须是对象"
     world_id = str(entry.get("world_id") or "").strip()
     name = str(entry.get("name") or "").strip()
     if not world_id:
-        return {"ok": False, "error": "缺少 world_id"}
+        return None, "缺少 world_id"
     if dependencies.lorebook.get_world(world_id) is None:
-        return {"ok": False, "error": "世界不存在"}
+        return None, "世界不存在"
     if not name:
-        return {"ok": False, "error": "世界书条目名称不能为空"}
+        return None, "世界书条目名称不能为空"
     entry = dict(entry)
     entry["world_id"] = world_id
     entry["name"] = name
@@ -410,14 +482,12 @@ def save_entry(
     tier = str(entry.get("tier") or "background").strip()
     entry["tier"] = tier if tier in _LOREBOOK_TIERS else "background"
     if not str(entry.get("id") or "").strip():
-        existing = {
-            str(e.get("id")) for e in dependencies.lorebook.list_entries(world_id)
-        }
-        entry["id"] = _entry_id_from_name(world_id, name, existing, 0)
-    dependencies.lorebook.add_entry(entry)
-    rebuild_lorebook_index(dependencies, world_id)
-    _sync_user_template_lorebook(dependencies, world_id)
-    return {"ok": True, "entry_id": entry["id"]}
+        if existing_ids is None:
+            existing_ids = {
+                str(e.get("id")) for e in dependencies.lorebook.list_entries(world_id)
+            }
+        entry["id"] = _entry_id_from_name(world_id, name, existing_ids, 0)
+    return entry, ""
 
 
 def _entry_id_from_name(world_id: str, name: str, existing_ids: set[str], index: int) -> str:

--- a/src/webui/services/worlds.py
+++ b/src/webui/services/worlds.py
@@ -394,8 +394,8 @@ def save_entry(
     # 导入/新增入口的防御性校验：缺键时生成 id 或返回 400 级错误，
     # 不让 KeyError 漏成 500（UI 导入的 body 可能完全不带 id 键）。
     prepared, error = _prepare_entry(dependencies, entry, existing_ids=None)
-    if error:
-        return {"ok": False, "error": error}
+    if error or prepared is None:
+        return {"ok": False, "error": error or "世界书条目无效"}
     dependencies.lorebook.add_entry(prepared)
     rebuild_lorebook_index(dependencies, prepared["world_id"])
     _sync_user_template_lorebook(dependencies, prepared["world_id"])

--- a/src/webui/services/worlds.py
+++ b/src/webui/services/worlds.py
@@ -442,13 +442,20 @@ def import_entries(
             })
             continue
         # world_id 来自路径参数：批量端点替客户端统一盖章，避免逐条重复。
+        candidate = {**raw, "world_id": world_id}
+        if str(candidate.get("id") or "").strip() and str(candidate["id"]) in existing_ids:
+            # 批量内/库内撞 id 的条目不得静默替换既有条目：改为重新生成 id，
+            # 让重复导入表现为新增而不是覆盖。
+            candidate["id"] = ""
         prepared, error = _prepare_entry(
-            dependencies, {**raw, "world_id": world_id}, existing_ids=existing_ids,
+            dependencies, candidate, existing_ids=existing_ids,
         )
-        if error:
-            failures.append({"index": index, "error": error})
+        if error or prepared is None:
+            failures.append({"index": index, "error": error or "世界书条目无效"})
             continue
         dependencies.lorebook.add_entry(prepared)
+        # 冲突集 = 库内既有 id + 本批已导入 id，防止同批后续条目复用。
+        existing_ids.add(prepared["id"])
         imported += 1
     if imported:
         rebuild_lorebook_index(dependencies, world_id)

--- a/tests/test_webui_rules_worlds.py
+++ b/tests/test_webui_rules_worlds.py
@@ -428,3 +428,60 @@ def test_save_entry_rejects_bad_target(web_api):
     assert api.save_entry({"world_id": "missing_world", "name": "x"}).get("ok") is False
     assert api.save_entry({"world_id": "import_world2", "name": "   "}).get("ok") is False
     assert api.save_entry({"world_id": "", "name": "x"}).get("ok") is False
+
+
+def test_import_entries_batches_large_lorebook_in_one_request(web_api):
+    """issue #213：50+ 条的批量导入必须一次请求完成，不再逐条撞写频控。"""
+
+    api, lorebook, _registry, _fake_llm, _worlds_dir = web_api
+    lorebook.create_world("import_batch_world", "批量导入世界")
+
+    entries = [
+        {"name": f"条目{i}", "type": "location", "keywords": [f"关键词{i}"], "content": f"内容{i}"}
+        for i in range(60)
+    ]
+    result = api.import_entries("import_batch_world", entries)
+
+    assert result.get("ok") is True
+    assert result.get("imported") == 60
+    assert result.get("failed") == []
+    assert lorebook.list_entries("import_batch_world").__len__() >= 60
+    names = {e["name"] for e in lorebook.list_entries("import_batch_world")}
+    assert {"条目0", "条目59"} <= names
+    # 批量内同名条目生成不冲突的 id。
+    assert len({e["id"] for e in lorebook.list_entries("import_batch_world")}) == len(
+        lorebook.list_entries("import_batch_world")
+    )
+
+
+def test_import_entries_reports_per_entry_failures(web_api):
+    api, lorebook, _registry, _fake_llm, _worlds_dir = web_api
+    lorebook.create_world("import_partial_world", "部分失败世界")
+
+    result = api.import_entries("import_partial_world", [
+        {"name": "好条目", "content": "c", "keywords": ["k"]},
+        {"name": "   ", "content": "c"},  # 名称为空
+        {"name": "超长条目", "content": "x" * 5001},  # 内容超长
+        {"name": "另一条", "content": "c"},
+    ])
+
+    assert result.get("ok") is True
+    assert result.get("imported") == 2
+    assert [f["index"] for f in result.get("failed", [])] == [1, 2]
+    names = {e["name"] for e in lorebook.list_entries("import_partial_world")}
+    assert {"好条目", "另一条"} <= names
+    assert "超长条目" not in names
+
+
+def test_import_entries_rejects_missing_world_and_oversize_batch(web_api):
+    api, lorebook, _registry, _fake_llm, _worlds_dir = web_api
+    lorebook.create_world("import_guard_world", "限额世界")
+
+    assert api.import_entries("missing_world", [{"name": "x"}]).get("ok") is False
+    assert api.import_entries("import_guard_world", []).get("ok") is False
+    oversize = [
+        {"name": f"条目{i}", "content": "c"} for i in range(501)
+    ]
+    result = api.import_entries("import_guard_world", oversize)
+    assert result.get("ok") is False
+    assert "上限" in str(result.get("error"))

--- a/tests/test_webui_rules_worlds.py
+++ b/tests/test_webui_rules_worlds.py
@@ -473,6 +473,35 @@ def test_import_entries_reports_per_entry_failures(web_api):
     assert "超长条目" not in names
 
 
+def test_batch_import_deduplicates_ids_within_same_batch(web_api):
+    """同一导入文件内的重复 id 不得复用：后条重新生成，先条不被覆盖。"""
+
+    api, lorebook, _registry, _fake_llm, _worlds_dir = web_api
+    lorebook.create_world("dup_import_world", "重复ID世界")
+
+    result = api.import_entries("dup_import_world", [
+        {"id": "dup_entry", "name": "Village", "content": "村庄"},
+        {"id": "dup_entry", "name": "Forest", "content": "森林"},
+        {"name": "River", "content": "河流"},
+        {"name": "River", "content": "另一条河"},
+    ])
+
+    assert result.get("ok") is True
+    assert result.get("imported") == 4
+    assert result.get("failed") == []
+    entries = lorebook.list_entries("dup_import_world")
+    ids = [e["id"] for e in entries]
+    assert len(ids) == len(set(ids))
+    by_name = {e["name"]: e for e in entries}
+    assert by_name["Village"]["id"] == "dup_entry"
+    assert by_name["Forest"]["id"] != "dup_entry"
+    # 同名条目也各自拿到不同 id。
+    rivers = [e for e in entries if e["name"] == "River"]
+    assert len(rivers) == 2
+    assert rivers[0]["id"] != rivers[1]["id"]
+    assert by_name["Village"]["content"] == "村庄"
+
+
 def test_import_entries_rejects_missing_world_and_oversize_batch(web_api):
     api, lorebook, _registry, _fake_llm, _worlds_dir = web_api
     lorebook.create_world("import_guard_world", "限额世界")


### PR DESCRIPTION
## 问题（#213）
导入条目超过 50 条时报「操作太频繁……请等待约 28 秒」并中途失败。

根因：前端 `importLore` 对每条条目单独 POST `/api/lorebook`，而 abuse guard 限制每 IP 每分钟 60 次写操作（防请求洪水，本身是对的）。50+ 条必然撞限流，且循环中途失败造成半截导入。

## 修复
- 新增 `POST /api/lorebook/{world_id}/import`：一次请求持久化整批条目
  - `world_id` 由路径参数统一盖章，客户端无需逐条携带
  - 逐条校验（名称/长度/类型归一），数据问题按 index 报告，不中断整批；索引重建与用户模板同步整批只做一次
  - 上限 500 条/次（`MAX_LOREBOOK_IMPORT_ENTRIES`），单条内容仍受 `MAX_LOREBOOK_CHARS` 约束
- 前端 `importLore` 改为单次批量请求；部分失败时提示「已导入 X 条，Y 条失败」
- **abuse guard 本身未动**：批量端点一次导入只占 1 次写请求，防洪水语义不变

## 服务层重构
`save_entry` 抽出共享的 `_prepare_entry`（校验+归一+id 生成），`import_entries` 复用；行为不变。

## 风险面
World/lorebook 管理入口；不触碰权限模型（写权限与单条 POST 一致）与限流策略。

## 验证
- 新增 3 个测试：60 条批量导入（含批量内 id 去重）、部分失败按 index 报告、缺世界/空列表/超限拒绝
- `python -m pytest -q`：1854 passed / 1 skipped
- `ruff check src tests` 通过；前端 typecheck / lint / 382 tests / build 全绿

Fixes #213