### PR TITLE
fix: allow staged image generation config

### DIFF
--- a/src/imagegen/service.py
+++ b/src/imagegen/service.py
@@ -118,11 +118,10 @@ class ImageGenerationService:
             raise ValueError(f"不支持的图像生成 provider：{self.provider_id}")
         if not self.enabled:
             return
-        parsed = urlparse(self.base_url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.username or parsed.password:
-            raise ValueError("图像生成 Base URL 必须是无内嵌凭据的 http(s) 地址")
-        if not self.model:
-            raise ValueError("启用图像生成时必须选择模型")
+        if self.base_url:
+            parsed = urlparse(self.base_url)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.username or parsed.password:
+                raise ValueError("图像生成 Base URL 必须是无内嵌凭据的 http(s) 地址")
 
 
 def _is_local_endpoint(value: str) -> bool:

--- a/tests/test_config_runtime_reload.py
+++ b/tests/test_config_runtime_reload.py
@@ -4,6 +4,7 @@ import pytest
 
 import web_server
 from src.common_factory import create_trpg_subsystems
+from src.imagegen import ImageGenerationService
 from src.llm.client import ProviderConfig
 
 
@@ -205,6 +206,52 @@ async def test_tts_config_reload_rebuilds_only_api_facade(monkeypatch):
     }, app))
 
     assert response.status == 200
+    assert app["subsystems"] is runtime
+    assert app["api"] is new_api
+    assert runtime.llm_client.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_imagegen_can_be_enabled_before_provider_and_model_are_selected(
+    monkeypatch,
+    tmp_path,
+):
+    runtime = _runtime()
+    old_api = object()
+    new_api = object()
+    app = {"subsystems": runtime, "api": old_api, "plugin_host": None}
+    saved_states = []
+    monkeypatch.setattr(
+        web_server,
+        "save_config",
+        lambda: saved_states.append(dict(web_server.STATE)),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_build_subsystems",
+        lambda **kwargs: pytest.fail("图像生成配置不应重建游戏子系统"),
+    )
+    monkeypatch.setitem(web_server.STATE, "imagegen_enabled", False)
+    monkeypatch.setitem(web_server.STATE, "imagegen_provider_ref", "")
+    monkeypatch.setitem(web_server.STATE, "imagegen_base_url", "")
+    monkeypatch.setitem(web_server.STATE, "imagegen_model", "")
+
+    def make_api(subsystems, plugin_host=None, config=None):
+        assert subsystems is runtime
+        service = ImageGenerationService(config, tmp_path / "generated-images")
+        assert service.enabled is True
+        assert service.available is False
+        return new_api
+
+    monkeypatch.setattr(web_server, "_make_api", make_api)
+
+    response = await web_server.api_config_post(
+        _ConfigRequest({"imagegen_enabled": True}, app)
+    )
+
+    assert response.status == 200
+    assert web_server.STATE["imagegen_enabled"] is True
+    assert saved_states[-1]["imagegen_enabled"] is True
     assert app["subsystems"] is runtime
     assert app["api"] is new_api
     assert runtime.llm_client.closed == 0

--- a/tests/test_imagegen_service.py
+++ b/tests/test_imagegen_service.py
@@ -82,10 +82,32 @@ def test_service_availability_and_config_validation(tmp_path):
     }
     with pytest.raises(ImageGenerationError, match="尚未配置或启用"):
         asyncio.run(disabled.generate(ImageGenerationRequest(prompt="harbor")))
+
+    staged = ImageGenerationService(
+        _config(imagegen_base_url="", imagegen_model=""),
+        tmp_path,
+    )
+    assert staged.enabled is True
+    assert staged.available is False
+    with pytest.raises(ImageGenerationError, match="尚未配置或启用"):
+        asyncio.run(staged.generate(ImageGenerationRequest(prompt="harbor")))
+
+    staged_with_base_url = ImageGenerationService(
+        _config(imagegen_model=""),
+        tmp_path,
+    )
+    assert staged_with_base_url.enabled is True
+    assert staged_with_base_url.available is False
+
     with pytest.raises(ValueError, match="Base URL"):
         ImageGenerationService(_config(imagegen_base_url="file:///tmp/images"), tmp_path)
-    with pytest.raises(ValueError, match="必须选择模型"):
-        ImageGenerationService(_config(imagegen_model=""), tmp_path)
+    with pytest.raises(ValueError, match="Base URL"):
+        ImageGenerationService(
+            _config(imagegen_base_url="https://user:pass@images.example/v1"),
+            tmp_path,
+        )
+    with pytest.raises(ValueError, match="provider"):
+        ImageGenerationService(_config(imagegen_provider="unsupported"), tmp_path)
 
 
 def test_service_bypasses_proxy_for_local_endpoints(tmp_path):


### PR DESCRIPTION
## Summary

允许图像生成配置分步保存。启用图像生成后，即使服务商地址或模型尚未选择，运行时也可以正常重建；在配置完整前服务保持不可用。

非空的非法 Base URL、不支持的 Provider，以及实际生成时的可用性检查仍会被拒绝。

## Why

Web 界面会先保存“启用”开关，之后才允许用户选择服务商和模型。原有后端要求启用时配置必须立即完整，导致第一次保存就抛出异常并返回 HTTP 500，用户无法继续配置。

## Impact

只勾选实际受影响的项目：

- [x] API
- [ ] Persisted Data / Save / Database
- [ ] Migration
- [ ] Compatibility / Breaking Change
- [ ] Security / Permission / Privacy
- [ ] Multiplayer / Actor / Turn Authority
- [ ] Ruleset Mechanics
- [ ] Architecture / Dependency Boundary
- [ ] Plugin / Content / Extension Contract
- [ ] UI only

## Module / Boundary

图像生成服务的配置校验，以及 `/api/config` 运行时热重载行为。

这是原有 `ImageGenerationService` 职责内的小型缺陷修复，没有新增职责或改变架构边界。

## Design / Migration Notes

N/A

## Validation

- [x] Relevant backend tests
- [ ] Relevant frontend tests
- [ ] Build / typecheck where applicable
- [ ] Architecture / security checks where applicable
- [x] Manual verification where meaningful

验证结果：

- `pytest -q tests/test_imagegen_service.py tests/test_config_runtime_reload.py`：22 passed
- `ruff check src/ tests/`：passed
- 已验证启用但配置不完整时，`/api/config` 返回 200，服务状态为 `available=false`
- 已验证 Base URL 和模型配置完整后，图像生成服务恢复可用
- 全量测试两次均为 1862 passed、1 skipped、1 个既有多人测试偶发失败；失败用例不同，单独重跑均通过

## Contract Check

- [x] 用户数据不会被无意覆盖或丢失
- [x] 权限 / private data 边界未退化
- [ ] 若改 persisted identity，已处理旧引用
- [x] 若改关键产品契约，已更新对应测试（Critical testing areas 见 `docs/ENGINEERING_RULES.md` §15）
- [ ] 若架构事实发生变化，已更新 `docs/ARCHITECTURE_*.md`