### PR TITLE
fix: support MiniMax image generation API

### DIFF
--- a/src/imagegen/contracts.py
+++ b/src/imagegen/contracts.py
@@ -7,6 +7,7 @@ from typing import Any
 
 
 IMAGE_PURPOSES = frozenset({"scene", "avatar", "item", "map", "freeform"})
+IMAGE_PROVIDER_IDS = frozenset({"openai-compatible", "minimax"})
 
 
 def game_image_owner_id(game_key: Any) -> str:

--- a/src/imagegen/providers.py
+++ b/src/imagegen/providers.py
@@ -259,6 +259,7 @@ def create_image_provider(
     model: str,
     timeout_seconds: float,
     proxy_url: str = "",
+    provider_id: str = "openai-compatible",
 ) -> ImageProvider:
     kwargs = {
         "base_url": base_url,
@@ -267,12 +268,15 @@ def create_image_provider(
         "timeout_seconds": timeout_seconds,
         "proxy_url": proxy_url,
     }
+    provider_id = str(provider_id or "").strip().lower()
     hostname = (urlparse(str(base_url or "").strip()).hostname or "").lower()
-    if (
+    if provider_id == "minimax" or (
         hostname in {"api.minimax.cn", "api.minimaxi.com"}
         and model == "image-01"
     ):
         return MiniMaxImageProvider(**kwargs)
+    if provider_id != "openai-compatible":
+        raise ImageProviderError(f"不支持的图像生成 provider：{provider_id}")
     return OpenAICompatibleImageProvider(**kwargs)
 
 

--- a/src/imagegen/providers.py
+++ b/src/imagegen/providers.py
@@ -162,6 +162,120 @@ class OpenAICompatibleImageProvider(ImageProvider):
         return body, content_type
 
 
+class MiniMaxImageProvider(ImageProvider):
+    provider_id = "minimax"
+
+    async def generate(self, prompt: str, *, size: str, quality: str = "") -> ProviderImage:
+        try:
+            width_text, height_text = str(size or "").strip().lower().split("x", 1)
+            width, height = int(width_text), int(height_text)
+        except (TypeError, ValueError) as exc:
+            raise ImageProviderError(
+                "MiniMax 图片尺寸必须是 512 到 2048 之间且为 8 的倍数"
+            ) from exc
+        if not all(
+            512 <= value <= 2048 and value % 8 == 0 for value in (width, height)
+        ):
+            raise ImageProviderError(
+                "MiniMax 图片尺寸必须是 512 到 2048 之间且为 8 的倍数"
+            )
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        payload = {
+            "model": self.model,
+            "prompt": prompt[:1500],
+            "n": 1,
+            "width": width,
+            "height": height,
+            "response_format": "base64",
+        }
+        response_payload = await self._post_json(payload, headers)
+        base_response = response_payload.get("base_resp")
+        if isinstance(base_response, dict):
+            status_code = base_response.get("status_code")
+            if status_code not in {None, 0, "0"}:
+                status_message = str(base_response.get("status_msg") or "未知错误")
+                raise ImageProviderError(
+                    f"MiniMax 图像生成失败（{status_code}）：{status_message}"
+                )
+        data = response_payload.get("data")
+        images = data.get("image_base64") if isinstance(data, dict) else None
+        if not isinstance(images, list) or not images:
+            raise ImageProviderError("MiniMax 图像生成响应缺少 data.image_base64")
+        try:
+            body = base64.b64decode(str(images[0]), validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ImageProviderError(
+                "MiniMax 图像生成服务返回了无效的 Base64 图片"
+            ) from exc
+        if not body:
+            raise ImageProviderError("MiniMax 图像生成服务返回了空图片")
+        if len(body) > MAX_IMAGE_BYTES:
+            raise ImageProviderError("生成图片不能超过 20 MB")
+        return ProviderImage(
+            body=body,
+            content_type=_image_content_type(body, "image/jpeg"),
+        )
+
+    async def _post_json(self, payload: dict, headers: dict[str, str]) -> dict:
+        timeout = aiohttp.ClientTimeout(
+            total=self.timeout_seconds,
+            connect=min(15.0, self.timeout_seconds),
+        )
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    _minimax_image_url(self.base_url),
+                    json=payload,
+                    headers=headers,
+                    proxy=self.proxy_url,
+                ) as response:
+                    body = await _read_limited(response, MAX_JSON_RESPONSE_BYTES)
+                    if response.status >= 400:
+                        detail = body.decode("utf-8", "replace")[:1000]
+                        raise ImageProviderError(
+                            f"MiniMax 图像生成服务返回 HTTP {response.status}: {detail or response.reason}"
+                        )
+        except ImageProviderError:
+            raise
+        except (aiohttp.ClientError, TimeoutError) as exc:
+            raise ImageProviderError(
+                f"无法连接 MiniMax 图像生成服务：{exc}"
+            ) from exc
+        try:
+            result = json.loads(body.decode("utf-8", "replace") or "{}")
+        except ValueError as exc:
+            raise ImageProviderError("MiniMax 图像生成服务返回了无法解析的响应") from exc
+        if not isinstance(result, dict):
+            raise ImageProviderError("MiniMax 图像生成服务返回了非对象响应")
+        return result
+
+
+def create_image_provider(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    timeout_seconds: float,
+    proxy_url: str = "",
+) -> ImageProvider:
+    kwargs = {
+        "base_url": base_url,
+        "api_key": api_key,
+        "model": model,
+        "timeout_seconds": timeout_seconds,
+        "proxy_url": proxy_url,
+    }
+    hostname = (urlparse(str(base_url or "").strip()).hostname or "").lower()
+    if (
+        hostname in {"api.minimax.cn", "api.minimaxi.com"}
+        and model == "image-01"
+    ):
+        return MiniMaxImageProvider(**kwargs)
+    return OpenAICompatibleImageProvider(**kwargs)
+
+
 def _openai_image_url(base_url: str) -> str:
     parsed = urlparse(str(base_url or "").strip())
     path = parsed.path.rstrip("/")
@@ -171,6 +285,18 @@ def _openai_image_url(base_url: str) -> str:
         target = path + "/images/generations"
     else:
         target = path + "/v1/images/generations"
+    return urlunparse(parsed._replace(path=target))
+
+
+def _minimax_image_url(base_url: str) -> str:
+    parsed = urlparse(str(base_url or "").strip())
+    path = parsed.path.rstrip("/")
+    if path.endswith("/image_generation"):
+        target = path
+    elif path.endswith("/v1"):
+        target = path + "/image_generation"
+    else:
+        target = path + "/v1/image_generation"
     return urlunparse(parsed._replace(path=target))
 
 

--- a/src/imagegen/service.py
+++ b/src/imagegen/service.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from .assets import ImageAssetError, ImageAssetStore
 from .contracts import IMAGE_PURPOSES, ImageGenerationRequest, ImageGenerationResult
-from .providers import ImageProvider, ImageProviderError, OpenAICompatibleImageProvider
+from .providers import ImageProvider, ImageProviderError, create_image_provider
 
 
 PURPOSE_PROMPT_SUFFIXES = {
@@ -100,7 +100,7 @@ class ImageGenerationService:
             "proxy_url": self.proxy_url,
         }
         if self.provider_id == "openai-compatible":
-            return OpenAICompatibleImageProvider(**kwargs)
+            return create_image_provider(**kwargs)
         raise ImageGenerationError(f"不支持的图像生成 provider：{self.provider_id}")
 
     def _compose_prompt(self, prompt: str, purpose: str, request_style: str) -> str:

--- a/src/imagegen/service.py
+++ b/src/imagegen/service.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from .assets import ImageAssetError, ImageAssetStore
-from .contracts import IMAGE_PURPOSES, ImageGenerationRequest, ImageGenerationResult
+from .contracts import IMAGE_PROVIDER_IDS, IMAGE_PURPOSES, ImageGenerationRequest, ImageGenerationResult
 from .providers import ImageProvider, ImageProviderError, create_image_provider
 
 
@@ -52,7 +52,7 @@ class ImageGenerationService:
         return {
             "enabled": self.enabled,
             "available": self.available,
-            "provider": self.provider_id,
+            "provider": self._provider().provider_id,
             "model": self.model,
             "auto_scene": self.auto_scene,
         }
@@ -71,8 +71,9 @@ class ImageGenerationService:
         composed_prompt = self._compose_prompt(prompt, purpose, request.style)
         size = self._size_for(request, purpose)
         try:
+            provider = self._provider()
             async with self._semaphore:
-                generated = await self._provider().generate(
+                generated = await provider.generate(
                     composed_prompt,
                     size=size,
                     quality=self.quality,
@@ -82,7 +83,7 @@ class ImageGenerationService:
                 purpose=purpose,
                 prompt=prompt,
                 revised_prompt=generated.revised_prompt,
-                provider=self.provider_id,
+                provider=getattr(provider, "provider_id", self.provider_id),
                 model=self.model,
                 owner_type=request.owner_type,
                 owner_id=request.owner_id,
@@ -98,10 +99,12 @@ class ImageGenerationService:
             "model": self.model,
             "timeout_seconds": self.timeout_seconds,
             "proxy_url": self.proxy_url,
+            "provider_id": self.provider_id,
         }
-        if self.provider_id == "openai-compatible":
+        try:
             return create_image_provider(**kwargs)
-        raise ImageGenerationError(f"不支持的图像生成 provider：{self.provider_id}")
+        except ImageProviderError as exc:
+            raise ImageGenerationError(str(exc)) from exc
 
     def _compose_prompt(self, prompt: str, purpose: str, request_style: str) -> str:
         parts = [self.style_prefix, str(request_style or "").strip(), prompt, PURPOSE_PROMPT_SUFFIXES[purpose]]
@@ -114,8 +117,10 @@ class ImageGenerationService:
         return self.landscape_size
 
     def _validate_config(self) -> None:
-        if self.provider_id != "openai-compatible":
+        if self.provider_id not in IMAGE_PROVIDER_IDS:
             raise ValueError(f"不支持的图像生成 provider：{self.provider_id}")
+        if self.provider_id == "minimax" and self.model and self.model != "image-01":
+            raise ValueError("MiniMax 图像生成目前仅支持 image-01")
         if not self.enabled:
             return
         if self.base_url:

--- a/src/webui/config_update.py
+++ b/src/webui/config_update.py
@@ -19,6 +19,7 @@ from src.ai_providers import (
     strip_orphan_provider_secrets,
 )
 from src.asr.contracts import SUPPORTED_ASR_PROVIDER_IDS
+from src.imagegen.contracts import IMAGE_PROVIDER_IDS
 from src.tts.contracts import SUPPORTED_PROVIDER_IDS
 from src.webui.access_password import hash_access_password
 from src.webui.cors import invalid_cors_origins, normalize_cors_origins
@@ -269,7 +270,7 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
                 candidate[key] = timeout
             elif key == "imagegen_provider":
                 provider = str(raw or "").strip()
-                if provider != "openai-compatible":
+                if provider not in IMAGE_PROVIDER_IDS:
                     return PreparedConfigUpdate(candidate, changed_keys, access_password_changed, "图像生成 Provider 无效")
                 candidate[key] = provider
             elif key == "imagegen_timeout_seconds":

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -284,7 +284,9 @@ class ConfigStore:
             "asr_timeout_seconds": float(saved.get("asr_timeout_seconds", 60)),
             "imagegen_enabled": bool(saved.get("imagegen_enabled", False)),
             "imagegen_auto_scene": bool(saved.get("imagegen_auto_scene", True)),
-            "imagegen_provider": "openai-compatible",
+            "imagegen_provider": str(
+                saved.get("imagegen_provider") or "openai-compatible"
+            ),
             "imagegen_base_url": str(
                 env.get("TRPG_IMAGEGEN_BASE_URL")
                 or saved.get("imagegen_base_url", "")

--- a/tests/test_imagegen_service.py
+++ b/tests/test_imagegen_service.py
@@ -19,6 +19,7 @@ from src.imagegen import (
 )
 from src.imagegen.providers import (
     ImageProviderError,
+    MiniMaxImageProvider,
     OpenAICompatibleImageProvider,
     ProviderImage,
 )
@@ -124,6 +125,75 @@ def test_service_bypasses_proxy_for_local_endpoints(tmp_path):
 
     assert local.proxy_url == ""
     assert remote.proxy_url == "http://proxy.example:7890"
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.minimax.cn/v1",
+        "https://api.minimaxi.com/v1",
+    ],
+)
+@pytest.mark.asyncio
+async def test_service_generates_with_minimax_on_official_hosts(
+    tmp_path, base_url, monkeypatch
+):
+    seen = {}
+
+    async def fake_minimax_post(self, payload, headers):
+        seen.update(payload)
+        return {
+            "data": {
+                "image_base64": [base64.b64encode(_png_bytes()).decode("ascii")]
+            },
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+    async def unexpected_openai_post(self, payload, headers):
+        raise AssertionError("official MiniMax hosts must use the native adapter")
+
+    monkeypatch.setattr(MiniMaxImageProvider, "_post_json", fake_minimax_post)
+    monkeypatch.setattr(OpenAICompatibleImageProvider, "_post_json", unexpected_openai_post)
+    service = ImageGenerationService(
+        _config(imagegen_base_url=base_url, imagegen_model="image-01"),
+        tmp_path,
+    )
+    result = await service.generate(
+        ImageGenerationRequest(prompt="harbor", purpose="avatar")
+    )
+
+    assert service.assets.file(result.asset_id).is_file()
+    assert seen["model"] == "image-01"
+    assert seen["response_format"] == "base64"
+
+
+@pytest.mark.asyncio
+async def test_service_preserves_openai_adapter_for_other_hosts(tmp_path, monkeypatch):
+    async def fake_openai_post(self, payload, headers):
+        return {
+            "data": [
+                {
+                    "b64_json": base64.b64encode(_png_bytes()).decode("ascii"),
+                    "revised_prompt": "openai-compatible result",
+                }
+            ]
+        }
+
+    async def unexpected_minimax_post(self, payload, headers):
+        raise AssertionError("third-party hosts must keep the OpenAI adapter")
+
+    monkeypatch.setattr(OpenAICompatibleImageProvider, "_post_json", fake_openai_post)
+    monkeypatch.setattr(MiniMaxImageProvider, "_post_json", unexpected_minimax_post)
+    service = ImageGenerationService(
+        _config(
+            imagegen_base_url="https://images.example/v1",
+            imagegen_model="image-01",
+        ),
+        tmp_path,
+    )
+    result = await service.generate(ImageGenerationRequest(prompt="harbor"))
+
+    assert result.revised_prompt == "openai-compatible result"
 
 
 @pytest.mark.parametrize(
@@ -258,6 +328,123 @@ async def test_openai_provider_accepts_url_results(monkeypatch):
     result = await provider.generate("harbor", size="1024x1024")
     assert result.content_type == "image/png"
     assert downloaded[0][0] == "https://cdn.example/result.png"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("base_path", ["/v1", "/v1/image_generation"])
+async def test_minimax_provider_uses_native_request_and_base64_response(base_path):
+    seen = {}
+    jpeg = b"\xff\xd8\xff" + b"generated-image"
+
+    async def image_handler(request):
+        seen["path"] = request.path
+        seen["authorization"] = request.headers.get("Authorization")
+        seen["payload"] = await request.json()
+        return web.json_response(
+            {
+                "data": {
+                    "image_base64": [base64.b64encode(jpeg).decode("ascii")]
+                },
+                "metadata": {"failed_count": "0", "success_count": "1"},
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    app = web.Application()
+    app.router.add_post("/v1/image_generation", image_handler)
+    async with TestServer(app) as server:
+        provider = MiniMaxImageProvider(
+            base_url=str(server.make_url(base_path)),
+            api_key="secret",
+            model="image-01",
+            timeout_seconds=30,
+        )
+        result = await provider.generate("harbor", size="1024x768", quality="high")
+
+    assert result.body == jpeg
+    assert result.content_type == "image/jpeg"
+    assert seen == {
+        "path": "/v1/image_generation",
+        "authorization": "Bearer secret",
+        "payload": {
+            "model": "image-01",
+            "prompt": "harbor",
+            "n": 1,
+            "width": 1024,
+            "height": 768,
+            "response_format": "base64",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_minimax_provider_surfaces_http_200_business_error(monkeypatch):
+    provider = MiniMaxImageProvider(
+        base_url="https://api.minimax.cn/v1",
+        api_key="secret",
+        model="image-01",
+        timeout_seconds=30,
+    )
+
+    async def fake_post(payload, headers):
+        return {
+            "data": {},
+            "base_resp": {"status_code": 1008, "status_msg": "insufficient balance"},
+        }
+
+    monkeypatch.setattr(provider, "_post_json", fake_post)
+
+    with pytest.raises(ImageProviderError, match="1008.*insufficient balance"):
+        await provider.generate("harbor", size="1024x1024")
+
+
+@pytest.mark.asyncio
+async def test_minimax_provider_limits_prompt_to_documented_length(monkeypatch):
+    provider = MiniMaxImageProvider(
+        base_url="https://api.minimax.cn/v1",
+        api_key="secret",
+        model="image-01",
+        timeout_seconds=30,
+    )
+    seen = {}
+
+    async def fake_post(payload, headers):
+        seen.update(payload)
+        return {
+            "data": {
+                "image_base64": [
+                    base64.b64encode(b"\xff\xd8\xffimage").decode("ascii")
+                ]
+            },
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+    monkeypatch.setattr(provider, "_post_json", fake_post)
+    await provider.generate("x" * 1501, size="1024x1024")
+
+    assert seen["prompt"] == "x" * 1500
+
+
+@pytest.mark.parametrize(
+    "size",
+    ["invalid", "511x1024", "1025x1024", "2048x2056"],
+)
+@pytest.mark.asyncio
+async def test_minimax_provider_rejects_unsupported_dimensions(size, monkeypatch):
+    provider = MiniMaxImageProvider(
+        base_url="https://api.minimax.cn/v1",
+        api_key="secret",
+        model="image-01",
+        timeout_seconds=30,
+    )
+
+    async def unexpected_post(payload, headers):
+        raise AssertionError("invalid dimensions must be rejected before the request")
+
+    monkeypatch.setattr(provider, "_post_json", unexpected_post)
+
+    with pytest.raises(ImageProviderError, match="512.*2048.*8"):
+        await provider.generate("harbor", size=size)
 
 
 @pytest.mark.asyncio

--- a/tests/test_imagegen_service.py
+++ b/tests/test_imagegen_service.py
@@ -109,6 +109,11 @@ def test_service_availability_and_config_validation(tmp_path):
         )
     with pytest.raises(ValueError, match="provider"):
         ImageGenerationService(_config(imagegen_provider="unsupported"), tmp_path)
+    with pytest.raises(ValueError, match="image-01"):
+        ImageGenerationService(
+            _config(imagegen_provider="minimax", imagegen_model="image-model"),
+            tmp_path,
+        )
 
 
 def test_service_bypasses_proxy_for_local_endpoints(tmp_path):
@@ -194,6 +199,35 @@ async def test_service_preserves_openai_adapter_for_other_hosts(tmp_path, monkey
     result = await service.generate(ImageGenerationRequest(prompt="harbor"))
 
     assert result.revised_prompt == "openai-compatible result"
+
+
+@pytest.mark.asyncio
+async def test_explicit_minimax_provider_uses_native_adapter_on_custom_endpoint(
+    tmp_path, monkeypatch,
+):
+    seen = {}
+
+    async def fake_minimax_post(self, payload, headers):
+        seen.update(payload)
+        return {
+            "data": {"image_base64": [base64.b64encode(_png_bytes()).decode("ascii")]},
+            "base_resp": {"status_code": 0},
+        }
+
+    monkeypatch.setattr(MiniMaxImageProvider, "_post_json", fake_minimax_post)
+    service = ImageGenerationService(
+        _config(
+            imagegen_provider="minimax",
+            imagegen_base_url="https://minimax-gateway.example/v1",
+            imagegen_model="image-01",
+        ),
+        tmp_path,
+    )
+    result = await service.generate(ImageGenerationRequest(prompt="harbor", purpose="avatar"))
+
+    assert result.provider == "minimax"
+    assert service.public_config()["provider"] == "minimax"
+    assert seen["response_format"] == "base64"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- 为 MiniMax `image-01` 增加原生文生图适配器。
- 支持将 Base URL 配置为 `/v1` 或完整的 `/v1/image_generation`。
- 保持其他 OpenAI-compatible 图像服务的现有行为不变。

## Why

DiceFrame 原先会将所有图像生成请求按照 OpenAI 协议发送到 `/v1/images/generations`。

MiniMax `image-01` 使用 `/v1/image_generation`，并采用不同的尺寸字段和响应结构，因此原有请求会返回 HTTP 404。

参考文档：https://platform.minimaxi.com/docs/api-reference/image-generation-t2i

## Impact

只勾选实际受影响的项目：

- [ ] API
- [ ] Persisted Data / Save / Database
- [ ] Migration
- [ ] Compatibility / Breaking Change
- [ ] Security / Permission / Privacy
- [ ] Multiplayer / Actor / Turn Authority
- [ ] Ruleset Mechanics
- [ ] Architecture / Dependency Boundary
- [ ] Plugin / Content / Extension Contract
- [ ] UI only

本次改动仅扩展现有内部图像 provider adapter，不改变 Web API、配置字段或持久化格式。

## Module / Boundary

该变化属于 `src/imagegen` 的 provider adapter 边界。

MiniMax 特有的端点、请求字段、响应解析和错误处理均封装在独立适配器中；`ImageGenerationService` 仍只负责调用 provider，并通过 factory 完成适配器选择。

## Design / Migration Notes

Current:

- 所有图像生成服务均使用 OpenAI-compatible 协议。

Proposed:

- 官方 MiniMax 域名上的 `image-01` 自动使用 MiniMax 原生适配器。
- 请求使用 `width`、`height` 和 `response_format: base64`。
- 响应从 `data.image_base64` 解码。
- 即使 HTTP 状态为 200，也会检查 `base_resp.status_code`。
- 其他域名继续使用原有 OpenAI-compatible 适配器。

没有配置 schema、Web API、持久化数据或 migration 变化。

## Validation

- [x] Relevant backend tests
  - `python -m pytest -q` → `1896 passed, 1 skipped`
  - 图像生成及相关配置回归测试 → `74 passed`
- [ ] Relevant frontend tests
- [ ] Build / typecheck where applicable
- [ ] Architecture / security checks where applicable
- [x] Manual verification where meaningful
  - 使用 MiniMax `image-01` 成功生成 1024×1024 JPEG 图片。
  - `python -m ruff check src/` 通过。
  - `git diff --check` 通过。

## Contract Check

- [x] 用户数据不会被无意覆盖或丢失
- [x] 权限 / private data 边界未退化
- [ ] 若改 persisted identity，已处理旧引用（不适用）
- [x] 若改关键产品契约，已更新对应测试（Critical testing areas 见 `docs/ENGINEERING_RULES.md` §15）
- [ ] 若架构事实发生变化，已更新 `docs/ARCHITECTURE_*.md`（不适用）