### PR TITLE
feat: purchase intent layer — per-actor purchase recovery

### DIFF
--- a/src/commands/economy_effects.py
+++ b/src/commands/economy_effects.py
@@ -16,6 +16,32 @@ from typing import Any, Iterable
 from uuid import uuid4
 
 from src.engine.language import localized_text
+from src.engine.intent.economy_intent import (
+    AMOUNT_SOURCE_MERCHANT_OFFER,
+    AMOUNT_SOURCE_NARRATION,
+    AMOUNT_SOURCE_PLAYER_ACTION,
+    bounded_economy_collection as _bounded_economy_collection,
+    has_economy_proposal,
+    record_purchase_clarification,
+    repair_missing_economy_proposals,
+    trim_open_history as _trim_open_history,
+)
+from src.engine.intent.matcher import (
+    match_open_merchant_offers,
+    normalized_item_name as _normalized_item_name,
+)
+from src.engine.intent.parser import (
+    FREE_PURCHASE_RE as _FREE_PURCHASE_RE,
+    PURCHASE_CONFIRM_RE as _PURCHASE_CONFIRM_RE,
+    PURCHASE_INTENT_RE as _PURCHASE_INTENT_RE,
+    PURCHASE_OFFER_RE as _PURCHASE_OFFER_RE,
+    charge_pattern as _charge_pattern,
+    completed_payment_pattern as _completed_payment_pattern,
+    currency_amount_pattern as _currency_amount_pattern,
+    currency_amounts as _currency_amounts,
+    currency_labels as _currency_labels,
+    currency_labels_for_rule,
+)
 
 _MAX_PURCHASE_QUOTE_HISTORY = 24
 _MAX_MERCHANT_OFFER_HISTORY = 24
@@ -23,10 +49,6 @@ _MAX_CLARIFICATION_HISTORY = 24
 
 # Price evidence ladder for repair: the seller's persisted quote outranks the
 # current narration, which outranks the acting player's own stated amount.
-AMOUNT_SOURCE_NARRATION = "narration"
-AMOUNT_SOURCE_PLAYER_ACTION = "player_action"
-AMOUNT_SOURCE_MERCHANT_OFFER = "merchant_offer"
-
 _ECONOMY_STATE_KEYS = {"pending_payments", "economy_proposals", "merchant_offers"}
 _DEFERRED_DATA_KEYS = {
     "confirmed",
@@ -48,130 +70,6 @@ _COMPLETION_EVIDENCE_RE = re.compile(
     r"(?:完成|成功|击败|打倒|交付|归还|回收|达成|兑现|领取|earned|completed|complete|defeated|delivered|recovered|claimed|critical success|大成功)",
     re.IGNORECASE,
 )
-_PURCHASE_INTENT_RE = re.compile(
-    r"(?:买下|买了|购买|购入|买入|付费|支付|缴纳|花费|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
-    re.IGNORECASE,
-)
-_FREE_PURCHASE_RE = re.compile(r"(?:免费|无需付费|不用钱|免费领取|free|no charge)", re.IGNORECASE)
-_PURCHASE_CONFIRM_RE = re.compile(
-    r"(?:成交|买了|买下|购买|确认购买|接受报价|就要这个|行|可以|同意|付钱|结账|"
-    r"deal|accept|accepted|confirm|confirmed|buy it|take it|pay|yes|"
-    r"成約|購入|承知|支払う|了解です|はい|了承)", re.IGNORECASE,
-)
-_PURCHASE_OFFER_RE = re.compile(
-    r"(?:需要|需|售价|价格|费用|收费|cost|price|charge)", re.IGNORECASE,
-)
-def _currency_labels(currency_labels: Iterable[str] | None = None) -> tuple[str, ...]:
-    """Return canonical rule labels plus legacy aliases for text recognition.
-
-    Narrative parsing is only a repair/fail-closed guard; the persisted
-    currency schema remains authoritative.  Rule-provided labels let the same
-    guard work for custom economies (USD, credits, gems, etc.) without adding
-    ruleset branches to the generic engine.
-    """
-
-    labels = {
-        "金币", "金子", "金", "gold", "credits", "credit", "dollars", "dollar",
-    }
-    for label in currency_labels or ():
-        value = str(label or "").strip()
-        if value:
-            labels.add(value)
-    return tuple(sorted(labels, key=len, reverse=True))
-
-
-def currency_labels_for_rule(rule: Any) -> tuple[str, ...]:
-    """Project declared rule currency IDs/names into the generic text guard."""
-
-    system = getattr(rule, "currency_system", None)
-    if not isinstance(system, dict) and isinstance(rule, dict):
-        system = rule.get("currency_system")
-    units = system.get("units", []) if isinstance(system, dict) else []
-    labels: list[str] = []
-    if isinstance(units, list):
-        for unit in units:
-            if isinstance(unit, dict):
-                labels.extend(
-                    str(unit.get(key) or "").strip()
-                    for key in ("id", "name", "label")
-                    if str(unit.get(key) or "").strip()
-                )
-    return _currency_labels(labels)
-
-
-def _currency_amount_pattern(currency_labels: Iterable[str] | None = None) -> re.Pattern[str]:
-    labels = "|".join(re.escape(label) for label in _currency_labels(currency_labels))
-    return re.compile(
-        rf"(?P<amount>[0-9]+|[零〇一二三四五六七八九十百千万两]+)"
-        rf"\s*(?:枚|个)?\s*(?:{labels})",
-        re.IGNORECASE,
-    )
-
-
-def _charge_pattern(currency_labels: Iterable[str] | None = None) -> re.Pattern[str]:
-    labels = "|".join(re.escape(label) for label in _currency_labels(currency_labels))
-    return re.compile(
-        rf"(?:需要|需|必须|须|售价|价格|费用|收费|支付|付费|购买|买下|花费|缴纳|"
-        rf"cost|price|charge|pay|purchase|spend)[^。！？\n]{{0,24}}?"
-        rf"(?:[一二三四五六七八九十百千万两\d]+)\s*(?:枚|个)?\s*(?:{labels})"
-        rf"|(?:[一二三四五六七八九十百千万两\d]+)\s*(?:{labels})"
-        rf"[^。！？\n]{{0,16}}?"
-        rf"(?:需要|需|支付|付费|购买|买下|花费|缴纳|cost|price|charge|pay|purchase|spend)",
-        re.IGNORECASE,
-    )
-
-
-def _completed_payment_pattern(currency_labels: Iterable[str] | None = None) -> re.Pattern[str]:
-    labels = "|".join(re.escape(label) for label in _currency_labels(currency_labels))
-    return re.compile(
-        rf"(?:掏出|拿出|数出|数了|递出|放下|交出|付出|支付了?|缴纳了?|付清|花费了?)\s*"
-        rf"(?:[一二三四五六七八九十百千万两\d]+)\s*(?:枚|个)?\s*(?:{labels})"
-        rf"|(?:paid|spent|handed over|paid out)\s+"
-        rf"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:{labels})",
-        re.IGNORECASE,
-    )
-
-
-def _chinese_amount(value: str) -> int | None:
-    """Parse the small Chinese numerals commonly used in narrative prices."""
-
-    if value.isdigit():
-        return int(value)
-    digits = {"零": 0, "〇": 0, "一": 1, "二": 2, "两": 2, "三": 3, "四": 4,
-              "五": 5, "六": 6, "七": 7, "八": 8, "九": 9}
-    units = {"十": 10, "百": 100, "千": 1000, "万": 10000}
-    total = 0
-    section = 0
-    number = 0
-    for char in value:
-        if char in digits:
-            number = digits[char]
-        elif char in units:
-            unit = units[char]
-            if unit == 10000:
-                section = (section + number) * unit
-                total += section
-                section = 0
-            else:
-                section += (number or 1) * unit
-            number = 0
-        else:
-            return None
-    return total + section + number
-
-
-def _currency_amounts(
-    narration: str,
-    currency_labels: Iterable[str] | None = None,
-) -> list[int]:
-    amounts: list[int] = []
-    for match in _currency_amount_pattern(currency_labels).finditer(str(narration or "")):
-        amount = _chinese_amount(match.group("amount"))
-        if amount is not None and amount > 0:
-            amounts.append(amount)
-    return amounts
-
-
 def repair_unbacked_purchase(
     instance: Any,
     data: dict[str, Any],
@@ -180,192 +78,17 @@ def repair_unbacked_purchase(
     actions: Iterable[dict[str, Any]] | None = None,
     currency_labels: Iterable[str] | None = None,
 ) -> tuple[int, bool]:
-    """Bind an explicit purchase to an economy proposal before state apply.
+    """Bind explicit purchase intents to economy proposals before state apply.
 
-    Item tags are intentionally independent from payment tags for ordinary
-    loot, but that old shape allowed a model to emit ``EQUIP`` for a purchase
-    while omitting ``PAY``.  The server now uses the player's explicit purchase
-    intent plus one unambiguous currency amount to synthesize the same typed
-    purchase proposal.  Ambiguous prices fail closed and suppress the grant.
+    实现已下沉到 intent 层（src.engine.intent.economy_intent）：本函数只保留
+    原调用入口。每个 actor 独立证据链，详见
+    ``repair_missing_economy_proposals``。
     """
 
-    state_update = data.get("state_update")
-    if not isinstance(state_update, dict) or has_economy_proposal(data):
-        return 0, False
-    action_records = list(actions) if actions is not None else list(getattr(instance, "action_queue", []))
-    action_text = "\n".join(
-        str(action.get("text") or "")
-        for action in action_records
-        if isinstance(action, dict)
+    return repair_missing_economy_proposals(
+        instance, data, narration,
+        actions=actions, currency_labels=currency_labels,
     )
-    narrative_text = str(narration or "")
-    explicit_purchase = bool(_PURCHASE_INTENT_RE.search(action_text))
-    charge_re = _charge_pattern(currency_labels)
-    completed_payment_re = _completed_payment_pattern(currency_labels)
-    priced_narrative = bool(charge_re.search(narrative_text) or completed_payment_re.search(narrative_text))
-    if not explicit_purchase and not priced_narrative:
-        return 0, False
-    actor_uids = {
-        str(action.get("user_id") or "")
-        for action in action_records
-        if isinstance(action, dict)
-        and str(action.get("user_id") or "") in getattr(instance, "players", {})
-        and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
-    }
-
-    grants: list[tuple[str, str]] = []
-    players_update = state_update.get("players")
-    if isinstance(players_update, dict):
-        for uid, update in players_update.items():
-            if not isinstance(update, dict):
-                continue
-            for key in ("equip_gain", "weapon_change"):
-                item = str(update.get(key) or "").strip()
-                if item:
-                    grants.append((str(uid), item))
-    loot = state_update.get("loot")
-    if isinstance(loot, list):
-        for item in loot:
-            if isinstance(item, dict):
-                uid = str(item.get("player") or "")
-                name = str(item.get("item") or "").strip()
-                if uid and name:
-                    grants.append((uid, name))
-    if not grants:
-        # An explicit purchase intent whose sale the model narrated without any
-        # structured grant cannot bind an item or a seller acceptance.  Keep
-        # the intent as a clarification instead of silently dropping it.
-        if explicit_purchase and priced_narrative:
-            record_purchase_clarification(
-                instance,
-                reason="MISSING_SELLER_PRICE_CONFIRMATION",
-                payer_uid=next(iter(actor_uids)) if len(actor_uids) == 1 else "",
-                amount_candidates=_currency_amounts(narrative_text, currency_labels),
-            )
-        return 0, False
-    if _FREE_PURCHASE_RE.search(narrative_text) and not priced_narrative:
-        return 0, False
-
-    # Bind only grants named by the purchase context.  If the narration does
-    # not name an item (legacy responses), retain the conservative behavior of
-    # treating all grants for the sole payer as transaction-bound.
-    context_text = f"{action_text}\n{narrative_text}"
-    named_grants = [
-        grant for grant in grants
-        if grant[1].casefold() in context_text.casefold()
-    ]
-    bound_grants = named_grants or grants
-
-    amounts = _currency_amounts(narrative_text, currency_labels)
-    grant_uids = {uid for uid, _item in bound_grants}
-    payer_candidates = actor_uids & grant_uids
-
-    def _drop_bound_grants() -> None:
-        if isinstance(players_update, dict):
-            for update in players_update.values():
-                if isinstance(update, dict):
-                    update.pop("equip_gain", None)
-                    update.pop("weapon_change", None)
-        if isinstance(loot, list):
-            state_update["loot"] = []
-
-    # Price evidence ladder: the seller's narration is the primary source; the
-    # acting player's own stated amount only fills a missing price field.  A
-    # player amount is evidence, never an override of a seller quote.
-    amount = 0
-    amount_source = ""
-    if len(amounts) == 1:
-        amount, amount_source = amounts[0], AMOUNT_SOURCE_NARRATION
-    elif not amounts and len(payer_candidates) == 1:
-        payer_uid = next(iter(payer_candidates))
-        intent_amounts = [
-            parsed
-            for action in action_records
-            if isinstance(action, dict)
-            and str(action.get("user_id") or "") == payer_uid
-            and _PURCHASE_INTENT_RE.search(str(action.get("text") or ""))
-            for parsed in _currency_amounts(str(action.get("text") or ""), currency_labels)
-        ]
-        unique_intent_amounts = sorted(set(intent_amounts))
-        if len(unique_intent_amounts) == 1:
-            amount, amount_source = unique_intent_amounts[0], AMOUNT_SOURCE_PLAYER_ACTION
-
-    if len(payer_candidates) != 1 or not amount or amount > 100_000:
-        _drop_bound_grants()
-        reason = (
-            "AMBIGUOUS_PAYER"
-            if len(payer_candidates) > 1
-            else "INVALID_AMOUNT"
-            if amount > 100_000
-            else "AMBIGUOUS_PRICE"
-        )
-        record_purchase_clarification(
-            instance,
-            reason=reason,
-            payer_uid=next(iter(payer_candidates)) if len(payer_candidates) == 1 else "",
-            item_candidates=[item for _uid, item in bound_grants],
-            amount_candidates=amounts,
-        )
-        return len(grants), True
-    payer_uid = next(iter(payer_candidates))
-    items = [item for uid, item in bound_grants if uid == payer_uid]
-
-    offers = match_open_merchant_offers(instance, items)
-    if len(offers) > 1:
-        _drop_bound_grants()
-        record_purchase_clarification(
-            instance,
-            reason="AMBIGUOUS_OFFER",
-            payer_uid=payer_uid,
-            item_candidates=items,
-            amount_candidates=[amount],
-        )
-        return len(grants), True
-    if len(offers) == 1:
-        offer_amount = int(offers[0].get("amount") or 0)
-        if amount != offer_amount:
-            _drop_bound_grants()
-            record_purchase_clarification(
-                instance,
-                reason="OFFER_PRICE_CONFLICT",
-                payer_uid=payer_uid,
-                item_candidates=items,
-                amount_candidates=sorted({amount, offer_amount}),
-            )
-            return len(grants), True
-        amount, amount_source = offer_amount, AMOUNT_SOURCE_MERCHANT_OFFER
-
-    proposal = {
-        "kind": "purchase",
-        "uid": payer_uid,
-        "amount": amount,
-        "recipient_uid": payer_uid,
-        "items": items,
-        "reason": f"购买 {'、'.join(items)}",
-        "approval_policy": "payer",
-        "source": "server_purchase_guard",
-        "amount_source": amount_source,
-    }
-    data.setdefault("state_update", {}).setdefault("economy_proposals", []).append(proposal)
-    # The proposal's rewards are the sole authoritative delivery path. Consume
-    # only grants bound to this payer/items; unrelated loot remains intact.
-    if isinstance(loot, list):
-        state_update["loot"] = [
-            entry for entry in loot
-            if not (
-                isinstance(entry, dict)
-                and str(entry.get("player") or "") == payer_uid
-                and str(entry.get("item") or "").strip() in items
-            )
-        ]
-    if isinstance(players_update, dict):
-        for uid, update in players_update.items():
-            if str(uid) != payer_uid or not isinstance(update, dict):
-                continue
-            for key in ("equip_gain", "weapon_change"):
-                if str(update.get(key) or "").strip() in items:
-                    update.pop(key, None)
-    return 0, False
 
 
 def _meaningful(value: Any) -> bool:
@@ -374,16 +97,6 @@ def _meaningful(value: Any) -> bool:
     if isinstance(value, (list, tuple, set)):
         return any(_meaningful(item) for item in value)
     return value not in {None, "", False, 0}
-
-
-def has_economy_proposal(data: dict[str, Any]) -> bool:
-    state_update = data.get("state_update")
-    if not isinstance(state_update, dict):
-        return False
-    return bool(
-        state_update.get("pending_payments")
-        or state_update.get("economy_proposals")
-    )
 
 
 def has_server_purchase_guard(data: dict[str, Any]) -> bool:
@@ -395,29 +108,6 @@ def has_server_purchase_guard(data: dict[str, Any]) -> bool:
         isinstance(proposal, dict) and proposal.get("source") == "server_purchase_guard"
         for proposal in proposals
     )
-
-def _bounded_economy_collection(instance: Any, key: str) -> list[dict[str, Any]]:
-    economy = getattr(instance, "economy", None)
-    if not isinstance(economy, dict):
-        return []
-    entries = economy.setdefault(key, [])
-    if not isinstance(entries, list):
-        economy[key] = []
-    return economy[key]
-
-
-def _trim_open_history(entries: list[dict[str, Any]], *, max_history: int) -> None:
-    open_entries = [
-        entry for entry in entries
-        if isinstance(entry, dict) and entry.get("status") == "open"
-    ]
-    resolved = [
-        entry for entry in entries
-        if not (isinstance(entry, dict) and entry.get("status") == "open")
-    ]
-    budget = max(0, max_history - len(open_entries))
-    entries[:] = (resolved[-budget:] if budget else []) + open_entries
-
 
 def record_merchant_offer(
     instance: Any,
@@ -471,105 +161,6 @@ def record_merchant_offer(
     _trim_open_history(offers, max_history=_MAX_MERCHANT_OFFER_HISTORY)
     return offer
 
-
-def _normalized_item_name(name: str) -> str:
-    """Casefolded name without whitespace so decoration variants compare stably."""
-
-    return "".join(str(name or "").split()).casefold()
-
-
-def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list[dict[str, Any]]:
-    """Open offers whose item reference matches a purchase item name.
-
-    Binding requires the purchase name to equal the offer's item reference or
-    extend it as a suffix (Chinese variants put modifiers before the head
-    noun: "矮人精钢剑" extends "精钢剑").  Bidirectional substring matching is
-    deliberately not used — "长剑鞘" must not inherit a "长剑" quote and
-    "铁剑碎片" must not inherit "铁剑"; uncertain matches fall through to
-    clarification instead of silently inheriting a price.
-    """
-
-    names = [_normalized_item_name(name) for name in item_names]
-    names = [name for name in names if name]
-    if not names:
-        return []
-    matches: list[dict[str, Any]] = []
-    for offer in _bounded_economy_collection(instance, "merchant_offers"):
-        if not isinstance(offer, dict) or offer.get("status") != "open":
-            continue
-        if (
-            offer.get("run_id")
-            and str(offer.get("run_id")) != str(getattr(instance, "run_id", ""))
-        ):
-            continue
-        display = _normalized_item_name(str(offer.get("item_display") or ""))
-        if len(display) < 2:
-            continue
-        if any(name == display or name.endswith(display) for name in names):
-            matches.append(offer)
-    return matches
-
-
-def record_purchase_clarification(
-    instance: Any,
-    *,
-    reason: str,
-    payer_uid: str = "",
-    item_candidates: Iterable[str] = (),
-    amount_candidates: Iterable[int] = (),
-) -> dict[str, Any] | None:
-    """Persist an unresolvable purchase intent as structured pending state.
-
-    A clarification is a business state, not an error: it can never settle,
-    charge, or deliver anything.  It keeps the structure of a failed
-    fail-closed binding available for GM/player resolution instead of
-    degrading it into a prose-only notice.
-    """
-
-    items: list[str] = []
-    for candidate in item_candidates:
-        name = str(candidate or "").strip()[:120]
-        if name and name not in items:
-            items.append(name)
-    amounts: list[int] = []
-    for amount_candidate in amount_candidates:
-        try:
-            parsed = int(amount_candidate)
-        except (TypeError, ValueError):
-            continue
-        if parsed > 0 and parsed not in amounts:
-            amounts.append(parsed)
-    if not items and not amounts:
-        return None
-    clarifications = _bounded_economy_collection(instance, "clarifications")
-    signature = (
-        str(payer_uid or ""), tuple(items), tuple(amounts), str(reason)[:60],
-    )
-    for entry in clarifications:
-        if not isinstance(entry, dict) or entry.get("status") != "open":
-            continue
-        entry_signature = (
-            str(entry.get("payer_uid") or ""),
-            tuple(str(item) for item in (entry.get("item_candidates") or [])),
-            tuple(int(value) for value in (entry.get("amount_candidates") or [])),
-            str(entry.get("reason") or ""),
-        )
-        if entry_signature == signature:
-            return entry
-    clarification = {
-        "id": f"clarify_{uuid4().hex}",
-        "run_id": str(getattr(instance, "run_id", "")),
-        "origin_round": int(getattr(instance, "round_number", 0) or 0),
-        "payer_uid": str(payer_uid or ""),
-        "item_candidates": items,
-        "amount_candidates": amounts,
-        "reason": str(reason)[:60],
-        "status": "open",
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
-    clarifications.append(clarification)
-    _trim_open_history(clarifications, max_history=_MAX_CLARIFICATION_HISTORY)
-    return clarification
 
 def _purchase_quotes(instance: Any) -> list[dict[str, Any]]:
     economy = getattr(instance, "economy", None)

--- a/src/engine/intent/__init__.py
+++ b/src/engine/intent/__init__.py
@@ -1,0 +1,11 @@
+"""Intent layer: structured player intents independent of AI output.
+
+Intent 层回答"玩家想做什么"。它只解析玩家自己的行动文本（规则解析 +
+轻量匹配，不消耗 LLM），把结果交给经济恢复层与既有 proposal 系统对接：
+
+```text
+Player action → PurchaseIntent → evidence repair → pending proposal
+```
+
+AI 叙事仍不是交易事实；恢复出的提案保持 pending，付款人确认前不动钱。
+"""

--- a/src/engine/intent/economy_intent.py
+++ b/src/engine/intent/economy_intent.py
@@ -1,0 +1,375 @@
+"""Purchase-intent recovery: intents + narration evidence → proposals.
+
+Intent 层与既有 proposal 系统的对接点。``repair_missing_economy_proposals``
+把每个 actor 的购买意图与其结构化 grant、叙事证据、持久化商家报价独立
+配对，产出 pending 提案或结构化澄清：
+
+```text
+Intent(actor) → evidence ladder → pending proposal / clarification
+```
+
+价格证据阶梯（每个 actor 独立）：persisted merchant offer > 按句绑定的
+叙事价格 > 全局唯一叙事金额 > 玩家行动自报金额 > clarification。玩家
+自报金额只是缺失价格字段的证据，永远不能覆盖 persisted offer。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+from typing import Any, Iterable
+from uuid import uuid4
+
+from src.engine.economy import MAX_ECONOMY_AMOUNT
+from src.engine.intent.matcher import match_open_merchant_offers
+from src.engine.intent.parser import (
+    FREE_PURCHASE_RE,
+    charge_pattern,
+    completed_payment_pattern,
+    currency_amounts,
+    parse_purchase_intents,
+)
+
+AMOUNT_SOURCE_NARRATION = "narration"
+AMOUNT_SOURCE_PLAYER_ACTION = "player_action"
+AMOUNT_SOURCE_MERCHANT_OFFER = "merchant_offer"
+
+_MAX_CLARIFICATION_HISTORY = 24
+
+
+def bounded_economy_collection(instance: Any, key: str) -> list[dict[str, Any]]:
+    economy = getattr(instance, "economy", None)
+    if not isinstance(economy, dict):
+        return []
+    entries = economy.setdefault(key, [])
+    if not isinstance(entries, list):
+        economy[key] = []
+    return economy[key]
+
+
+def trim_open_history(entries: list[dict[str, Any]], *, max_history: int) -> None:
+    open_entries = [
+        entry for entry in entries
+        if isinstance(entry, dict) and entry.get("status") == "open"
+    ]
+    resolved = [
+        entry for entry in entries
+        if not (isinstance(entry, dict) and entry.get("status") == "open")
+    ]
+    budget = max(0, max_history - len(open_entries))
+    entries[:] = (resolved[-budget:] if budget else []) + open_entries
+
+
+def has_economy_proposal(data: dict[str, Any]) -> bool:
+    state_update = data.get("state_update")
+    if not isinstance(state_update, dict):
+        return False
+    return bool(
+        state_update.get("pending_payments")
+        or state_update.get("economy_proposals")
+    )
+
+
+def record_purchase_clarification(
+    instance: Any,
+    *,
+    reason: str,
+    payer_uid: str = "",
+    item_candidates: Iterable[str] = (),
+    amount_candidates: Iterable[int] = (),
+) -> dict[str, Any] | None:
+    """Persist an unresolvable purchase intent as structured pending state.
+
+    A clarification is a business state, not an error: it can never settle,
+    charge, or deliver anything.  It keeps the structure of a failed
+    fail-closed binding available for GM/player resolution instead of
+    degrading it into a prose-only notice.
+    """
+
+    items: list[str] = []
+    for candidate in item_candidates:
+        name = str(candidate or "").strip()[:120]
+        if name and name not in items:
+            items.append(name)
+    amounts: list[int] = []
+    for amount_candidate in amount_candidates:
+        try:
+            parsed = int(amount_candidate)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0 and parsed not in amounts:
+            amounts.append(parsed)
+    if not items and not amounts and not payer_uid:
+        return None
+    clarifications = bounded_economy_collection(instance, "clarifications")
+    signature = (
+        str(payer_uid or ""), tuple(items), tuple(amounts), str(reason)[:60],
+    )
+    for entry in clarifications:
+        if not isinstance(entry, dict) or entry.get("status") != "open":
+            continue
+        entry_signature = (
+            str(entry.get("payer_uid") or ""),
+            tuple(str(item) for item in (entry.get("item_candidates") or [])),
+            tuple(int(value) for value in (entry.get("amount_candidates") or [])),
+            str(entry.get("reason") or ""),
+        )
+        if entry_signature == signature:
+            return entry
+    clarification = {
+        "id": f"clarify_{uuid4().hex}",
+        "run_id": str(getattr(instance, "run_id", "")),
+        "origin_round": int(getattr(instance, "round_number", 0) or 0),
+        "payer_uid": str(payer_uid or ""),
+        "item_candidates": items,
+        "amount_candidates": amounts,
+        "reason": str(reason)[:60],
+        "status": "open",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    clarifications.append(clarification)
+    trim_open_history(clarifications, max_history=_MAX_CLARIFICATION_HISTORY)
+    return clarification
+
+
+def _collect_grants(state_update: dict[str, Any]) -> tuple[dict[str, list[str]], list[dict[str, Any]] | None]:
+    """Collect AI-emitted item grants grouped by actor."""
+
+    grants_by_uid: dict[str, list[str]] = {}
+    players_update = state_update.get("players")
+    if isinstance(players_update, dict):
+        for uid, update in players_update.items():
+            if not isinstance(update, dict):
+                continue
+            for key in ("equip_gain", "weapon_change"):
+                item = str(update.get(key) or "").strip()
+                if item:
+                    grants_by_uid.setdefault(str(uid), []).append(item)
+    loot = state_update.get("loot")
+    loot_entries = loot if isinstance(loot, list) else None
+    if loot_entries is not None:
+        for entry in loot_entries:
+            if isinstance(entry, dict):
+                uid = str(entry.get("player") or "")
+                name = str(entry.get("item") or "").strip()
+                if uid and name:
+                    grants_by_uid.setdefault(uid, []).append(name)
+    return grants_by_uid, loot_entries
+
+
+def _narration_amounts_for_items(
+    narration_text: str,
+    item_names: list[str],
+    currency_labels: Iterable[str] | None,
+) -> list[int]:
+    bound: list[int] = []
+    for sentence in re.split(r"[。！？.!?\n]+", narration_text):
+        if not any(
+            item and item.casefold() in sentence.casefold()
+            for item in item_names
+        ):
+            continue
+        bound.extend(currency_amounts(sentence, currency_labels))
+    return sorted(set(bound))
+
+
+def repair_missing_economy_proposals(
+    instance: Any,
+    data: dict[str, Any],
+    narration: str,
+    *,
+    actions: Iterable[dict[str, Any]] | None = None,
+    currency_labels: Iterable[str] | None = None,
+) -> tuple[int, bool]:
+    """Recover purchases the model narrated without structured payment tags.
+
+    每个 actor 独立一条证据链：merchant offer > 按句绑定叙事价格 > 全局唯一
+    叙事金额 > 行动自报金额 > clarification。有 grant 且证据唯一的 actor 合成
+    pending 提案（扣款发货仍需付款人确认）；无 grant 的意图按 actor 记为
+    结构化澄清，不再静默丢失。返回 (dropped_grant_count, clarified_any)。
+    """
+
+    state_update = data.get("state_update")
+    if not isinstance(state_update, dict) or has_economy_proposal(data):
+        return 0, False
+    action_records = (
+        list(actions) if actions is not None
+        else list(getattr(instance, "action_queue", []))
+    )
+    intents = parse_purchase_intents(
+        action_records, getattr(instance, "players", {}), currency_labels,
+    )
+    narrative_text = str(narration or "")
+    priced_narrative = bool(
+        charge_pattern(currency_labels).search(narrative_text)
+        or completed_payment_pattern(currency_labels).search(narrative_text)
+    )
+    if not intents and not priced_narrative:
+        return 0, False
+    if FREE_PURCHASE_RE.search(narrative_text) and not priced_narrative:
+        return 0, False
+
+    players_update = state_update.get("players")
+    grants_by_uid, loot_entries = _collect_grants(state_update)
+    narration_amounts = currency_amounts(narrative_text, currency_labels)
+    context_text = (
+        narrative_text
+        + "\n"
+        + "\n".join(intent.action_text for intent in intents)
+    )
+
+    def _drop_grants(actor_uid: str, items: list[str]) -> None:
+        if isinstance(players_update, dict):
+            update = players_update.get(actor_uid)
+            if isinstance(update, dict):
+                for key in ("equip_gain", "weapon_change"):
+                    if str(update.get(key) or "").strip() in items:
+                        update.pop(key, None)
+        current_loot = state_update.get("loot")
+        if isinstance(current_loot, list):
+            state_update["loot"] = [
+                entry for entry in current_loot
+                if not (
+                    isinstance(entry, dict)
+                    and str(entry.get("player") or "") == actor_uid
+                    and str(entry.get("item") or "").strip() in items
+                )
+            ]
+
+    def _clarify(
+        *,
+        reason: str,
+        payer_uid: str,
+        item_candidates: list[str],
+        amount_candidates: list[int],
+    ) -> None:
+        record_purchase_clarification(
+            instance,
+            reason=reason,
+            payer_uid=payer_uid,
+            item_candidates=item_candidates,
+            amount_candidates=amount_candidates,
+        )
+
+    dropped = 0
+    clarified_any = False
+    proposals: list[dict[str, Any]] = []
+
+    for intent in intents:
+        actor_grants = grants_by_uid.get(intent.actor_uid, [])
+        named = [
+            item for item in actor_grants
+            if item.casefold() in context_text.casefold()
+        ]
+        if named:
+            bound_items = named
+        elif actor_grants and len(grants_by_uid) == 1:
+            # 唯一有 grant 的 actor：叙事未点名时沿用保守兜底。
+            bound_items = list(actor_grants)
+        else:
+            bound_items = []
+
+        if not bound_items:
+            # 无卖方接受证据（AI 未发 grant）：意图按 actor 记为澄清，
+            # 不再静默丢失（round-12 结构图问题的恢复入口）。
+            _clarify(
+                reason="MISSING_SELLER_PRICE_CONFIRMATION",
+                payer_uid=intent.actor_uid,
+                item_candidates=[intent.item_context] if intent.item_context else [],
+                amount_candidates=[
+                    *intent.amount_candidates,
+                    *narration_amounts,
+                ],
+            )
+            clarified_any = True
+            continue
+
+        offers = match_open_merchant_offers(instance, bound_items)
+        offer_amount = (
+            int(offers[0].get("amount") or 0) if len(offers) == 1 else None
+        )
+        item_bound_amounts = _narration_amounts_for_items(
+            narrative_text, bound_items, currency_labels,
+        )
+
+        amount = 0
+        amount_source = ""
+        if len(offers) > 1:
+            _drop_grants(intent.actor_uid, bound_items)
+            dropped += len(bound_items)
+            _clarify(
+                reason="AMBIGUOUS_OFFER",
+                payer_uid=intent.actor_uid,
+                item_candidates=bound_items,
+                amount_candidates=[*intent.amount_candidates, *narration_amounts],
+            )
+            clarified_any = True
+            continue
+        if offer_amount is not None:
+            evidence = (
+                item_bound_amounts[0]
+                if len(item_bound_amounts) == 1
+                else narration_amounts[0] if len(narration_amounts) == 1
+                else intent.amount_candidates[0] if len(intent.amount_candidates) == 1
+                else 0
+            )
+            if evidence and evidence != offer_amount:
+                _drop_grants(intent.actor_uid, bound_items)
+                dropped += len(bound_items)
+                _clarify(
+                    reason="OFFER_PRICE_CONFLICT",
+                    payer_uid=intent.actor_uid,
+                    item_candidates=bound_items,
+                    amount_candidates=sorted({evidence, offer_amount}),
+                )
+                clarified_any = True
+                continue
+            amount, amount_source = offer_amount, AMOUNT_SOURCE_MERCHANT_OFFER
+        elif len(item_bound_amounts) == 1:
+            amount, amount_source = item_bound_amounts[0], AMOUNT_SOURCE_NARRATION
+        elif len(narration_amounts) == 1:
+            amount, amount_source = narration_amounts[0], AMOUNT_SOURCE_NARRATION
+        elif len(intent.amount_candidates) == 1:
+            amount, amount_source = (
+                intent.amount_candidates[0], AMOUNT_SOURCE_PLAYER_ACTION,
+            )
+
+        if not amount or amount > MAX_ECONOMY_AMOUNT:
+            _drop_grants(intent.actor_uid, bound_items)
+            dropped += len(bound_items)
+            _clarify(
+                reason=(
+                    "INVALID_AMOUNT"
+                    if amount > MAX_ECONOMY_AMOUNT
+                    else "AMBIGUOUS_PRICE"
+                ),
+                payer_uid=intent.actor_uid,
+                item_candidates=bound_items if bound_items else [intent.item_context],
+                amount_candidates=[
+                    *intent.amount_candidates,
+                    *narration_amounts,
+                ],
+            )
+            clarified_any = True
+            continue
+
+        proposals.append({
+            "kind": "purchase",
+            "uid": intent.actor_uid,
+            "amount": amount,
+            "recipient_uid": intent.actor_uid,
+            "items": bound_items,
+            "reason": f"购买 {'、'.join(bound_items)}",
+            "approval_policy": "payer",
+            "source": "server_purchase_guard",
+            "amount_source": amount_source,
+        })
+        # 合成提案消费该 actor 的 grant 作为唯一发货路径；这不是丢弃，
+        # 不计入 dropped（dropped 只统计进澄清的 grant）。
+        _drop_grants(intent.actor_uid, bound_items)
+
+    for proposal in proposals:
+        data.setdefault("state_update", {}).setdefault(
+            "economy_proposals", [],
+        ).append(proposal)
+    return dropped, clarified_any

--- a/src/engine/intent/matcher.py
+++ b/src/engine/intent/matcher.py
@@ -1,0 +1,73 @@
+"""Item-name binding between purchase intents, grants and merchant offers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from src.engine.intent.parser import currency_amounts
+
+
+def normalized_item_name(name: str) -> str:
+    """Casefolded name without whitespace so decoration variants compare stably."""
+
+    return "".join(str(name or "").split()).casefold()
+
+
+def match_open_merchant_offers(instance: Any, item_names: Iterable[str]) -> list[dict[str, Any]]:
+    """Open offers whose item reference matches a purchase item name.
+
+    Binding requires the purchase name to equal the offer's item reference or
+    extend it as a suffix (Chinese variants put modifiers before the head
+    noun: "矮人精钢剑" extends "精钢剑").  Bidirectional substring matching is
+    deliberately not used — "长剑鞘" must not inherit a "长剑" quote and
+    "铁剑碎片" must not inherit "铁剑"; uncertain matches fall through to
+    clarification instead of silently inheriting a price.
+    """
+
+    names = [normalized_item_name(name) for name in item_names]
+    names = [name for name in names if name]
+    if not names:
+        return []
+    matches: list[dict[str, Any]] = []
+    economy = getattr(instance, "economy", {})
+    offers = economy.get("merchant_offers", []) if isinstance(economy, dict) else []
+    for offer in offers:
+        if not isinstance(offer, dict) or offer.get("status") != "open":
+            continue
+        if (
+            offer.get("run_id")
+            and str(offer.get("run_id")) != str(getattr(instance, "run_id", ""))
+        ):
+            continue
+        display = normalized_item_name(str(offer.get("item_display") or ""))
+        if len(display) < 2:
+            continue
+        if any(name == display or name.endswith(display) for name in names):
+            matches.append(offer)
+    return matches
+
+
+def narration_price_for_items(
+    narration: str,
+    item_names: Iterable[str],
+    currency_labels: Iterable[str] | None = None,
+) -> int | None:
+    """Bind a narration price to one purchase item at sentence granularity.
+
+    只有"商品名与金额出现在同一句"的叙事金额才算该商品的报价；同句出现
+    多个金额视为无法唯一确认（返回 None）。找不到绑定句返回 None，交由
+    更低优先级的证据（全局唯一金额 / 行动自报）兜底。
+    """
+
+    names = [normalized_item_name(name) for name in item_names]
+    names = [name for name in names if len(name) >= 2]
+    if not names:
+        return None
+    bound: list[int] = []
+    for sentence in re.split(r"[。！？.!?\n]+", str(narration or "")):
+        if not any(name in normalized_item_name(sentence) for name in names):
+            continue
+        bound.extend(currency_amounts(sentence, currency_labels))
+    unique = sorted(set(bound))
+    return unique[0] if len(unique) == 1 else None

--- a/src/engine/intent/models.py
+++ b/src/engine/intent/models.py
@@ -1,0 +1,20 @@
+"""Intent 层的结构化模型。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PurchaseIntent:
+    """One actor's stated purchase intent, parsed from their own action text.
+
+    ``item_context`` 是去掉金额与购买动词后的商品指代片段（供澄清展示与
+    宽松绑定），``amount_candidates`` 是该 actor 行动里出现的全部金额——
+    多于一个时视为无法唯一确认。意图只是证据，不是交易事实。
+    """
+
+    actor_uid: str
+    action_text: str
+    item_context: str
+    amount_candidates: tuple[int, ...]

--- a/src/engine/intent/parser.py
+++ b/src/engine/intent/parser.py
@@ -1,0 +1,190 @@
+"""Narrative/intent text parsing primitives shared by the economy guards.
+
+这些正则与金额解析原属 economy_effects，现下沉到 engine 作为 intent 层的
+解析基座：ruleset-neutral，不依赖任何具体规则系统；规则只需通过
+``currency_labels_for_rule`` 投影自己的货币称谓。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from src.engine.intent.models import PurchaseIntent
+
+PURCHASE_INTENT_RE = re.compile(
+    r"(?:买下|买了|购买|购入|买入|付费|支付|缴纳|花费|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
+    re.IGNORECASE,
+)
+FREE_PURCHASE_RE = re.compile(r"(?:免费|无需付费|不用钱|免费领取|free|no charge)", re.IGNORECASE)
+PURCHASE_CONFIRM_RE = re.compile(
+    r"(?:成交|买了|买下|购买|确认购买|接受报价|就要这个|行|可以|同意|付钱|结账|"
+    r"deal|accept|accepted|confirm|confirmed|buy it|take it|pay|yes|"
+    r"成約|購入|承知|支払う|了解です|はい|了承)", re.IGNORECASE,
+)
+PURCHASE_OFFER_RE = re.compile(
+    r"(?:需要|需|售价|价格|费用|收费|cost|price|charge)", re.IGNORECASE,
+)
+_PAYMENT_VERB_RE = re.compile(
+    r"(?:掏|拿出|递给?|付|支付|付钱|结账|给钱|花费|spend|pay|buy|purchase|bought|paid)",
+    re.IGNORECASE,
+)
+
+
+def currency_labels(extra_labels: Iterable[str] | None = None) -> tuple[str, ...]:
+    """Return canonical rule labels plus legacy aliases for text recognition.
+
+    Narrative parsing is only a repair/fail-closed guard; the persisted
+    currency schema remains authoritative.  Rule-provided labels let the same
+    guard work for custom economies (USD, credits, gems, etc.) without adding
+    ruleset branches to the generic engine.
+    """
+
+    labels = {
+        "金币", "金子", "金", "gold", "credits", "credit", "dollars", "dollar",
+    }
+    for label in extra_labels or ():
+        value = str(label or "").strip()
+        if value:
+            labels.add(value)
+    return tuple(sorted(labels, key=len, reverse=True))
+
+
+def currency_labels_for_rule(rule: Any) -> tuple[str, ...]:
+    """Project declared rule currency IDs/names into the generic text guard."""
+
+    system = getattr(rule, "currency_system", None)
+    if not isinstance(system, dict) and isinstance(rule, dict):
+        system = rule.get("currency_system")
+    units = system.get("units", []) if isinstance(system, dict) else []
+    labels: list[str] = []
+    if isinstance(units, list):
+        for unit in units:
+            if isinstance(unit, dict):
+                labels.extend(
+                    str(unit.get(key) or "").strip()
+                    for key in ("id", "name", "label")
+                    if str(unit.get(key) or "").strip()
+                )
+    return currency_labels(labels)
+
+
+def currency_amount_pattern(extra_labels: Iterable[str] | None = None) -> re.Pattern[str]:
+    labels = "|".join(re.escape(label) for label in currency_labels(extra_labels))
+    return re.compile(
+        rf"(?P<amount>[0-9]+|[零〇一二三四五六七八九十百千万两]+)"
+        rf"\s*(?:枚|个)?\s*(?:{labels})",
+        re.IGNORECASE,
+    )
+
+
+def charge_pattern(extra_labels: Iterable[str] | None = None) -> re.Pattern[str]:
+    labels = "|".join(re.escape(label) for label in currency_labels(extra_labels))
+    return re.compile(
+        rf"(?:需要|需|必须|须|售价|价格|费用|收费|支付|付费|购买|买下|花费|缴纳|"
+        rf"cost|price|charge|pay|purchase|spend)[^。！？\n]{{0,24}}?"
+        rf"(?:[一二三四五六七八九十百千万两\d]+)\s*(?:枚|个)?\s*(?:{labels})"
+        rf"|(?:[一二三四五六七八九十百千万两\d]+)\s*(?:{labels})"
+        rf"[^。！？\n]{{0,16}}?"
+        rf"(?:需要|需|支付|付费|购买|买下|花费|缴纳|cost|price|charge|pay|purchase|spend)",
+        re.IGNORECASE,
+    )
+
+
+def completed_payment_pattern(extra_labels: Iterable[str] | None = None) -> re.Pattern[str]:
+    labels = "|".join(re.escape(label) for label in currency_labels(extra_labels))
+    return re.compile(
+        rf"(?:掏出|拿出|数出|数了|递出|放下|交出|付出|支付了?|缴纳了?|付清|花费了?)\s*"
+        rf"(?:[一二三四五六七八九十百千万两\d]+)\s*(?:枚|个)?\s*(?:{labels})"
+        rf"|(?:paid|spent|handed over|paid out)\s+"
+        rf"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:{labels})",
+        re.IGNORECASE,
+    )
+
+
+def _chinese_amount(value: str) -> int | None:
+    """Parse the small Chinese numerals commonly used in narrative prices."""
+
+    if value.isdigit():
+        return int(value)
+    digits = {"零": 0, "〇": 0, "一": 1, "二": 2, "两": 2, "三": 3, "四": 4,
+              "五": 5, "六": 6, "七": 7, "八": 8, "九": 9}
+    units = {"十": 10, "百": 100, "千": 1000, "万": 10000}
+    total = 0
+    section = 0
+    number = 0
+    for char in value:
+        if char in digits:
+            number = digits[char]
+        elif char in units:
+            unit = units[char]
+            if unit == 10000:
+                section = (section + number) * unit
+                total += section
+                section = 0
+            else:
+                section += (number or 1) * unit
+            number = 0
+        else:
+            return None
+    return total + section + number
+
+
+def currency_amounts(
+    narration: str,
+    extra_labels: Iterable[str] | None = None,
+) -> list[int]:
+    amounts: list[int] = []
+    for match in currency_amount_pattern(extra_labels).finditer(str(narration or "")):
+        amount = _chinese_amount(match.group("amount"))
+        if amount is not None and amount > 0:
+            amounts.append(amount)
+    return amounts
+
+
+def item_context_from_action(
+    text: str,
+    extra_labels: Iterable[str] | None = None,
+) -> str:
+    """Derive a loose item hint from one player action.
+
+    去掉金额、货币与购买动词后剩下的片段作为商品指代；只用于澄清展示与
+    宽松绑定，永远不作为价格或身份的权威来源。
+    """
+
+    cleaned = currency_amount_pattern(extra_labels).sub(" ", str(text or ""))
+    cleaned = re.sub(r"[（(][^）)]*[)）]", " ", cleaned)
+    cleaned = PURCHASE_INTENT_RE.sub(" ", cleaned)
+    cleaned = _PAYMENT_VERB_RE.sub(" ", cleaned)
+    return re.sub(r"^[\s，,。.、：:；;'-]+|[\s，,。.、：:；;'-]+$", "", cleaned)
+
+
+def parse_purchase_intents(
+    action_records: Iterable[Any],
+    players: Any,
+    extra_labels: Iterable[str] | None = None,
+) -> list[PurchaseIntent]:
+    """Parse each player's own action into one purchase intent.
+
+    每个 actor 独立解析：意图只来自玩家自己的行动文本，AI 输出不参与。
+    没有购买动词的行动不产生意图。
+    """
+
+    intents: list[PurchaseIntent] = []
+    for action in action_records:
+        if not isinstance(action, dict):
+            continue
+        actor_uid = str(action.get("user_id") or "")
+        text = str(action.get("text") or "")
+        if not actor_uid or actor_uid not in players:
+            continue
+        if not PURCHASE_INTENT_RE.search(text):
+            continue
+        amounts = currency_amounts(text, extra_labels)
+        intents.append(PurchaseIntent(
+            actor_uid=actor_uid,
+            action_text=text,
+            item_context=item_context_from_action(text, extra_labels),
+            amount_candidates=tuple(sorted(set(amounts))),
+        ))
+    return intents

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -558,7 +558,8 @@ def test_prose_sale_without_grants_persists_clarification() -> None:
     dropped, ambiguous = repair_unbacked_purchase(
         instance, data, "你掏出三十金币递了过去，商家点头把剑包好。",
     )
-    assert (dropped, ambiguous) == (0, False)
+    # 无 grant 的意图按 actor 记为澄清，repair 已接管（ambiguous=True 跳过 discard）。
+    assert (dropped, ambiguous) == (0, True)
     assert not data["state_update"].get("economy_proposals")
     clarification = instance.economy["clarifications"][0]
     assert clarification["reason"] == "MISSING_SELLER_PRICE_CONFIRMATION"
@@ -2547,3 +2548,77 @@ async def test_character_update_is_rejected_during_swipe(web_api) -> None:
     assert instance.players[uid] == before
     release.set()
     await asyncio.wait_for(rewrite, 1)
+
+
+def test_two_actors_same_round_repair_splits_per_payer() -> None:
+    """复刻 round-12：双人同轮各自购买，按 actor 拆成独立待确认提案。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "gm", "text": "买下《王都周边地城简录》（5金币）"},
+        {"user_id": "p2", "text": "买下那卷结构图（3金币）"},
+    ]
+    data = {"state_update": {"loot": [
+        {"player": "gm", "item": "王都周边地城简录"},
+        {"player": "p2", "item": "结构图"},
+    ]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data,
+        "“结构图三金币，简录五金币，都是旧货，不还价。”老头把两样东西并排摆在柜台上。"
+        "“我测试”掏出三枚金币搁在柜台上，抓起卷轴塞进怀里。你也数出五枚金币推过去，"
+        "老头把册子递到你手里。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposals = data["state_update"]["economy_proposals"]
+    assert len(proposals) == 2
+    by_payer = {p["uid"]: p for p in proposals}
+    assert by_payer["gm"]["amount"] == 5
+    assert by_payer["gm"]["items"] == ["王都周边地城简录"]
+    assert by_payer["p2"]["amount"] == 3
+    assert by_payer["p2"]["items"] == ["结构图"]
+    for proposal in proposals:
+        assert proposal["status"] if False else proposal["amount_source"] == "player_action"
+    # 双人的 grant 都被各自提案消费，loot 不再残留。
+    assert data["state_update"]["loot"] == []
+    assert not instance.economy.get("clarifications")
+
+
+def test_intent_without_grant_becomes_per_actor_clarification() -> None:
+    """AI 没发 grant 的那半购买：按 actor 记结构化澄清，不再无痕丢失。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "p2", "text": "买下那卷结构图（3金币）"},
+    ]
+    data = {"state_update": {}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data,
+        "“结构图三金币。”老头把发黑的卷轴推了过去，“我测试”把钱递了过去。",
+    )
+    assert (dropped, ambiguous) == (0, True)
+    assert not data["state_update"].get("economy_proposals")
+    clarifications = instance.economy["clarifications"]
+    assert len(clarifications) == 1
+    clarification = clarifications[0]
+    assert clarification["payer_uid"] == "p2"
+    assert clarification["reason"] == "MISSING_SELLER_PRICE_CONFIRMATION"
+    assert clarification["amount_candidates"] == [3]
+    assert any("结构图" in item for item in clarification["item_candidates"])
+
+
+def test_repair_binds_narration_price_per_item_sentence() -> None:
+    """叙事里商品与金额同句唯一绑定时，优先于行动自报金额。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "gm", "text": "掏9金币买下精钢剑"},
+    ]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data,
+        "霍根咧嘴：“矮人精钢剑卖三十金币，不讲价。”你把钱数给了他，剑归了你。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert proposal["amount_source"] == "narration"


### PR DESCRIPTION
## 背景
真实存档（round 12）暴露的缺口：双人同轮各自购买（结构图 3 金 / 简录 5 金），AI 散文成交不发票据——repair 的"唯一付款人"约束使两笔购买整体 fail-closed，澄清的价格候选混在一起无法按人处理；AI 漏发 grant 的那半购买连澄清都没有，纯散文丢失。此类"玩家行动自带价格、AI 不发 PAY"已发生 3 次（round 7 / 9 / 12），是模型稳定行为而非偶发。

按《Intent Layer 执行方案》实施 PR A：意图解析只看玩家自己的行动（规则解析 + 轻量匹配，零 LLM 成本），repair 从"整轮单付款人"重构为"每个 actor 独立证据链"。

## 改动
**新包 `src/engine/intent/`**（文档推荐结构）：
- `parser.py`：货币/金额/购买意图正则与逐 actor 意图解析 `parse_purchase_intents`（从 economy_effects 下沉，commands → engine 依赖方向正确）；意图附 `item_context`（去掉金额与购买动词的商品指代片段，仅供澄清展示与宽松绑定）
- `matcher.py`：归一化精确/后缀商品绑定（`match_open_merchant_offers` 迁入）+ 新增**按句叙事价格绑定**（商品名与金额同句才算该商品的叙事报价，同句多金额视为不确定）
- `economy_intent.py`：`repair_missing_economy_proposals` 逐 actor 证据编排 + `record_purchase_clarification`/`has_economy_proposal`（自 economy_effects 迁移）
- `economy_effects.repair_unbacked_purchase` 保留原入口，实现委托 intent 层；全部旧符号兼容再导出（round_processor / swipe / game_lifecycle / 测试零改动）

**逐 actor 证据阶梯**（每 actor 独立）：
1. persisted merchant offer（金额权威，冲突 → OFFER_PRICE_CONFLICT 澄清）
2. 按句绑定的叙事价格（商品名+金额同句唯一）
3. 全局唯一叙事金额
4. 行动自报金额（amount_source=player_action）
5. 无法唯一确认 → 按 actor 的 AMBIGUOUS_PRICE / AMBIGUOUS_OFFER / AMBIGUOUS_PAYER 澄清

**round 12 两个缺口的闭环**：
- 双人同轮 → 各自合成 pending 提案（payer/item/amount 不串线，金额冲突各自澄清）
- AI 未发 grant 的意图 → 按 actor 的 MISSING_SELLER_PRICE_CONFIRMATION 澄清（带 item_context 与玩家自报金额），不再无痕丢失

## 不在本 PR
PR B：Reward Intent + auto settlement 结合；PR C：通用 Event Proposal；Event Card UI；canonical item。

## 风险面
- 恢复层行为重构：单 actor 场景证据阶梯保持原语义（narration > action、offer 冲突澄清、免费豁免、唯一 grant 兜底），既有 14 个 repair 测试全部不改断言通过（仅 1 个返回标志断言按新语义更新：澄清产生时 ambiguous=True 表示 repair 已接管）
- 无 grant 澄清为新增能力：无 grant 时不再触发 discard 重复记录（clarified → 跳过 discard）
- 不触碰确认权/结算链/回滚语义

## 验证
- 新增 3 个测试：双人同轮按 payer 拆分（round-12 复刻）、无 grant 意图按 actor 澄清、按句叙事绑定优先于行动金额
- `python -m pytest -q`：1876 passed / 1 skipped
- ruff ✅；`python -m mypy`（CI 同款 55 文件）✅