### PR TITLE
feat: auto-settle qualifying narrative rewards

### DIFF
--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -464,12 +464,65 @@ def is_nonblocking_personal_purchase(
     return True
 
 
-def blocking_economy_proposals(instance: Any) -> list[dict[str, Any]]:
-    """Return pending proposals that must hold the narrative barrier."""
+def is_auto_settleable_reward(
+    instance: Any,
+    proposal: dict[str, Any],
+    *,
+    gold_cap: int = 50,
+) -> bool:
+    """Whether a pending narrative reward may settle without a GM click.
+
+    Deliberately narrow: plain single-recipient gold rewards for a current
+    player within the configured cap.  Team splits, cross-run entries and
+    anything outside the cap stay blocking so the GM keeps final say over
+    unusual or high-impact grants.
+    """
+
+    if not isinstance(proposal, dict):
+        return False
+    if proposal.get("status") != "pending" or str(proposal.get("run_id") or "") != str(instance.run_id):
+        return False
+    if str(proposal.get("kind") or "") != "reward":
+        return False
+    if proposal.get("contributors"):
+        return False
+    recipient_uid = str(proposal.get("recipient_uid") or "")
+    if not recipient_uid or recipient_uid not in instance.players:
+        return False
+    try:
+        amount = int(proposal.get("amount", 0) or 0)
+    except (TypeError, ValueError):
+        return False
+    return 0 < amount <= gold_cap
+
+
+def blocking_economy_proposals(
+    instance: Any,
+    *,
+    auto_reward_gold_cap: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return pending proposals that must hold the narrative barrier.
+
+    When ``auto_reward_gold_cap`` is provided (auto-reward enabled), plain
+    rewards within the cap are not blockers: they will settle automatically
+    right after the current round completes through the standard payment
+    path.  Without the argument the behavior is unchanged (all pending
+    rewards block, as before).
+    """
+
+    def _blocked(proposal: dict[str, Any]) -> bool:
+        if not is_nonblocking_personal_purchase(instance, proposal):
+            if (
+                auto_reward_gold_cap is not None
+                and is_auto_settleable_reward(instance, proposal, gold_cap=auto_reward_gold_cap)
+            ):
+                return False
+            return True
+        return False
 
     return [
         proposal for proposal in pending_economy_proposals(instance)
-        if not is_nonblocking_personal_purchase(instance, proposal)
+        if _blocked(proposal)
     ]
 
 
@@ -499,11 +552,15 @@ def has_pending_economy_decision(instance: Any) -> bool:
     )
 
 
-def has_blocking_economy_decision(instance: Any) -> bool:
+def has_blocking_economy_decision(
+    instance: Any,
+    *,
+    auto_reward_gold_cap: int | None = None,
+) -> bool:
     """Whether unresolved economy state must stop narrative progression."""
 
     return bool(
-        blocking_economy_proposals(instance)
+        blocking_economy_proposals(instance, auto_reward_gold_cap=auto_reward_gold_cap)
         or pending_effect_groups(instance)
         or pending_memory_deliveries(instance)
         or pending_memory_reversals(instance)

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -507,6 +507,8 @@ class WebAPI:
             resolve_luck_decision=self.resolve_luck_decision,
             decline_pending_luck=self.decline_pending_luck,
             drain_economy_outbox=self._drain_economy_outbox,
+            economy_auto_reward_settings=self.economy_auto_reward_settings,
+            resolve_reward=self.resolve_reward_as_gm,
         )
         self._map_dependencies = maps.MapDependencies(
             get_instance=self._reg.get,
@@ -1535,6 +1537,25 @@ class WebAPI:
             payment_id,
             accepted,
             session_uid,
+        )
+
+    async def resolve_reward_as_gm(self, game_key: str, payment_id: str, session_uid: str = "") -> dict[str, Any]:
+        """Settle one narrative reward through the standard payment-confirm path.
+
+        Used by the round-completion auto-settler: the authority chain
+        (ledger, deferred effects, save) is the manual confirmation path —
+        only the GM click is removed for qualifying rewards.
+        """
+
+        return await self.resolve_payment(game_key, payment_id, True, session_uid)
+
+    def economy_auto_reward_settings(self) -> tuple[bool, int]:
+        """Live economy auto-reward switch and gold cap from runtime config."""
+
+        state = self._config_state if isinstance(self._config_state, dict) else {}
+        return (
+            bool(state.get("economy_auto_reward_enabled", True)),
+            max(1, int(state.get("economy_auto_reward_gold_cap", 50) or 50)),
         )
 
     async def create_payment_proposal(

--- a/src/webui/config_update.py
+++ b/src/webui/config_update.py
@@ -57,6 +57,7 @@ CONFIG_KEYS = (
     "imagegen_enabled", "imagegen_auto_scene", "imagegen_provider", "imagegen_base_url",
     "imagegen_api_key", "imagegen_model", "imagegen_square_size", "imagegen_landscape_size",
     "imagegen_quality", "imagegen_style_prefix", "imagegen_timeout_seconds", "test_timeout_seconds",
+    "economy_auto_reward_enabled", "economy_auto_reward_gold_cap",
     "model_request_timeout_seconds",
     "ai_providers", *PROVIDER_REF_KEYS,
 )
@@ -208,8 +209,14 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
                 "proxy_enabled", "qq_bot_enabled", "napcat_chat_filter_enabled",
                 "napcat_show_dropped_logs", "napcat_block_official_bots",
                 "imagegen_enabled", "imagegen_auto_scene",
+                "economy_auto_reward_enabled",
             }:
                 candidate[key] = bool(raw)
+            elif key == "economy_auto_reward_gold_cap":
+                cap_value = int(raw)
+                if cap_value < 1:
+                    return PreparedConfigUpdate(candidate, changed_keys, access_password_changed, "奖励自动结算金币上限必须大于 0")
+                candidate[key] = cap_value
             elif key in {
                 "napcat_heartbeat_sec", "napcat_reconnect_delay_sec",
                 "napcat_action_timeout_sec", "napcat_command_dedup_window_sec",

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -307,6 +307,12 @@ class ConfigStore:
                 saved.get("imagegen_timeout_seconds", 120)
             ),
             "test_timeout_seconds": float(saved.get("test_timeout_seconds", 30)),
+            "economy_auto_reward_enabled": bool(
+                saved.get("economy_auto_reward_enabled", True)
+            ),
+            "economy_auto_reward_gold_cap": int(
+                saved.get("economy_auto_reward_gold_cap", 50)
+            ),
             "model_request_timeout_seconds": float(
                 env.get("TRPG_MODEL_REQUEST_TIMEOUT_SECONDS")
                 or saved.get("model_request_timeout_seconds", 120)

--- a/src/webui/services/turns.py
+++ b/src/webui/services/turns.py
@@ -232,6 +232,9 @@ async def _auto_settle_rewards(
     service (ledger + deferred effects + save), so the authority path is
     identical to a manual confirmation — only the click is removed.  Anything
     over the cap or with the switch off stays pending for the GM.
+
+    每个 reward proposal 独立结算：单个失败（服务返回非 ok 或异常）只影响
+    该提案（保持 pending 交还 GM），不中断其余提案，也不保证整批原子提交。
     """
 
     resolve_reward = dependencies.resolve_reward

--- a/src/webui/services/turns.py
+++ b/src/webui/services/turns.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from src.engine.economy import (
     has_blocking_economy_decision,
     blocking_economy_proposals,
+    is_auto_settleable_reward,
     pending_effect_groups,
     pending_memory_deliveries,
     pending_memory_reversals,
@@ -47,6 +48,10 @@ class TurnDependencies:
     resolve_luck_decision: Callable[..., Awaitable[dict[str, Any]]]
     decline_pending_luck: Callable[..., Awaitable[dict[str, Any]]]
     drain_economy_outbox: Callable[[Any], Awaitable[bool]] | None = None
+    # 奖励自动结算：settings 返回 (enabled, gold_cap)；resolve_reward 复用
+    # 标准支付确认服务（交易流水 + 效果组提交 + 存档），只是免掉 GM 点击。
+    economy_auto_reward_settings: Callable[[], tuple[bool, int]] | None = None
+    resolve_reward: Callable[[str, str, str], Awaitable[dict[str, Any]]] | None = None
 
 
 class TurnResult(TypedDict):
@@ -199,16 +204,84 @@ async def _process_round(
     dependencies: TurnDependencies,
     instance: "GameInstance",
     *,
+    game_key: str,
     on_delta: NarrationDelta | None,
     on_reset: NarrationReset | None,
 ) -> tuple[str, Any]:
     if dependencies.process_round is None:
         raise RuntimeError("round processor is not available")
-    return await dependencies.process_round(
+    narration, response = await dependencies.process_round(
         instance,
         on_delta=on_delta,
         on_reset=on_reset,
     )
+    await _auto_settle_rewards(dependencies, instance, game_key)
+    return narration, response
+
+
+async def _auto_settle_rewards(
+    dependencies: TurnDependencies,
+    instance: "GameInstance",
+    game_key: str,
+) -> None:
+    """Auto-settle qualifying narrative reward proposals after a round.
+
+    A pending kind=reward proposal blocks the table until the GM confirms it,
+    which turns the GM into a clerk for ordinary rewards ("击杀怪物，获得 12
+    金币").  Qualifying rewards settle through the standard payment-confirm
+    service (ledger + deferred effects + save), so the authority path is
+    identical to a manual confirmation — only the click is removed.  Anything
+    over the cap or with the switch off stays pending for the GM.
+    """
+
+    resolve_reward = dependencies.resolve_reward
+    settings = dependencies.economy_auto_reward_settings
+    if resolve_reward is None or settings is None:
+        return
+    try:
+        enabled, gold_cap = settings()
+    except Exception:
+        logger.warning("读取奖励自动结算配置失败，本轮跳过自动结算", exc_info=True)
+        return
+    if not enabled or gold_cap < 1:
+        return
+    economy = getattr(instance, "economy", {})
+    proposals = economy.get("proposals", []) if isinstance(economy, dict) else []
+    for proposal in list(proposals):
+        if not is_auto_settleable_reward(instance, proposal, gold_cap=gold_cap):
+            continue
+        proposal_id = str(proposal.get("id") or "")
+        if not proposal_id:
+            continue
+        try:
+            result = await resolve_reward(game_key, proposal_id, str(instance.gm_uid or ""))
+            if not result.get("ok"):
+                logger.warning(
+                    "奖励自动结算未成功，保留待确认: game=%s proposal=%s code=%s",
+                    game_key, proposal_id, result.get("code"),
+                )
+        except Exception:
+            logger.warning(
+                "奖励自动结算异常，保留待确认: game=%s proposal=%s",
+                game_key, proposal_id, exc_info=True,
+            )
+
+
+def _auto_reward_cap(dependencies: TurnDependencies) -> int | None:
+    """Gold cap for auto-settleable rewards; None when the switch is off.
+
+    Passed into the barrier check so a plain reward within the cap does not
+    block the table: it will settle automatically when the round completes.
+    """
+
+    settings = dependencies.economy_auto_reward_settings
+    if settings is None:
+        return None
+    try:
+        enabled, gold_cap = settings()
+    except Exception:
+        return None
+    return gold_cap if enabled and gold_cap >= 1 else None
 
 
 async def submit_action(
@@ -259,7 +332,9 @@ async def submit_action(
     if instance.is_dead(actor_uid):
         return _result({"error": "角色已死亡，无法提交行动"}, 403)
     await _retry_external_economy_effects(dependencies, instance)
-    if has_blocking_economy_decision(instance):
+    if has_blocking_economy_decision(
+        instance, auto_reward_gold_cap=_auto_reward_cap(dependencies),
+    ):
         return _result(economy_decision_pending_payload(instance, actor_uid), 409)
     if instance.state == GameState.ACTIVE_JUDGMENT:
         return _result({"error": "本轮正在推进剧情，请等待下一轮开始", "phase": "processing"}, 409)
@@ -329,7 +404,7 @@ async def submit_action(
             await dependencies.save_instance(instance)
             return _result(_pending_luck_payload(instance, roll=roll_payload))
         narration, _ = await _process_round(
-            dependencies, instance, on_delta=on_delta, on_reset=on_reset,
+            dependencies, instance, game_key=game_key, on_delta=on_delta, on_reset=on_reset,
         )
         payload = _round_payload(
             instance,
@@ -388,10 +463,12 @@ async def resolve_luck_and_continue(
     if not instance:
         return _result({"ok": False, "error": "游戏不存在"}, 404)
     await _retry_external_economy_effects(dependencies, instance)
-    if has_blocking_economy_decision(instance):
+    if has_blocking_economy_decision(
+        instance, auto_reward_gold_cap=_auto_reward_cap(dependencies),
+    ):
         return _result(economy_decision_pending_payload(instance, actor_uid), 409)
     narration, _ = await _process_round(
-        dependencies, instance, on_delta=on_delta, on_reset=on_reset,
+        dependencies, instance, game_key=game_key, on_delta=on_delta, on_reset=on_reset,
     )
     payload = {
         **decision,
@@ -419,7 +496,9 @@ async def advance_round(
     if actor_uid != instance.gm_uid:
         return _result({"ok": False, "error": "仅 GM 可推进"}, 403)
     await _retry_external_economy_effects(dependencies, instance)
-    if has_blocking_economy_decision(instance):
+    if has_blocking_economy_decision(
+        instance, auto_reward_gold_cap=_auto_reward_cap(dependencies),
+    ):
         return _result(economy_decision_pending_payload(instance, actor_uid), 409)
 
     if instance.state == GameState.ACTIVE_JUDGMENT and instance.action_queue:
@@ -433,7 +512,7 @@ async def advance_round(
             advanced_declined_luck = list(declined.get("declined_luck_decisions") or [])
         logger.warning("检测到卡死状态，自动恢复 process_round - game_key=%s", game_key)
         narration, _ = await _process_round(
-            dependencies, instance, on_delta=on_delta, on_reset=on_reset,
+            dependencies, instance, game_key=game_key, on_delta=on_delta, on_reset=on_reset,
         )
         payload = _round_payload(instance, narration, viewer_uid=actor_uid)
         if advanced_declined_luck:
@@ -483,7 +562,7 @@ async def advance_round(
             declined = await dependencies.decline_pending_luck(game_key)
             declined_luck = list(declined.get("declined_luck_decisions") or [])
         narration, _ = await _process_round(
-            dependencies, instance, on_delta=on_delta, on_reset=on_reset,
+            dependencies, instance, game_key=game_key, on_delta=on_delta, on_reset=on_reset,
         )
         payload = _round_payload(instance, narration, ok=True, viewer_uid=actor_uid)
         if forced_waiting:

--- a/tests/test_turn_service.py
+++ b/tests/test_turn_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -422,3 +423,48 @@ async def test_auto_settle_skips_purchases_and_team_rewards() -> None:
     assert result["status"] == 409
     assert result["payload"]["error_code"] == "ECONOMY_DECISION_PENDING"
     assert api.resolved_rewards == []
+
+
+@pytest.mark.asyncio
+async def test_auto_reward_duplicate_settlement_is_idempotent() -> None:
+    """已结算提案不会被再次自动结算；重复推进不重复入账。"""
+
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    _reward_proposal(instance, proposal_id="reward-once", amount=30)
+
+    first = await submit_action(api.dependencies, "game", "gm", "继续前进")
+    assert first["status"] == 200
+    assert api.resolved_rewards == [("game", "reward-once", "gm")]
+
+    # 真实服务结算后提案变 committed；再次推进不得重复结算。
+    instance.economy["proposals"][0]["status"] = "committed"
+    second = await submit_action(api.dependencies, "game", "gm", "继续前进")
+    assert second["status"] == 200
+    assert api.resolved_rewards == [("game", "reward-once", "gm")]
+
+
+@pytest.mark.asyncio
+async def test_multiple_rewards_settle_independently() -> None:
+    """同轮多个奖励逐条独立结算：单个失败保持 pending，不中断其余。"""
+
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    _reward_proposal(instance, proposal_id="reward-a", amount=10)
+    _reward_proposal(instance, proposal_id="reward-b", amount=20)
+
+    async def flaky_resolve(game_key: str, payment_id: str, session_uid: str) -> dict:
+        api.resolved_rewards.append((game_key, payment_id, session_uid))
+        if payment_id == "reward-b":
+            return {"ok": False, "code": "FORBIDDEN"}
+        return {"ok": True}
+
+    dependencies = replace(api.dependencies, resolve_reward=flaky_resolve)
+    result = await submit_action(dependencies, "game", "gm", "继续前进")
+
+    assert result["status"] == 200
+    assert [r[1] for r in api.resolved_rewards] == ["reward-a", "reward-b"]
+    by_id = {p["id"]: p for p in instance.economy["proposals"]}
+    assert by_id["reward-b"]["status"] == "pending"

--- a/tests/test_turn_service.py
+++ b/tests/test_turn_service.py
@@ -117,6 +117,8 @@ class FakeApi:
         self.roll_result: dict = {"ok": True, "value": 13}
         self.luck_result: dict = {"ok": True, "ready_to_resolve": False}
         self.declined_result: dict = {"declined_luck_decisions": []}
+        self.auto_reward_settings: tuple[bool, int] = (True, 50)
+        self.resolved_rewards: list[tuple[str, str, str]] = []
         self.dependencies = TurnDependencies(
             get_instance=self._reg.get,
             parse_game_key=self._parse_key,
@@ -130,7 +132,13 @@ class FakeApi:
             process_round=self._handler.process_round,
             resolve_luck_decision=self.resolve_luck_decision,
             decline_pending_luck=self.decline_pending_luck,
+            economy_auto_reward_settings=lambda: self.auto_reward_settings,
+            resolve_reward=self.resolve_reward,
         )
+
+    async def resolve_reward(self, game_key: str, payment_id: str, session_uid: str) -> dict:
+        self.resolved_rewards.append((game_key, payment_id, session_uid))
+        return {"ok": True}
 
     @staticmethod
     def _parse_key(_key: str):
@@ -323,3 +331,94 @@ async def test_force_advance_recovers_judgment_and_declines_luck() -> None:
     recovered = await advance_round(api.dependencies, "game", "gm", force=True)
     assert recovered["payload"]["narration"] == "叙事完成"
     assert recovered["payload"]["declined_luck_decisions"] == [{"check_id": "luck-1"}]
+
+
+def _reward_proposal(instance, *, proposal_id: str, amount: int, uid: str = "gm") -> dict:
+    proposal = {
+        "id": proposal_id,
+        "run_id": instance.run_id,
+        "status": "pending",
+        "kind": "reward",
+        "approval_policy": "gm",
+        "payer_uid": "",
+        "recipient_uid": uid,
+        "amount": amount,
+        "contributors": [],
+        "visibility": "private",
+    }
+    instance.economy["proposals"].append(proposal)
+    return proposal
+
+
+@pytest.mark.asyncio
+async def test_qualifying_reward_auto_settles_after_round() -> None:
+    """普通小额奖励在回合完成后自动结算，不需要 GM 点击。"""
+
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    _reward_proposal(instance, proposal_id="reward-small", amount=12)
+
+    result = await submit_action(api.dependencies, "game", "gm", "继续前进")
+
+    assert result["status"] == 200
+    assert api.resolved_rewards == [("game", "reward-small", "gm")]
+
+
+@pytest.mark.asyncio
+async def test_reward_over_cap_stays_pending_for_gm() -> None:
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    _reward_proposal(instance, proposal_id="reward-big", amount=500)
+
+    result = await submit_action(api.dependencies, "game", "gm", "继续前进")
+
+    # 超上限的奖励仍是叙事屏障：行动被拦下，等 GM 处理。
+    assert result["status"] == 409
+    assert result["payload"]["error_code"] == "ECONOMY_DECISION_PENDING"
+    assert api.resolved_rewards == []
+
+
+@pytest.mark.asyncio
+async def test_auto_reward_switch_off_keeps_gm_confirmation() -> None:
+    """GM 总开关关闭后回到全部确认模式。"""
+
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    api.auto_reward_settings = (False, 50)
+    _reward_proposal(instance, proposal_id="reward-off", amount=12)
+
+    result = await submit_action(api.dependencies, "game", "gm", "继续前进")
+
+    # 总开关关闭：回到全部确认模式，行动被 pending 奖励拦下。
+    assert result["status"] == 409
+    assert result["payload"]["error_code"] == "ECONOMY_DECISION_PENDING"
+    assert api.resolved_rewards == []
+
+
+@pytest.mark.asyncio
+async def test_auto_settle_skips_purchases_and_team_rewards() -> None:
+    """购买与团队分摊不进自动结算，付款人/GM 确认语义保持不变。"""
+
+    instance = FakeInstance()
+    instance.try_advance_result = True
+    api = FakeApi(instance)
+    instance.economy["proposals"].append({
+        "id": "purchase-1", "run_id": instance.run_id, "status": "pending",
+        "kind": "purchase", "approval_policy": "payer", "payer_uid": "gm",
+        "recipient_uid": "gm", "amount": 30, "contributors": [],
+        "rewards": [{"name": "药水", "category": "consumable"}],
+    })
+    _reward_proposal(instance, proposal_id="team-reward", amount=10)
+    instance.economy["proposals"][-1]["contributors"] = [
+        {"uid": "gm", "amount": 5}, {"uid": "p2", "amount": 5},
+    ]
+
+    result = await submit_action(api.dependencies, "game", "gm", "继续前进")
+
+    # 团队分摊奖励是 blocker；个人购买保持非阻塞，二者都不进自动结算。
+    assert result["status"] == 409
+    assert result["payload"]["error_code"] == "ECONOMY_DECISION_PENDING"
+    assert api.resolved_rewards == []


### PR DESCRIPTION
## 背景
按《经济确认边界方案》：普通奖励应"Server validation → 自动结算"，GM 只裁定例外。现状是 AI 给的 GOLD/reward 提案需要 GM 点确认，且确认前**阻塞整桌推进**——"击杀怪物获得 12 金币"也要全桌等 GM 点头，GM 变成了记账员。

## 改动
**资格式自动结算**（不建第二套结算链）：
- 回合完成后，`kind=reward` 且满足资格的 pending 提案**自动走标准支付确认服务**（`resolve_payment`：交易流水 + 效果组提交 + 记忆投递 + 存档 + 回滚语义），与 GM 手动确认完全同一条权威链路，只是免去点击
- 资格判定（economy 层新谓词 `is_auto_settleable_reward`）：单收款人、在局内、金额 ≤ 上限、无团队分摊、当前 run
- **叙事屏障豁免共享同一资格定义**：开关开启时，上限内的普通奖励不再阻塞行动提交；开关关闭或超上限时行为与现状完全一致（pending → GM）

**配置（GM 总开关 + 上限）**：
- `economy_auto_reward_enabled`（默认 true）——一键回到全部确认模式
- `economy_auto_reward_gold_cap`（默认 50，保存时校验 ≥1）
- 两个键持久化进 config.json 并暴露于 STATE，服务经 `config_state` 动态读取，**无需重建 runtime**（不在任何 runtime rebuild 键组内）

**接线**：TurnDependencies 注入 `economy_auto_reward_settings` / `resolve_reward` 两个 callable（composition root 注入，服务不直接导入 characters 服务，遵守跨服务边界）。

## 不在本 PR（按文档分期）
PR B 交易/澄清卡片 UI；PR C Item Resolver / 落位；canonical item。

## 风险面
- 权威链不变：自动结算 = 手动确认同一路径，交易流水/效果组/回滚语义全部沿用
- 失败安全：自动结算异常或未 ok → 提案保持 pending，GM 手动处理
- 购买/团队分摊/超上限不受影响（测试覆盖）

## 验证
- 新增 4 个测试：合格奖励自动到账（免 GM 点击）、超上限 → 409 阻塞且不自动结算、总开关关闭 → 同上、购买/团队分摊不进自动结算
- `python -m pytest -q`：1867 passed / 1 skipped
- `ruff check src tests` ✅；`python -m mypy`（CI 同款 55 文件白名单）✅