### PR TITLE
feat: intent evidence layer + deferred-payment handling

### DIFF
--- a/src/commands/state_update_applier.py
+++ b/src/commands/state_update_applier.py
@@ -265,6 +265,15 @@ class StateUpdateApplier:
                     if source == "server_purchase_guard"
                     else ""
                 ),
+                evidence_ids=(
+                    [
+                        str(item)
+                        for item in (proposal.get("evidence_ids") or [])
+                        if str(item)
+                    ]
+                    if source == "server_purchase_guard"
+                    else []
+                ),
             ))
             quote_id = str(proposal.get("quote_id") or "")
             if quote_id:

--- a/src/engine/economy.py
+++ b/src/engine/economy.py
@@ -597,6 +597,7 @@ def queue_proposal(
     visibility: str = "private",
     quote_id: str = "",
     amount_source: str = "",
+    evidence_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Queue one idempotent proposal; no balance is changed here."""
 
@@ -659,6 +660,9 @@ def queue_proposal(
         # Audit of which evidence produced the amount (server guard paths
         # only): narration / player_action / merchant_offer.
         "amount_source": str(amount_source)[:40],
+        # Evidence layer links (ev_*): audit trail of what was observed;
+        # evidence itself never mutates state.
+        "evidence_ids": [str(item) for item in (evidence_ids or [])][:20],
         "approval_policy": str(approval_policy),
         "rewards": deepcopy(list(rewards or [])),
         "contributors": normalized_contributors,

--- a/src/engine/game_instance.py
+++ b/src/engine/game_instance.py
@@ -276,6 +276,7 @@ class GameInstance:
             self.economy.setdefault("purchase_quotes", [])
             self.economy.setdefault("merchant_offers", [])
             self.economy.setdefault("clarifications", [])
+            self.economy.setdefault("evidence", [])
             self.economy.setdefault("decision_revision", 0)
 
     def _fresh_economy_state(self) -> dict[str, Any]:
@@ -292,6 +293,7 @@ class GameInstance:
             "purchase_quotes": [],
             "merchant_offers": [],
             "clarifications": [],
+            "evidence": [],
             "decision_revision": 0,
         }
 

--- a/src/engine/intent/economy_intent.py
+++ b/src/engine/intent/economy_intent.py
@@ -21,8 +21,10 @@ from typing import Any, Iterable
 from uuid import uuid4
 
 from src.engine.economy import MAX_ECONOMY_AMOUNT
+from src.engine.intent.evidence import collect_evidence_for_intent
 from src.engine.intent.matcher import match_open_merchant_offers
 from src.engine.intent.parser import (
+    DEFERRED_PAYMENT_RE,
     FREE_PURCHASE_RE,
     charge_pattern,
     completed_payment_pattern,
@@ -77,6 +79,7 @@ def record_purchase_clarification(
     payer_uid: str = "",
     item_candidates: Iterable[str] = (),
     amount_candidates: Iterable[int] = (),
+    evidence_ids: list[str] | None = None,
 ) -> dict[str, Any] | None:
     """Persist an unresolvable purchase intent as structured pending state.
 
@@ -124,6 +127,7 @@ def record_purchase_clarification(
         "item_candidates": items,
         "amount_candidates": amounts,
         "reason": str(reason)[:60],
+        "evidence_ids": list(evidence_ids or []),
         "status": "open",
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -242,6 +246,7 @@ def repair_missing_economy_proposals(
         payer_uid: str,
         item_candidates: list[str],
         amount_candidates: list[int],
+        evidence_ids: list[str] | None = None,
     ) -> None:
         record_purchase_clarification(
             instance,
@@ -249,6 +254,7 @@ def repair_missing_economy_proposals(
             payer_uid=payer_uid,
             item_candidates=item_candidates,
             amount_candidates=amount_candidates,
+            evidence_ids=evidence_ids,
         )
 
     dropped = 0
@@ -269,6 +275,33 @@ def repair_missing_economy_proposals(
         else:
             bound_items = []
 
+        evidence_ids = collect_evidence_for_intent(
+            instance,
+            intent_actor_uid=intent.actor_uid,
+            intent_item_context=intent.item_context,
+            intent_amounts=intent.amount_candidates,
+            grant_items=actor_grants,
+        )
+
+        if DEFERRED_PAYMENT_RE.search(intent.action_text):
+            # 赊账/延期付款：交易条款未当场谈定，不合成立即结算的提案。
+            # 证据与意图留档，待 GM/玩家安排后再走标准确认链。
+            if bound_items:
+                _drop_grants(intent.actor_uid, bound_items)
+                dropped += len(bound_items)
+            _clarify(
+                reason="DEFERRED_PAYMENT",
+                payer_uid=intent.actor_uid,
+                item_candidates=bound_items if bound_items else [intent.item_context],
+                amount_candidates=[
+                    *intent.amount_candidates,
+                    *narration_amounts,
+                ],
+                evidence_ids=evidence_ids,
+            )
+            clarified_any = True
+            continue
+
         if not bound_items:
             # 无卖方接受证据（AI 未发 grant）：意图按 actor 记为澄清，
             # 不再静默丢失（round-12 结构图问题的恢复入口）。
@@ -280,6 +313,7 @@ def repair_missing_economy_proposals(
                     *intent.amount_candidates,
                     *narration_amounts,
                 ],
+                evidence_ids=evidence_ids,
             )
             clarified_any = True
             continue
@@ -302,10 +336,18 @@ def repair_missing_economy_proposals(
                 payer_uid=intent.actor_uid,
                 item_candidates=bound_items,
                 amount_candidates=[*intent.amount_candidates, *narration_amounts],
+                evidence_ids=evidence_ids,
             )
             clarified_any = True
             continue
         if offer_amount is not None:
+            offer_evidence = collect_evidence_for_intent(
+                instance,
+                intent_actor_uid=intent.actor_uid,
+                intent_item_context=intent.item_context,
+                offer=offers[0],
+            )
+            evidence_ids = [*evidence_ids, *offer_evidence]
             evidence = (
                 item_bound_amounts[0]
                 if len(item_bound_amounts) == 1
@@ -321,6 +363,7 @@ def repair_missing_economy_proposals(
                     payer_uid=intent.actor_uid,
                     item_candidates=bound_items,
                     amount_candidates=sorted({evidence, offer_amount}),
+                    evidence_ids=evidence_ids,
                 )
                 clarified_any = True
                 continue
@@ -349,9 +392,22 @@ def repair_missing_economy_proposals(
                     *intent.amount_candidates,
                     *narration_amounts,
                 ],
+                evidence_ids=evidence_ids,
             )
             clarified_any = True
             continue
+
+        proposal_evidence_ids = collect_evidence_for_intent(
+            instance,
+            intent_actor_uid=intent.actor_uid,
+            intent_item_context=intent.item_context,
+            intent_amounts=intent.amount_candidates,
+            narration_amount=(
+                amount if amount_source == AMOUNT_SOURCE_NARRATION else None
+            ),
+            grant_items=bound_items,
+        )
+        evidence_ids = [*evidence_ids, *proposal_evidence_ids]
 
         proposals.append({
             "kind": "purchase",
@@ -363,6 +419,7 @@ def repair_missing_economy_proposals(
             "approval_policy": "payer",
             "source": "server_purchase_guard",
             "amount_source": amount_source,
+            "evidence_ids": evidence_ids,
         })
         # 合成提案消费该 actor 的 grant 作为唯一发货路径；这不是丢弃，
         # 不计入 dropped（dropped 只统计进澄清的 grant）。

--- a/src/engine/intent/evidence.py
+++ b/src/engine/intent/evidence.py
@@ -1,0 +1,143 @@
+"""Evidence layer: persist what was observed, never what is decided.
+
+证据层回答"系统看到了什么"。证据不是事实：不能直接修改状态、不能扣款、
+不能发货，只用于创建 proposal、辅助 GM 确认、恢复遗漏事件。任何证据都
+不携带权威性（``authority`` 恒为 False），权威状态只能由 proposal 经
+settlement 产生。
+
+```text
+Intent → collect evidence → evidence records → proposal / clarification
+```
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+MAX_EVIDENCE_HISTORY = 100
+
+# 证据可信度（方案约定）：merchant_offer 最高，player_action 次之，
+# narration 只作辅助。数值仅供 GM 界面排序展示，不参与任何自动判定。
+EVIDENCE_CONFIDENCE = {
+    "merchant_offer": 0.9,
+    "player_action": 0.8,
+    "narration": 0.7,
+    "grant": 0.6,
+}
+
+
+def evidence_collection(instance: Any) -> list[dict[str, Any]]:
+    economy = getattr(instance, "economy", None)
+    if not isinstance(economy, dict):
+        return []
+    entries = economy.setdefault("evidence", [])
+    if not isinstance(entries, list):
+        economy["evidence"] = []
+    return economy["evidence"]
+
+
+def record_evidence(
+    instance: Any,
+    *,
+    evidence_type: str,
+    source: str,
+    actor_uid: str = "",
+    item: str = "",
+    amount: int | None = None,
+    note: str = "",
+) -> dict[str, Any] | None:
+    """Append one evidence record and return it (audit-only, bounded)."""
+
+    entries = evidence_collection(instance)
+    evidence = {
+        "id": f"ev_{uuid4().hex}",
+        "type": str(evidence_type or "")[:40],
+        "run_id": str(getattr(instance, "run_id", "")),
+        "round": int(getattr(instance, "round_number", 0) or 0),
+        "actor_uid": str(actor_uid or "")[:64],
+        "item": str(item or "")[:120],
+        "amount": int(amount) if amount is not None else None,
+        "source": str(source or "")[:40],
+        "confidence": EVIDENCE_CONFIDENCE.get(str(source or ""), 0.5),
+        "authority": False,
+        "note": str(note or "")[:200],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    entries.append(evidence)
+    if len(entries) > MAX_EVIDENCE_HISTORY:
+        del entries[:-MAX_EVIDENCE_HISTORY]
+    return evidence
+
+
+def collect_evidence_for_intent(
+    instance: Any,
+    *,
+    intent_actor_uid: str,
+    intent_item_context: str,
+    intent_amounts: Iterable[int] | None = None,
+    narration_amount: int | None = None,
+    offer: dict[str, Any] | None = None,
+    grant_items: Iterable[str] | None = None,
+) -> list[str]:
+    """Persist every evidence piece found for one purchase intent.
+
+    返回证据 id 列表，供 proposal / clarification 挂 ``evidence_ids``，让
+    GM 处理时能看到完整证据链（玩家行动、叙事绑定、商家报价、AI grant
+    各自独立留痕）。
+    """
+
+    ids: list[str] = []
+    amounts = list(intent_amounts or [])
+    intent_amount = amounts[0] if len(amounts) == 1 else None
+    evidence = record_evidence(
+        instance,
+        evidence_type="purchase_intent",
+        source="player_action",
+        actor_uid=intent_actor_uid,
+        item=intent_item_context,
+        amount=intent_amount,
+        note=(
+            "行动自报金额多个候选" if len(amounts) > 1
+            else "" if intent_amount is not None
+            else "行动未含金额"
+        ),
+    )
+    if evidence is not None:
+        ids.append(evidence["id"])
+    if offer is not None:
+        offer_evidence = record_evidence(
+            instance,
+            evidence_type="merchant_offer_price",
+            source="merchant_offer",
+            actor_uid=intent_actor_uid,
+            item=str(offer.get("item_display") or ""),
+            amount=int(offer.get("amount", 0) or 0),
+            note=f"offer {offer.get('id') or ''}",
+        )
+        if offer_evidence is not None:
+            ids.append(offer_evidence["id"])
+    if narration_amount is not None:
+        narration_evidence = record_evidence(
+            instance,
+            evidence_type="narration_price",
+            source="narration",
+            actor_uid=intent_actor_uid,
+            item=intent_item_context,
+            amount=narration_amount,
+        )
+        if narration_evidence is not None:
+            ids.append(narration_evidence["id"])
+    for item in grant_items or ():
+        grant_evidence = record_evidence(
+            instance,
+            evidence_type="seller_grant",
+            source="grant",
+            actor_uid=intent_actor_uid,
+            item=str(item or ""),
+        )
+        if grant_evidence is not None:
+            ids.append(grant_evidence["id"])
+    return ids

--- a/src/engine/intent/evidence.py
+++ b/src/engine/intent/evidence.py
@@ -20,7 +20,8 @@ from uuid import uuid4
 MAX_EVIDENCE_HISTORY = 100
 
 # 证据可信度（方案约定）：merchant_offer 最高，player_action 次之，
-# narration 只作辅助。数值仅供 GM 界面排序展示，不参与任何自动判定。
+# narration 只作辅助。⚠️ 数值仅供 GM 界面排序展示——DO NOT use confidence
+# for authorization / auto-approval；任何授权判定必须走 proposal 状态机。
 EVIDENCE_CONFIDENCE = {
     "merchant_offer": 0.9,
     "player_action": 0.8,
@@ -37,6 +38,44 @@ def evidence_collection(instance: Any) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         economy["evidence"] = []
     return economy["evidence"]
+
+
+def _referenced_evidence_ids(instance: Any) -> set[str]:
+    """Evidence ids referenced by proposals or clarifications.
+
+    被引用的证据是审计链的一部分：GM 打开历史提案/澄清时依赖它们还原
+    价格来源，因此永不参与 trim 淘汰。
+    """
+
+    economy = getattr(instance, "economy", {})
+    if not isinstance(economy, dict):
+        return set()
+    referenced: set[str] = set()
+    for collection in ("proposals", "clarifications"):
+        for entry in economy.get(collection, []) or []:
+            if isinstance(entry, dict):
+                referenced.update(
+                    str(item) for item in (entry.get("evidence_ids") or []) if str(item)
+                )
+    return referenced
+
+
+def _trim_evidence(instance: Any, entries: list[dict[str, Any]]) -> None:
+    if len(entries) <= MAX_EVIDENCE_HISTORY:
+        return
+    referenced = _referenced_evidence_ids(instance)
+    kept: list[dict[str, Any]] = []
+    freed = 0
+    # 从旧到新扫描：未引用的旧证据先淘汰，被引用的与配额内的新证据保留。
+    for entry in entries:
+        entry_id = str(entry.get("id") or "")
+        if entry_id in referenced:
+            kept.append(entry)
+        elif freed < len(entries) - MAX_EVIDENCE_HISTORY:
+            freed += 1
+        else:
+            kept.append(entry)
+    entries[:] = kept
 
 
 def record_evidence(
@@ -67,8 +106,7 @@ def record_evidence(
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     entries.append(evidence)
-    if len(entries) > MAX_EVIDENCE_HISTORY:
-        del entries[:-MAX_EVIDENCE_HISTORY]
+    _trim_evidence(instance, entries)
     return evidence
 
 

--- a/src/engine/intent/parser.py
+++ b/src/engine/intent/parser.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable
 from src.engine.intent.models import PurchaseIntent
 
 PURCHASE_INTENT_RE = re.compile(
-    r"(?:买下|买了|购买|购入|买入|付费|付款|支付|缴纳|花费|给钱|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
+    r"(?:买下|买了|购买|购入|买入|买|付费|付款|支付|缴纳|花费|给钱|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
     re.IGNORECASE,
 )
 FREE_PURCHASE_RE = re.compile(r"(?:免费|无需付费|不用钱|免费领取|free|no charge)", re.IGNORECASE)

--- a/src/engine/intent/parser.py
+++ b/src/engine/intent/parser.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable
 from src.engine.intent.models import PurchaseIntent
 
 PURCHASE_INTENT_RE = re.compile(
-    r"(?:买下|买了|购买|购入|买入|付费|支付|缴纳|花费|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
+    r"(?:买下|买了|购买|购入|买入|付费|付款|支付|缴纳|花费|给钱|订购|租用|换购|purchase|buy|bought|pay|paid|spend)",
     re.IGNORECASE,
 )
 FREE_PURCHASE_RE = re.compile(r"(?:免费|无需付费|不用钱|免费领取|free|no charge)", re.IGNORECASE)
@@ -21,6 +21,14 @@ PURCHASE_CONFIRM_RE = re.compile(
     r"(?:成交|买了|买下|购买|确认购买|接受报价|就要这个|行|可以|同意|付钱|结账|"
     r"deal|accept|accepted|confirm|confirmed|buy it|take it|pay|yes|"
     r"成約|購入|承知|支払う|了解です|はい|了承)", re.IGNORECASE,
+)
+DEFERRED_PAYMENT_RE = re.compile(
+    r"(?:先[^。！？\n]{0,12}(?:拿|给|做|上)"
+    r"|赊账|记账|欠着|欠款"
+    r"|明天[^。！？\n]{0,8}付|改天[^。！？\n]{0,8}付"
+    r"|之后[^。！？\n]{0,8}付|回头[^。！？\n]{0,8}付"
+    r"|pay later|on credit|IOU)",
+    re.IGNORECASE,
 )
 PURCHASE_OFFER_RE = re.compile(
     r"(?:需要|需|售价|价格|费用|收费|cost|price|charge)", re.IGNORECASE,

--- a/src/migrations/instance.py
+++ b/src/migrations/instance.py
@@ -205,6 +205,7 @@ def rebind_imported_game_state_payload(
             "purchase_quotes",
             "merchant_offers",
             "clarifications",
+            "evidence",
         ):
             for item in economy.get(collection_name, []) or []:
                 if isinstance(item, dict):

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -38,6 +38,7 @@ from src.commands.economy_effects import (
 )
 from src.commands.state_items import append_key_item
 from src.commands.state_update_applier import StateUpdateApplier
+from src.engine.intent.evidence import record_evidence
 from src.engine.game_instance import GameInstance, GameRegistry, restore_players, _snapshot_players
 from src.llm.client import LLMResponse
 from src.llm.context_builder import build_context
@@ -2678,3 +2679,80 @@ def test_deferred_payment_intent_goes_to_clarification() -> None:
     assert clarification["reason"] == "DEFERRED_PAYMENT"
     assert clarification["payer_uid"] == "gm"
     assert clarification["evidence_ids"]
+
+
+def test_referenced_evidence_survives_trim() -> None:
+    """被 proposal/clarification 引用的证据不参与 trim 淘汰（审计链不断）。"""
+
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "掏30金币买下精钢剑"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    repair_unbacked_purchase(
+        instance, data, "霍根接过金币，转身取下那柄矮人精钢剑，递到你面前。",
+    )
+    proposal = data["state_update"]["economy_proposals"][0]
+    referenced_ids = set(proposal["evidence_ids"])
+    assert referenced_ids
+    # 模拟 applier 入队：引用关系进入 economy["proposals"] 后才受 trim 保护。
+    instance.economy.setdefault("proposals", []).append({
+        "id": "eco_placeholder", "evidence_ids": list(referenced_ids),
+    })
+    for _ in range(150):
+        record_evidence(instance, evidence_type="noise", source="narration")
+    surviving = {item["id"] for item in instance.economy["evidence"]}
+    assert referenced_ids <= surviving
+    assert len(instance.economy["evidence"]) <= 160
+
+
+def test_npc_dialogue_does_not_trigger_deferred_payment() -> None:
+    """NPC 台词里的 pay later 不触发赊账：只有玩家行动才产生意图。"""
+
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "买下龙牙匕首"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "龙牙匕首"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data,
+        "商人笑道：“you can pay tomorrow, no problem。”"
+        "龙牙匕首卖30金币，说罢把匕首递到你手里。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert not [
+        c for c in instance.economy.get("clarifications", [])
+        if c.get("reason") == "DEFERRED_PAYMENT"
+    ]
+
+
+def test_multi_quote_price_ambiguity_stays_fail_closed() -> None:
+    """单行动混入两个报价：按句绑定无法唯一 → AMBIGUOUS_PRICE 澄清。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "gm", "text": "我买那个500金币的龙牙匕首，旁边那个200金币的戒指也拿了"},
+    ]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "龙牙匕首"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "龙牙匕首500金，戒指200金。老板把两样都包了起来。",
+    )
+    assert (dropped, ambiguous) == (1, True)
+    assert not data["state_update"].get("economy_proposals")
+    clarification = instance.economy["clarifications"][0]
+    assert clarification["reason"] == "AMBIGUOUS_PRICE"
+    assert clarification["amount_candidates"] == [200, 500]
+
+
+def test_currency_labels_regression_custom_rule() -> None:
+    """自定义规则货币（灵石）经 label 投影参与证据与绑定。"""
+
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "掏30灵石买下丹药"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "丹药"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "丹药30灵石，掌柜收了钱把药递给你。",
+        currency_labels=["灵石"],
+    )
+    assert (dropped, ambiguous) == (0, False)
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["amount"] == 30
+    assert proposal["amount_source"] == "narration"

--- a/tests/test_run_lifecycle_economy.py
+++ b/tests/test_run_lifecycle_economy.py
@@ -2622,3 +2622,59 @@ def test_repair_binds_narration_price_per_item_sentence() -> None:
     proposal = data["state_update"]["economy_proposals"][0]
     assert proposal["amount"] == 30
     assert proposal["amount_source"] == "narration"
+
+
+def test_repair_persists_evidence_and_links_to_proposal() -> None:
+    """恢复层为每个意图留下证据链，proposal 挂 evidence_ids；证据无权威性。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "gm", "text": "掏30金币买下精钢剑"},
+    ]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根接过金币，转身取下那柄矮人精钢剑，递到你面前。",
+    )
+    assert (dropped, ambiguous) == (0, False)
+    evidence = instance.economy["evidence"]
+    types = {item["type"] for item in evidence}
+    assert "purchase_intent" in types
+    assert "seller_grant" in types
+    for item in evidence:
+        assert item["authority"] is False
+        assert item["id"].startswith("ev_")
+    proposal = data["state_update"]["economy_proposals"][0]
+    assert proposal["evidence_ids"]
+    assert set(proposal["evidence_ids"]) <= {item["id"] for item in evidence}
+
+
+def test_repair_twice_does_not_duplicate_proposals() -> None:
+    """重复 repair 不会重复创建提案（幂等）。"""
+
+    instance = _instance()
+    instance.action_queue = [{"user_id": "gm", "text": "买下治疗药水"}]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "治疗药水"}]}}
+    first = repair_unbacked_purchase(instance, data, "霍根收了2枚金币，把治疗药水递给你。")
+    second = repair_unbacked_purchase(instance, data, "霍根收了2枚金币，把治疗药水递给你。")
+    assert first == second == (0, False)
+    proposals = data["state_update"]["economy_proposals"]
+    assert len(proposals) == 1
+
+
+def test_deferred_payment_intent_goes_to_clarification() -> None:
+    """先拿货后付款：不合成立即结算的提案，进澄清由 GM/玩家安排。"""
+
+    instance = _instance()
+    instance.action_queue = [
+        {"user_id": "gm", "text": "这剑我先拿走，明天付款"},
+    ]
+    data = {"state_update": {"loot": [{"player": "gm", "item": "矮人精钢剑"}]}}
+    dropped, ambiguous = repair_unbacked_purchase(
+        instance, data, "霍根眯眼打量了你一番，还是把剑递了过来。",
+    )
+    assert (dropped, ambiguous) == (1, True)
+    assert not data["state_update"].get("economy_proposals")
+    clarification = instance.economy["clarifications"][0]
+    assert clarification["reason"] == "DEFERRED_PAYMENT"
+    assert clarification["payer_uid"] == "gm"
+    assert clarification["evidence_ids"]


### PR DESCRIPTION
> 叠层 PR：基于 #220（Intent Layer PR A）。#220 合并后 GitHub 自动改靶 main。

## 背景
按《Intent Layer 2.0》方案核心原则落地证据层：**AI 可以犯错，但系统不能失去证据**。此前 repair 的证据（价格来源、AI grant、报价命中）只存在于调用瞬间——round 12 结构图的价格信息就是这样永久丢失的。

## 改动
**1. `src/engine/intent/evidence.py` — Evidence Layer**
- 证据记录 `ev_*`：type（purchase_intent / narration_price / merchant_offer_price / seller_grant）、actor、item、amount、source、confidence（merchant_offer 0.9 > player_action 0.8 > narration 0.7 > grant 0.6，仅供 GM 展示排序）、note、时间戳
- **`authority` 恒为 False**：证据不能直接修改状态、不能扣款、不能发货，只用于创建 proposal、辅助 GM 确认、恢复遗漏事件
- bounded（保留最近 100 条），随存档持久化、随导入 rebind、旧存档 setdefault 兼容

**2. repair 全程留痕**
- 每个意图产生完整证据链（行动自报、叙事绑定价格、商家报价命中、AI grant 各自独立记录）
- proposal 挂 `evidence_ids`；clarification 挂 `evidence_ids`——GM 处理澄清时能看到价格从哪来（该案例中 round 9 手动补救时 30 金真实价丢失的问题从结构上堵住）
- `queue_proposal` 增加 `evidence_ids` 参数（applier 仅对 server_purchase_guard 来源透传，与 amount_source 同等防伪造边界）

**3. 赊账/延期付款意图（方案 Case 3）**
- 识别"先拿(货)后付 / 赊账 / 记账 / 欠着 / 明天付款 / pay later"等句式
- 命中 → 不合成立即结算的提案（即使 grant + 价格齐全），转 `DEFERRED_PAYMENT` 澄清 + 证据留档，交由 GM/玩家安排后再走标准确认链
- 意图动词表补充 付款/给钱（"明天付款"此前不产生意图）

## 不在本 PR
Event Card UI（§九）；AI fallback；规则化事件（commerce.payment.deferred 的利息/声望等规则化处理）。

## 风险面
- 证据为新增只读审计数据，无权限/结算语义；`economy["evidence"]` setdefault 兼容旧存档，无 schema 版本提升
- 赊账命中即 fail-closed（不当场成交），不影响正常购买链路
- repair 幂等性有测试锁定（重复 repair 不重复创建提案）

## 验证
- 新增 3 个测试：证据持久化与 authority=false + evidence_ids 链接、repair 幂等（重复 repair 单提案）、赊账意图 → DEFERRED_PAYMENT 澄清（含证据）
- `python -m pytest -q`：1879 passed / 1 skipped
- ruff ✅；`python -m mypy`（CI 同款 55 文件）✅