### PR TITLE
ci: portable package first in release asset order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,13 +193,13 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
           gh release upload "$tag" \
-            "dist/DiceFrame-${tag}-docker-update-linux-amd64.zip" \
-            --clobber
-          gh release upload "$tag" \
             "dist/DiceFrame-${tag}-windows-portable.zip" \
             --clobber
           gh release upload "$tag" \
             "dist/DiceFrame-${tag}-windows.zip" \
+            --clobber
+          gh release upload "$tag" \
+            "dist/DiceFrame-${tag}-docker-update-linux-amd64.zip" \
             --clobber
           gh release upload "$tag" \
             "dist/SHA256SUMS" \


### PR DESCRIPTION
调整 release.yml 资产上传顺序为用户视角：便携版 → 源码包 → Docker 更新 → SHA256SUMS。GitHub Release 资产按上传顺序展示，下个 tag 生效（不影响已发布的 v2.5.1-beta.4）。