### PR TITLE
refactor(config)!: 统一使用 AI 服务商引用，移除旧配置兼容

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,30 +8,11 @@ TZ=Asia/Shanghai
 # Optional public-content mirror. Leave blank to use the official source.
 DICEFRAME_CONTENT_BASE_URL=
 
-# LLM provider. Leave blank and configure in WebUI if preferred.
-TRPG_LLM_API_KEY=
-TRPG_LLM_BASE_URL=
-TRPG_LLM_MODEL=
-
-# Optional shared TTS engine. Keep provider=browser for zero-configuration system voices.
-# OpenAI-compatible works with both cloud APIs and local servers such as Kokoro-FastAPI.
-# edge-tts uses Microsoft Edge online voices for free: no key or base URL required,
-# voice like zh-CN-XiaoxiaoNeural, output is always MP3.
-TRPG_TTS_PROVIDER=browser
-TRPG_TTS_BASE_URL=
-TRPG_TTS_API_KEY=
-TRPG_TTS_MODEL=tts-1
-TRPG_TTS_VOICE=alloy
-TRPG_TTS_AUDIO_FORMAT=mp3
-
-# Optional cloud speech-to-text for voice input in the action composer.
-# OpenAI-compatible /v1/audio/transcriptions works with OpenAI whisper-1,
-# SiliconFlow SenseVoice, Groq and similar providers. Keep provider=disabled
-# to hide the microphone button entirely.
-TRPG_ASR_PROVIDER=disabled
-TRPG_ASR_BASE_URL=
-TRPG_ASR_API_KEY=
-TRPG_ASR_MODEL=whisper-1
+# Configure AI connections in WebUI -> AI Providers, then assign model routing.
+# AI capability-specific environment variables (TRPG_LLM_*, TRPG_EMBEDDING_*,
+# TRPG_TTS_*, TRPG_ASR_*, TRPG_IMAGEGEN_*) are no longer supported.
+# Browser and edge-tts voices need no provider reference; disabled ASR needs none.
+# Local compatible providers may leave their API key empty.
 
 # Optional fixed WebUI login token. Leave blank to auto-generate into data/access_token.txt.
 TRPG_ACCESS_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@
 - 不要把翻译后的 display name 当作 canonical identity。
 - Locale 不得无意改变 mechanics。
 - compatibility 应留在明确边界，不要散回正常业务逻辑。
+- **应用 AI 配置只支持新格式**：共享服务商目录 `ai_providers`、独立凭据 `ai_provider_key_<id>` 与能力级 `*_provider_ref`。禁止新增或恢复旧直填地址、密钥、API 格式及旧 AI 环境配置回退；旧字段更新必须明确拒绝，不自动迁移、不猜测创建服务商。
+- 缺失或失效的服务商引用应使对应能力保持未配置或停用，不能启用残留旧值；删除服务商时同步清理引用与凭据。TTS `browser`、`edge-tts` 和 ASR `disabled` 无需引用，本地服务商允许空密钥；需要远端地址的 TTS（含 `gpt-sovits`）与 ASR 必须解析有效引用。
+- 引用解析后传给服务的内部连接参数仍是合法运行时契约。此新配置规则不取消当前仍有效的存档、规则、插件和业务数据契约；移除其它兼容前须核实上游生产与投影路径，并覆盖拒绝或转换行为。
 - specific ruleset 不应反向污染 generic engine。
 - migration correctness > migration completeness；无法证明安全时 fail closed。
 - 系统模板不得无条件覆盖用户数据。

--- a/README.md
+++ b/README.md
@@ -125,14 +125,11 @@ python web_server.py
 http://localhost:18000
 ```
 
-第一次进入“管理 → 设置”，先在“模型接口”的“AI 服务商”中添加连接信息与模型目录，再到“模型配置”分配主模型、备用模型和各项 AI 能力；向量记忆不再使用独立选项卡，开关、输入上限和测试与向量模型配置放在一起。旧版已经保存的内联 API 地址、模型名和 API Key 仍可继续使用；环境变量方式也保持兼容：
+第一次进入“管理 → 设置”，先在“模型接口”的“AI 服务商”中添加连接信息与模型目录，再到“模型配置”分配主模型、备用模型和各项 AI 能力；向量记忆的开关、输入上限和测试与向量模型配置放在一起。
 
-```bash
-TRPG_LLM_API_KEY=your_key
-TRPG_LLM_BASE_URL=https://api.deepseek.com/v1
-TRPG_LLM_MODEL=deepseek-v4-pro
-python web_server.py
-```
+**AI 配置契约变更：**应用仅支持 `ai_providers` 与各能力的 `*_provider_ref`，API Key 使用 `ai_provider_key_<id>` 保存到敏感配置。旧能力级直填地址、密钥、API 格式及 `TRPG_LLM_*`、`TRPG_EMBEDDING_*`、`TRPG_TTS_*`、`TRPG_ASR_*`、`TRPG_IMAGEGEN_*` 环境入口不再启用，也不会自动迁移或创建服务商；旧配置更新请求返回 HTTP 400 `unsupported AI config fields`。请在设置页手动添加服务商并分配用途。
+
+主备模型、向量、生图及 OpenAI-compatible/GPT-SoVITS 语音只使用对应服务商引用；缺失或未知引用不会恢复旧地址和密钥，相关远程能力保持未配置。浏览器语音、edge-tts 和已禁用 ASR 无需服务商引用，本地服务商允许空 API Key。服务商连接测试可使用临时地址与密钥，但不会回退到旧能力级配置。
 
 Windows 下也可以双击 `web_ui.bat` 启动；它会检查依赖，并在缺少前端构建产物时自动构建。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -70,14 +70,11 @@ Open:
 http://localhost:18000
 ```
 
-On first launch, add the endpoint and model catalog under **Management → Settings → Model API → AI Providers**, then assign the main model, fallbacks, and optional AI roles under **Model routing**. Existing inline Base URL, model, and API key settings from older versions remain supported. Environment variables remain available as well:
+On first launch, add the endpoint and model catalog under **Management → Settings → Model API → AI Providers**, then assign the main model, fallbacks, and optional AI roles under **Model routing**.
 
-```bash
-TRPG_LLM_API_KEY=your_key
-TRPG_LLM_BASE_URL=https://api.openai.com/v1
-TRPG_LLM_MODEL=gpt-4.1-mini
-python web_server.py
-```
+**Breaking AI configuration contract:** connections use only `ai_providers` and capability `*_provider_ref` fields; keys are stored as `ai_provider_key_<id>` in secret storage. Legacy inline endpoints, keys, API formats and `TRPG_LLM_*`, `TRPG_EMBEDDING_*`, `TRPG_TTS_*`, `TRPG_ASR_*`, `TRPG_IMAGEGEN_*` environment inputs are no longer activated. No automatic migration or provider creation occurs. Updates containing old fields return HTTP 400 `unsupported AI config fields`; add providers and assign roles manually in Settings.
+
+Main/fallback models, embedding, images and OpenAI-compatible/GPT-SoVITS speech require their corresponding provider references. Missing or unknown references leave remote capabilities unconfigured and never revive old credentials. Browser voices, edge-tts and disabled ASR need no reference; local providers may use an empty API key. Provider connection tests accept temporary credentials without falling back to old capability settings.
 
 On Windows, `web_ui.bat` can start the Web UI. It checks Python runtime dependencies and, if `static-v2/` is missing, runs `npm ci` and `npm run build` inside `frontend-v2/` before starting `web_server.py`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,6 @@ services:
       # The image already defaults to Asia/Shanghai; set TZ in .env to change it.
       TZ: "${TZ:-Asia/Shanghai}"
 
-      TRPG_LLM_API_KEY: "${TRPG_LLM_API_KEY:-}"
-      TRPG_LLM_BASE_URL: "${TRPG_LLM_BASE_URL:-}"
-      TRPG_LLM_MODEL: "${TRPG_LLM_MODEL:-}"
-      TRPG_API_KEY: "${TRPG_API_KEY:-}"
-      TRPG_BASE_URL: "${TRPG_BASE_URL:-}"
-      TRPG_MODEL: "${TRPG_MODEL:-}"
       TRPG_ACCESS_TOKEN: "${TRPG_ACCESS_TOKEN:-}"
       TRPG_WEB_CORS_ORIGINS: "${TRPG_WEB_CORS_ORIGINS:-}"
       TRPG_PROXY_URL: "${TRPG_PROXY_URL:-}"

--- a/docs/ARCHITECTURE_CN.md
+++ b/docs/ARCHITECTURE_CN.md
@@ -13,6 +13,8 @@
 - `src/webui/access_control.py`：owner、Bot、SSE ticket、玩家分享与房间密码访问边界；
 - `src/webui/config_controller.py`：配置热重载事务和服务商连接测试。
 
+AI 应用配置仅使用 `ai_providers` 与各能力的 `*_provider_ref`；凭据以 `ai_provider_key_<id>` 单独保存。旧能力级直填地址/密钥/API 格式及 AI 能力环境入口不再参与解析，更新请求包含旧字段时明确拒绝，不自动迁移或创建服务商。缺失/未知引用不会激活残留配置；browser、edge-tts 与 disabled ASR 无需引用，本地服务商允许空 key。composition 解析后传给服务的内部 `*_base_url` / `*_api_key` 仍是有效运行时契约。
+
 模板同步和配置默认值迁移写盘只在真实 application startup 发生，不在导入独立 owner 模块时发生。配置热重载必须先完整构造候选 runtime，写盘成功后才替换活动状态；构造或写盘失败均保留旧 runtime。
 
 WebUI service 不直接导入另一个 service。跨域业务调用使用 composition root 注入的 callable/protocol；多域共同使用但不执行业务编排的纯契约和投影位于 `src/webui/` 根边界，例如生命周期事务上下文、规则草稿 shape 校验、休息只读投影及角色卡 identity/deduplication。类型检查专用导入不构成运行时依赖。

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -13,6 +13,8 @@ This document describes the current implementation, not a roadmap. The dependenc
 - `src/webui/access_control.py`: owner, Bot, SSE ticket, player-share, and room-password access control;
 - `src/webui/config_controller.py`: transactional runtime reload and provider connection tests.
 
+AI application configuration uses only `ai_providers` and capability `*_provider_ref` fields, with credentials stored separately as `ai_provider_key_<id>`. Legacy capability endpoints, keys, API formats and AI capability environment inputs are not resolved; updates containing removed fields are explicitly rejected, without migration or provider creation. Missing/unknown references cannot activate residual settings. Browser, edge-tts and disabled ASR need no reference, and local providers may use empty keys. Internal `*_base_url` / `*_api_key` fields produced by composition remain valid service runtime contracts.
+
 Template synchronization and migrated-default persistence happen only during real application startup, not when importing the individual owner modules. A runtime configuration reload fully constructs the candidate runtime before persistence and swaps active state only after persistence succeeds; construction or persistence failure keeps the previous runtime active.
 
 A WebUI service does not import another service directly. Cross-domain business calls use callables or protocols injected by the composition root. Pure contracts and projections shared by multiple domains but performing no business orchestration live at the `src/webui/` root boundary, including lifecycle transaction context, ruleset draft-shape validation, read-only rest projection, and character-card identity/deduplication. Type-checking-only imports are not runtime dependencies.

--- a/frontend-v2/src/api/types.ts
+++ b/frontend-v2/src/api/types.ts
@@ -1805,10 +1805,7 @@ export interface BotTokenResponse {
 }
 
 export interface AppConfig {
-  base_url?: string
   model?: string
-  api_format?: string
-  api_key?: SecretField
   ai_providers?: AiProvider[]
   llm_provider_ref?: string
   fallback1_provider_ref?: string
@@ -1818,18 +1815,10 @@ export interface AppConfig {
   asr_provider_ref?: string
   imagegen_provider_ref?: string
   fallback1_enabled?: boolean
-  fallback1_base_url?: string
-  fallback1_api_key?: SecretField
   fallback1_model?: string
-  fallback1_api_format?: string
   fallback2_enabled?: boolean
-  fallback2_base_url?: string
-  fallback2_api_key?: SecretField
   fallback2_model?: string
-  fallback2_api_format?: string
   embedding_enabled?: boolean
-  embedding_base_url?: string
-  embedding_api_key?: SecretField
   embedding_model?: string
   embedding_max_input?: number
   narrative_max_tokens?: number
@@ -1850,8 +1839,6 @@ export interface AppConfig {
   bot_token_source?: 'env' | 'generated'
   update_channel?: 'stable' | 'preview'
   tts_provider?: 'browser' | 'openai-compatible' | 'gpt-sovits' | 'edge-tts'
-  tts_base_url?: string
-  tts_api_key?: SecretField
   tts_model?: string
   tts_audio_format?: 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm'
   tts_default_voice?: string
@@ -1860,15 +1847,11 @@ export interface AppConfig {
   tts_timeout_seconds?: number
   tts_cache_mb?: number
   asr_provider?: 'disabled' | 'openai-compatible'
-  asr_base_url?: string
-  asr_api_key?: SecretField
   asr_model?: string
   asr_timeout_seconds?: number
   imagegen_enabled?: boolean
   imagegen_auto_scene?: boolean
   imagegen_provider?: 'openai-compatible'
-  imagegen_base_url?: string
-  imagegen_api_key?: SecretField
   imagegen_model?: string
   imagegen_square_size?: string
   imagegen_landscape_size?: string

--- a/frontend-v2/src/composables/useProviderModelSettings.ts
+++ b/frontend-v2/src/composables/useProviderModelSettings.ts
@@ -73,7 +73,7 @@ export const MODEL_ROUTING_CONFIG_KEYS = [
   'fallback1_enabled', 'fallback1_provider_ref', 'fallback1_model',
   'fallback2_enabled', 'fallback2_provider_ref', 'fallback2_model',
   'embedding_enabled', 'embedding_provider_ref', 'embedding_model', 'embedding_max_input',
-  'tts_provider', 'tts_provider_ref', 'tts_model',
+  'tts_provider', 'tts_provider_ref', 'tts_model', 'tts_default_voice',
   'asr_provider', 'asr_provider_ref', 'asr_model',
   'imagegen_enabled', 'imagegen_auto_scene', 'imagegen_provider_ref', 'imagegen_model',
   'imagegen_square_size', 'imagegen_landscape_size', 'imagegen_quality',
@@ -337,7 +337,7 @@ export function useProviderModelSettings(options: UseProviderModelSettingsOption
   }
 
   function providerDraftReady(draft: ProviderDraft): boolean {
-    return Boolean(draft.base_url.trim() && providerHasKey(draft))
+    return Boolean(draft.base_url.trim())
   }
 
   function setActiveProviderTestModel(value: string | number) {

--- a/frontend-v2/src/features/admin/SettingsView.vue
+++ b/frontend-v2/src/features/admin/SettingsView.vue
@@ -580,7 +580,7 @@ function providerReady(ref: unknown): boolean {
   const id = String(ref || '').trim()
   if (!id) return false
   const p = providerById(id)
-  return Boolean(p && p.base_url && p.api_key?.configured)
+  return Boolean(p && p.base_url)
 }
 const systemStatusItems = computed<SystemStatusItem[]>(() => {
   const c = store.config

--- a/frontend-v2/src/features/admin/settings/ModelRoutingPane.vue
+++ b/frontend-v2/src/features/admin/settings/ModelRoutingPane.vue
@@ -101,7 +101,7 @@ function setAsrProvider(value: string) {
       <NButton @click="emit('open-providers')">{{ t('providerAdd') }}</NButton>
     </div>
 
-    <div v-if="supported && providers.length" class="model-routing-grid" :class="{ 'is-saving': saving }">
+    <div v-if="supported" class="model-routing-grid" :class="{ 'is-saving': saving }">
       <article class="model-role-card model-role-card-main">
         <header><NIcon :component="SparklesOutline" /><div><h4>{{ t('modelRoleMain') }}</h4><p>{{ t('modelRoleMainHint') }}</p></div></header>
         <label><span>{{ t('providerName') }}</span><select :value="store.config.llm_provider_ref || ''" @change="setRoleProvider('llm_provider_ref', 'model', eventValue($event), 'chat')"><option value="">{{ t('modelRoutingChooseProvider') }}</option><option v-for="provider in providers" :key="provider.id" :value="provider.id">{{ provider.name || provider.id }}</option></select></label>

--- a/frontend-v2/src/i18n/messages/en.ts
+++ b/frontend-v2/src/i18n/messages/en.ts
@@ -299,7 +299,7 @@ export const en = {
   addedFromLibrary: 'Character added from library',
   apiSetupRequiredTitle: 'Configure the model API before creating an adventure',
   apiSetupRequiredHint: 'You can fill in the world and characters first. Complete the model settings before generating content or creating the adventure.',
-  apiSetupRequired: 'The model API is not configured. Open Settings and fill in the API key, base URL, and model.',
+  apiSetupRequired: 'The main model is not configured. Add an AI provider in Settings and assign a main model.',
   goToApiSettings: 'Open API Settings',
   overviewKicker: 'ADVENTURE ARCHIVE',
   recentAdventures: 'Recent / Active Adventures',

--- a/frontend-v2/src/i18n/messages/ja.ts
+++ b/frontend-v2/src/i18n/messages/ja.ts
@@ -299,7 +299,7 @@ export const ja = {
   addedFromLibrary: 'カードライブラリからキャラクターを追加しました',
   apiSetupRequiredTitle: '冒険を作成する前にモデル API の設定が必要です',
   apiSetupRequiredHint: '先に世界とキャラクターを入力できます。コンテンツを生成したり冒険を作成したりする前に、モデル設定を完了してください。',
-  apiSetupRequired: 'モデル API が未設定です。設定ページで API Key・Base URL・モデルを入力してください。',
+  apiSetupRequired: 'メインモデルが未設定です。設定ページで AI プロバイダーを追加し、メインモデルを選択してください。',
   goToApiSettings: 'API 設定へ',
   overviewKicker: 'ADVENTURE ARCHIVE',
   recentAdventures: '最近 / 進行中の冒険',

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -299,7 +299,7 @@ export const zhCN = {
   addedFromLibrary: '已从卡库添加角色',
   apiSetupRequiredTitle: '创建冒险前需要配置模型 API',
   apiSetupRequiredHint: '你可以先填写世界和角色；生成内容或正式创建冒险前，请先完成模型设置。',
-  apiSetupRequired: '尚未配置模型 API，请先前往设置页填写 API Key、Base URL 和模型。',
+  apiSetupRequired: '尚未配置主模型，请先在设置页添加 AI 服务商并选择主模型。',
   goToApiSettings: '前往 API 设置',
   overviewKicker: 'ADVENTURE ARCHIVE',
   recentAdventures: '最近 / 进行中的冒险',

--- a/frontend-v2/src/stores/useSettingsStore.ts
+++ b/frontend-v2/src/stores/useSettingsStore.ts
@@ -3,9 +3,7 @@ import { ref } from 'vue'
 import { ApiError, api, errorMessage, setAccessToken } from '@/api/client'
 import type { AppConfig, BotTokenResponse, TestResult } from '@/api/types'
 
-export type SecretKey =
-  | 'api_key' | 'embedding_api_key' | 'fallback1_api_key' | 'fallback2_api_key'
-  | 'bot_token' | 'napcat_token' | 'proxy_url' | 'tts_api_key' | 'asr_api_key' | 'imagegen_api_key'
+export type SecretKey = 'bot_token' | 'napcat_token' | 'proxy_url'
 // 已知 secret 之外还允许动态的服务商 key（ai_provider_key_<id>）
 export type SecretInput = Partial<Record<SecretKey, string>> & { [key: string]: string | undefined }
 
@@ -135,31 +133,14 @@ export const useSettingsStore = defineStore('settings', () => {
   async function test(kind: 'model' | 'embedding' | 'proxy'): Promise<TestResult> {
     const path = kind === 'proxy' ? '/test-proxy' : kind === 'embedding' ? '/test-embedding' : '/test-connection'
     const body: Record<string, unknown> = {
-      ...(config.value as Record<string, unknown>),
+      proxy_enabled: config.value.proxy_enabled,
+      ...collectSecrets(['proxy_url']),
     }
-    for (const key of ['api_key', 'embedding_api_key', 'fallback1_api_key', 'fallback2_api_key']) {
-      delete body[key]
-    }
-    Object.assign(body, collectSecrets(['api_key', 'embedding_api_key', 'fallback1_api_key', 'fallback2_api_key', 'proxy_url']))
-    if (kind === 'embedding') {
-      const providerRef = String(getConfigField('embedding_provider_ref') ?? '').trim()
-      if (providerRef) {
-        // 引用服务商时凭据由服务端从凭据库取（前端只有掩码）。
-        body.provider_id = providerRef
-        body.base_url = String(getConfigField('embedding_base_url') ?? '').trim()
-        body.model = String(getConfigField('embedding_model') ?? '').trim()
-        body.api_key = secrets.value.embedding_api_key?.trim() || ''
-      } else {
-        // The backend embedding test reads body.base_url/model/api_key for legacy compatibility.
-        // Map the embedding_* config fields and pass only plaintext secrets, not SecretField objects.
-        body.base_url = String(getConfigField('embedding_base_url') ?? '').trim()
-        body.model = String(getConfigField('embedding_model') ?? '').trim()
-        body.api_key = secrets.value.embedding_api_key?.trim() || secrets.value.api_key?.trim()
-      }
-    }
-    if (kind === 'model') {
-      const providerRef = String(getConfigField('llm_provider_ref') ?? '').trim()
-      if (providerRef) body.provider_id = providerRef
+    if (kind !== 'proxy') {
+      body.provider_id = String(kind === 'embedding'
+        ? config.value.embedding_provider_ref || '' : config.value.llm_provider_ref || '').trim()
+      body.model = String(kind === 'embedding'
+        ? config.value.embedding_model || '' : config.value.model || '').trim()
     }
     return api<TestResult>(path, { method: 'POST', body: JSON.stringify(body) })
   }

--- a/frontend-v2/src/utils/asr.ts
+++ b/frontend-v2/src/utils/asr.ts
@@ -24,7 +24,9 @@ export async function initializeAsr(force = false): Promise<void> {
     asrRuntimeConfig.value = {
       provider,
       ready: provider === 'openai-compatible' && Boolean(
-        String(config.asr_provider_ref || '').trim() || String(config.asr_base_url || '').trim(),
+        config.asr_provider_ref && config.ai_providers?.some(
+          item => item.id === config.asr_provider_ref && String(item.base_url || '').trim(),
+        ),
       ),
     }
   }).catch(() => {

--- a/frontend-v2/src/utils/modelConfiguration.ts
+++ b/frontend-v2/src/utils/modelConfiguration.ts
@@ -1,23 +1,13 @@
 import type { AppConfig } from '@/api/types'
 
-/**
- * The create screen must recognize both the legacy inline model fields and the
- * provider library introduced for shared model routing.
- */
+/** Model routing needs a saved provider and model; local providers may have no key. */
 export function isLlmConfigReady(config: Partial<AppConfig>): boolean {
   const providerRef = String(config.llm_provider_ref || '').trim()
-  if (providerRef) {
-    const provider = (config.ai_providers || []).find(item => item.id === providerRef)
-    return Boolean(
-      provider
-      && String(provider.base_url || '').trim()
-      && String(config.model || '').trim()
-      && provider.api_key?.configured,
-    )
-  }
+  const provider = (config.ai_providers || []).find(item => item.id === providerRef)
   return Boolean(
-    String(config.base_url || '').trim()
-    && String(config.model || '').trim()
-    && config.api_key?.configured,
+    providerRef
+    && provider
+    && String(provider.base_url || '').trim()
+    && String(config.model || '').trim(),
   )
 }

--- a/frontend-v2/tests/ModelRoutingPane.test.ts
+++ b/frontend-v2/tests/ModelRoutingPane.test.ts
@@ -1,0 +1,93 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { i18n } from '../src/i18n'
+import ModelRoutingPane from '../src/features/admin/settings/ModelRoutingPane.vue'
+import { useProviderModelSettings } from '../src/composables/useProviderModelSettings'
+import { useSettingsStore } from '../src/stores/useSettingsStore'
+import type { AppConfig } from '../src/api/types'
+
+const mocks = vi.hoisted(() => ({ api: vi.fn() }))
+vi.mock('../src/api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/api/client')>()
+  return { ...actual, api: mocks.api }
+})
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  mocks.api.mockReset()
+  i18n.global.locale.value = 'zh-CN'
+})
+
+function setup(config: Partial<AppConfig>, supported = true) {
+  const store = useSettingsStore()
+  store.config = structuredClone(config)
+  let persisted = structuredClone(config)
+  mocks.api.mockImplementation(async (_path: string, options?: RequestInit) => {
+    if (options?.method === 'POST') {
+      persisted = { ...persisted, ...JSON.parse(String(options.body)) }
+      return {}
+    }
+    return structuredClone(persisted)
+  })
+  const settings = useProviderModelSettings({
+    store,
+    t: key => key,
+    toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+  })
+  const wrapper = mount(ModelRoutingPane, {
+    props: {
+      supported, saving: false, embeddingTesting: false, embeddingResult: null,
+      onSave: () => { void settings.saveModelRouting() },
+    },
+    global: { plugins: [i18n], stubs: { HelpButton: true, TestResultCard: true } },
+  })
+  return { wrapper, store }
+}
+
+it('allows Edge TTS with an empty provider catalog and persists its default voice', async () => {
+  const { wrapper, store } = setup({
+    ai_providers: [], tts_provider: 'browser', tts_provider_ref: '',
+    tts_default_voice: 'alloy', asr_provider: 'disabled',
+  })
+  const ttsMode = wrapper.findAll('select').find(select => select.find('option[value="edge-tts"]').exists())
+  expect(ttsMode).toBeDefined()
+  await ttsMode!.setValue('edge-tts')
+  await wrapper.get('.model-routing-save').trigger('click')
+  await flushPromises()
+
+  const post = mocks.api.mock.calls.find(([, options]) => options?.method === 'POST')
+  expect(JSON.parse(post![1].body)).toMatchObject({
+    tts_provider: 'edge-tts', tts_provider_ref: '', tts_default_voice: 'zh-CN-XiaoxiaoNeural',
+  })
+  expect(store.config.tts_provider).toBe('edge-tts')
+  expect(store.config.tts_default_voice).toBe('zh-CN-XiaoxiaoNeural')
+  expect(store.config.ai_providers).toEqual([])
+  wrapper.unmount()
+})
+
+it('persists the OpenAI default voice after switching from Edge TTS', async () => {
+  const { wrapper, store } = setup({
+    ai_providers: [{ id: 'local', name: 'Local', base_url: 'http://localhost:8000/v1', api_format: 'openai', models: ['tts-1'] }],
+    tts_provider: 'edge-tts', tts_provider_ref: 'local', tts_model: 'tts-1',
+    tts_default_voice: 'zh-CN-XiaoxiaoNeural',
+  })
+  const ttsMode = wrapper.findAll('select').find(select => select.find('option[value="edge-tts"]').exists())!
+  await ttsMode.setValue('openai-compatible')
+  await wrapper.get('.model-routing-save').trigger('click')
+  await flushPromises()
+
+  const post = mocks.api.mock.calls.find(([, options]) => options?.method === 'POST')
+  expect(JSON.parse(post![1].body)).toMatchObject({
+    tts_provider: 'openai-compatible', tts_provider_ref: 'local', tts_default_voice: 'alloy',
+  })
+  expect(store.config.tts_default_voice).toBe('alloy')
+  wrapper.unmount()
+})
+
+it('keeps routing unavailable when the backend does not support provider configuration', () => {
+  const { wrapper } = setup({ ai_providers: [] }, false)
+  expect(wrapper.findAll('select')).toHaveLength(0)
+  expect(wrapper.get('.model-routing-save').attributes('disabled')).toBeDefined()
+  wrapper.unmount()
+})

--- a/frontend-v2/tests/asr.test.ts
+++ b/frontend-v2/tests/asr.test.ts
@@ -92,6 +92,11 @@ function detail(): GameDetail {
   }
 }
 
+const configuredAsr = {
+  asr_provider: 'openai-compatible', asr_provider_ref: 'local',
+  ai_providers: [{ id: 'local', name: 'Local', base_url: 'http://localhost:8000/v1', api_format: 'openai' }],
+}
+
 async function configureAsr(config: Record<string, unknown>): Promise<void> {
   mockedApi.mockReset()
   mockedApi.mockResolvedValue(config as never)
@@ -156,24 +161,26 @@ describe('voiceInputSupported', () => {
     expect(voiceInputSupported()).toBe(false)
   })
 
-  it('shows up once a cloud engine is configured with mic access', async () => {
+  it('does not enable a legacy inline ASR configuration', async () => {
     await configureAsr({ asr_provider: 'openai-compatible', asr_base_url: 'https://api.example.com/v1' })
-    expect(voiceInputSupported()).toBe(true)
+    expect(voiceInputSupported()).toBe(false)
   })
 
   it('recognizes ASR configured through the shared provider routing', async () => {
-    await configureAsr({ asr_provider: 'openai-compatible', asr_provider_ref: 'siliconflow' })
+    await configureAsr(configuredAsr)
     expect(voiceInputSupported()).toBe(true)
+    await configureAsr({ ...configuredAsr, asr_provider_ref: 'missing' })
+    expect(voiceInputSupported()).toBe(false)
   })
 
   it('stays hidden on insecure origins', async () => {
-    await configureAsr({ asr_provider: 'openai-compatible', asr_base_url: 'https://api.example.com/v1' })
+    await configureAsr(configuredAsr)
     Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true })
     expect(voiceInputSupported()).toBe(false)
   })
 
   it('stays hidden in P2P peer games where the upload cannot be relayed', async () => {
-    await configureAsr({ asr_provider: 'openai-compatible', asr_base_url: 'https://api.example.com/v1' })
+    await configureAsr(configuredAsr)
     mockedPeerClient.mockReturnValue({} as never)
     expect(voiceInputSupported()).toBe(false)
   })
@@ -257,7 +264,7 @@ describe('ActionComposer voice input', () => {
   })
 
   it('toggles recording from the mic button once the engine is ready', async () => {
-    await configureAsr({ asr_provider: 'openai-compatible', asr_base_url: 'https://api.example.com/v1' })
+    await configureAsr(configuredAsr)
     const wrapper = mount(ActionComposer, {
       global: { plugins: [i18n] },
       props: { gameKey: 'web|room|bot', userId: 'player-1', detail: detail() },

--- a/frontend-v2/tests/modelConfiguration.test.ts
+++ b/frontend-v2/tests/modelConfiguration.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { isLlmConfigReady } from '../src/utils/modelConfiguration'
 
 describe('isLlmConfigReady', () => {
-  it('accepts a configured legacy inline model', () => {
+  it('rejects legacy inline model configuration', () => {
     expect(isLlmConfigReady({
       base_url: 'https://api.example/v1',
       model: 'chat-model',
       api_key: { configured: true, masked: '***1234' },
-    })).toBe(true)
+    })).toBe(false)
   })
 
   it('accepts a configured provider-library model', () => {
@@ -24,7 +24,7 @@ describe('isLlmConfigReady', () => {
     })).toBe(true)
   })
 
-  it('rejects a provider reference without a configured provider key', () => {
+  it('accepts a provider without a key for local compatible services', () => {
     expect(isLlmConfigReady({
       llm_provider_ref: 'comfy',
       model: 'comfy-image',
@@ -35,7 +35,7 @@ describe('isLlmConfigReady', () => {
         api_format: 'openai',
         api_key: { configured: false, masked: '' },
       }],
-    })).toBe(false)
+    })).toBe(true)
   })
 
   it('does not fall back to inline fields when a provider reference is active', () => {

--- a/scripts/dev/run_cli_game.py
+++ b/scripts/dev/run_cli_game.py
@@ -19,12 +19,11 @@ from src.lorebook.matcher import KeywordMatcher
 from src.lorebook.store import LorebookStore
 from src.memory.delta import MemoryStore
 from src.commands.game_handler import GameHandler
+from src.ai_providers import resolve_provider
+from src.network_proxy import effective_proxy_url
+from src.webui.runtime_config import ConfigStore, RuntimePaths
 
-# ---------- 配置（从环境变量或默认值） ----------
-
-API_KEY = os.getenv("TRPG_LLM_API_KEY", os.getenv("TRPG_API_KEY", ""))
-BASE_URL = os.getenv("TRPG_LLM_BASE_URL", os.getenv("TRPG_BASE_URL", "https://api.deepseek.com/v1"))
-MODEL = os.getenv("TRPG_LLM_MODEL", os.getenv("TRPG_MODEL", "deepseek-v4-pro"))
+# ---------- 配置（与 WebUI 共用服务商配置契约） ----------
 DATA_DIR = Path(os.getenv("TRPG_DATA_DIR", str(ROOT / "data")))
 
 # 颜色输出
@@ -48,24 +47,28 @@ def print_warn(text: str) -> None:
 
 async def main() -> None:
     print(f"{BOLD}TRPG 独立运行器{RESET}")
-    print(f"模型: {MODEL}  |  数据目录: {DATA_DIR}")
+    config = ConfigStore(RuntimePaths.from_root(ROOT, os.environ), os.environ).load().state
+    provider = resolve_provider(config, config.get("llm_provider_ref", ""))
+    model = str(config.get("model") or "").strip()
+    if not provider or not provider["base_url"] or not model:
+        print("请先在 WebUI 的 AI 服务商与模型配置中设置主模型。")
+        return
+    print(f"模型: {model}  |  数据目录: {DATA_DIR}")
     print()
-
-    if not API_KEY:
-        api_key = input("请输入 API Key（或设置环境变量 TRPG_API_KEY）: ").strip()
-        if not api_key:
-            print("未提供 API Key，退出。")
-            return
-    else:
-        api_key = API_KEY
 
     # 初始化模块
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     providers = [ProviderConfig(
-        provider_name="default", base_url=BASE_URL,
-        api_key=api_key, model_name=MODEL,
+        provider_name="default", base_url=provider["base_url"],
+        api_key=provider["api_key"], model_name=model, api_format=provider["api_format"],
     )]
-    llm_client = LLMClient(providers=providers, default="default")
+    llm_client = LLMClient(
+        providers=providers,
+        default="default",
+        proxy_url=effective_proxy_url(
+            bool(config.get("proxy_enabled")), config.get("proxy_url", ""),
+        ),
+    )
 
     lorebook_store = LorebookStore(DATA_DIR / "lorebook.db")
     lorebook_store.open()

--- a/src/ai_providers.py
+++ b/src/ai_providers.py
@@ -3,7 +3,7 @@
 服务商元数据（名称/Base URL/api 格式）是普通配置，API Key 以
 `ai_provider_key_<id>` 的扁平 secret 形式存储，随现有 secrets.json 管线落盘。
 各能力（LLM 主/备、embedding、TTS、ASR、生图）通过 `*_provider_ref` 引用服务商；
-引用为空时回退既有的内联配置键，保证旧配置零改动。
+旧能力级直填配置与环境入口不受支持；引用缺失时能力保持未配置。
 """
 
 from __future__ import annotations
@@ -19,6 +19,16 @@ _MODEL_CAPABILITIES = frozenset({"chat", "image", "embedding", "tts", "asr"})
 PROVIDER_REF_KEYS = frozenset({
     "llm_provider_ref", "fallback1_provider_ref", "fallback2_provider_ref",
     "embedding_provider_ref", "tts_provider_ref", "asr_provider_ref", "imagegen_provider_ref",
+})
+
+# 已移除的公开配置入口。只用于明确拒绝请求和过滤残留，不参与运行时解析。
+UNSUPPORTED_AI_CONFIG_KEYS = frozenset({
+    "base_url", "api_key", "api_format",
+    "fallback1_base_url", "fallback1_api_key", "fallback1_api_format",
+    "fallback2_base_url", "fallback2_api_key", "fallback2_api_format",
+    "embedding_base_url", "embedding_api_key",
+    "tts_base_url", "tts_api_key", "asr_base_url", "asr_api_key",
+    "imagegen_base_url", "imagegen_api_key",
 })
 
 # 路由键 -> 该路由要求的模型能力。只对明确的手动覆盖做协调，
@@ -116,6 +126,12 @@ def resolve_provider(config: dict[str, Any], ref: str) -> dict[str, str] | None:
     return None
 
 
+def is_llm_config_ready(config: dict[str, Any]) -> bool:
+    """主模型需要有效引用、地址和模型；本地服务商可以不提供 API Key。"""
+    provider = resolve_provider(config, config.get("llm_provider_ref", ""))
+    return bool(provider and provider["base_url"] and str(config.get("model") or "").strip())
+
+
 def provider_secret_keys_for(providers: list[dict[str, Any]]) -> set[str]:
     return {provider_secret_key(entry["id"]) for entry in providers}
 
@@ -129,7 +145,7 @@ def strip_orphan_provider_secrets(candidate: dict[str, Any]) -> None:
 
 
 def strip_dangling_provider_refs(candidate: dict[str, Any]) -> None:
-    """把指向已删除服务商的引用键清空，运行时回退内联配置。"""
+    """把指向已删除服务商的引用键清空，使对应能力保持未配置。"""
     known = {str(entry.get("id") or "") for entry in candidate.get("ai_providers") or []}
     for key in PROVIDER_REF_KEYS:
         ref = str(candidate.get(key) or "").strip()

--- a/src/common_factory.py
+++ b/src/common_factory.py
@@ -81,7 +81,7 @@ def create_trpg_subsystems(
     embedding_client = None
     if embedding_enabled and embedding_base_url:
         from src.memory.embedding import EmbeddingClient
-        emb_key = embedding_api_key or providers[0].api_key if providers else ""
+        emb_key = embedding_api_key
         embedding_client = EmbeddingClient(
             embedding_base_url, emb_key, embedding_model or "nomic-embed-text",
             max_input_override=embedding_max_input,

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -703,8 +703,6 @@ class WebAPI:
             missing.append("base_url")
         if not str(getattr(provider, "model_name", "") or "").strip():
             missing.append("model")
-        if not str(getattr(provider, "api_key", "") or "").strip():
-            missing.append("api_key")
         return {
             "ready": not missing,
             "missing": missing,
@@ -718,10 +716,10 @@ class WebAPI:
             return None
         english = str(language or "").lower().startswith("en")
         message = (
-            "The model API is not configured. Open Settings and fill in the API key, "
-            "base URL, and model before continuing."
+            "The main model is not configured. Add an AI provider in Settings "
+            "and assign a main model before continuing."
             if english
-            else "尚未配置模型 API，请先前往设置页填写 API Key、Base URL 和模型。"
+            else "尚未配置主模型，请先在设置页添加 AI 服务商并选择主模型。"
         )
         return {
             "ok": False,

--- a/src/webui/bootstrap.py
+++ b/src/webui/bootstrap.py
@@ -73,13 +73,10 @@ class WebUIBootstrap:
 
     async def embed_pending_memories(self, app: web.Application) -> None:
         state = self.dependencies.state
-        if not (
-            state.get("embedding_enabled", False)
-            and state.get("embedding_base_url", "")
-        ):
+        if not state.get("embedding_enabled", False):
             return
         subsystems: TRPGSubsystems | None = app.get("subsystems")
-        if not subsystems or not subsystems.memory_store:
+        if not subsystems or not subsystems.memory_store or not subsystems.memory_store.embedding_client:
             return
         try:
             for instance in subsystems.registry.list_all():

--- a/src/webui/composition.py
+++ b/src/webui/composition.py
@@ -21,7 +21,6 @@ from src.migrations.config import DEFAULT_NARRATIVE_MAX_TOKENS
 from src.network_proxy import effective_proxy_url
 from src.tts import SpeechService
 from src.webui.api import WebAPI
-from src.webui.config_update import normalize_api_format
 
 
 @dataclass(frozen=True)
@@ -77,9 +76,9 @@ class RuntimeComposition:
             main_api_key = main_provider["api_key"]
             main_api_format = main_provider["api_format"]
         else:
-            main_base_url = runtime_config["base_url"]
-            main_api_key = runtime_config["api_key"]
-            main_api_format = normalize_api_format(runtime_config.get("api_format"))
+            main_base_url = ""
+            main_api_key = ""
+            main_api_format = "openai"
         providers = [
             ProviderConfig(
                 provider_name="default",
@@ -96,24 +95,14 @@ class RuntimeComposition:
                 runtime_config,
                 runtime_config.get(f"fallback{index}_provider_ref", ""),
             )
-            fallback_base_url = (
-                fallback_provider["base_url"]
-                if fallback_provider
-                else runtime_config.get(f"fallback{index}_base_url", "")
-            )
+            if not fallback_provider:
+                continue
+            fallback_base_url = fallback_provider["base_url"]
             fallback_model = runtime_config.get(f"fallback{index}_model", "")
             if not (fallback_base_url and fallback_model):
                 continue
-            if fallback_provider:
-                fallback_api_key = fallback_provider["api_key"]
-                fallback_api_format = fallback_provider["api_format"]
-            else:
-                fallback_api_key = (
-                    runtime_config.get(f"fallback{index}_api_key") or main_api_key
-                )
-                fallback_api_format = normalize_api_format(
-                    runtime_config.get(f"fallback{index}_api_format")
-                )
+            fallback_api_key = fallback_provider["api_key"]
+            fallback_api_format = fallback_provider["api_format"]
             providers.append(
                 ProviderConfig(
                     provider_name=f"fallback{index}",
@@ -133,10 +122,8 @@ class RuntimeComposition:
             embedding_base_url = embedding_provider["base_url"]
             embedding_api_key = embedding_provider["api_key"]
         else:
-            embedding_base_url = runtime_config.get("embedding_base_url", "")
-            embedding_api_key = (
-                runtime_config.get("embedding_api_key") or main_api_key
-            )
+            embedding_base_url = ""
+            embedding_api_key = ""
         embedding_enabled = bool(
             runtime_config.get("embedding_enabled", False) and embedding_base_url
         )
@@ -182,21 +169,22 @@ class RuntimeComposition:
     def config_with_resolved_api_refs(config: dict) -> dict:
         """Resolve shared providers into capability-specific runtime keys."""
         resolved = dict(config)
-        tts_provider = resolve_provider(config, config.get("tts_provider_ref", ""))
-        if tts_provider:
-            resolved["tts_base_url"] = tts_provider["base_url"]
-            resolved["tts_api_key"] = tts_provider["api_key"]
-        asr_provider = resolve_provider(config, config.get("asr_provider_ref", ""))
-        if asr_provider:
-            resolved["asr_base_url"] = asr_provider["base_url"]
-            resolved["asr_api_key"] = asr_provider["api_key"]
-        imagegen_provider = resolve_provider(
-            config,
-            config.get("imagegen_provider_ref", ""),
-        )
-        if imagegen_provider and imagegen_provider.get("api_format") == "openai":
-            resolved["imagegen_base_url"] = imagegen_provider["base_url"]
-            resolved["imagegen_api_key"] = imagegen_provider["api_key"]
+        # Always overwrite these internal fields: residual public settings are never credentials.
+        for capability in ("tts", "asr", "imagegen"):
+            provider = resolve_provider(config, config.get(f"{capability}_provider_ref", ""))
+            if capability == "imagegen" and provider and provider["api_format"] != "openai":
+                provider = None
+            resolved[f"{capability}_base_url"] = provider["base_url"] if provider else ""
+            resolved[f"{capability}_api_key"] = provider["api_key"] if provider else ""
+            if provider and provider["base_url"]:
+                continue
+            # Unconfigured installations must still start so the owner can configure them.
+            if capability == "tts" and config.get("tts_provider") in {"openai-compatible", "gpt-sovits"}:
+                resolved["tts_provider"] = "browser"
+            elif capability == "asr":
+                resolved["asr_provider"] = "disabled"
+            elif capability == "imagegen":
+                resolved["imagegen_enabled"] = False
         return resolved
 
     def make_api(

--- a/src/webui/config_controller.py
+++ b/src/webui/config_controller.py
@@ -244,8 +244,7 @@ class ConfigController:
                         exc_info=True,
                     )
         embedding_now = state.get("embedding_enabled", False) and bool(
-            state.get("embedding_base_url", "")
-            or resolve_provider(state, state.get("embedding_provider_ref", ""))
+            resolve_provider(state, state.get("embedding_provider_ref", ""))
         )
         if model_runtime_changed and embedding_now and subsystems is not None:
             try:
@@ -350,15 +349,9 @@ class ConfigController:
                 body.get("api_format") or provider["api_format"]
             )
         else:
-            base_url = clean_text_value(body.get("base_url")) or state.get(
-                "base_url", ""
-            )
-            api_key = clean_text_value(body.get("api_key")) or state.get(
-                "api_key", ""
-            )
-            api_format = normalize_api_format(
-                body.get("api_format") or state.get("api_format")
-            )
+            base_url = clean_text_value(body.get("base_url"))
+            api_key = clean_text_value(body.get("api_key"))
+            api_format = normalize_api_format(body.get("api_format"))
         if not self.is_safe_external_url(base_url):
             return web.json_response(
                 {"ok": False, "error": "base_url 非法或不允许"},
@@ -442,11 +435,7 @@ class ConfigController:
             api_key = clean_text_value(body.get("api_key")) or provider["api_key"]
         else:
             base_url = clean_text_value(body.get("base_url"))
-            api_key = (
-                clean_text_value(body.get("api_key"))
-                or state.get("embedding_api_key")
-                or state.get("api_key", "")
-            )
+            api_key = clean_text_value(body.get("api_key"))
         model = clean_text_value(body.get("model")) or "nomic-embed-text"
         if not self.is_safe_external_url(base_url):
             return web.json_response(
@@ -505,7 +494,8 @@ class ConfigController:
                 {"ok": False, "error": "代理地址仅支持 http:// 或 https://"},
                 status=400,
             )
-        url = str(state.get("base_url") or "").strip().rstrip("/")
+        provider = resolve_provider(state, state.get("llm_provider_ref", ""))
+        url = str(provider["base_url"] if provider else "").strip().rstrip("/")
         if not self.is_safe_external_url(url):
             return web.json_response(
                 {"ok": False, "error": "请先配置有效的模型服务地址"},

--- a/src/webui/config_update.py
+++ b/src/webui/config_update.py
@@ -12,6 +12,7 @@ from typing import Any
 from src.network_proxy import effective_proxy_url, is_supported_proxy_url
 from src.ai_providers import (
     PROVIDER_REF_KEYS,
+    UNSUPPORTED_AI_CONFIG_KEYS,
     is_provider_secret_key,
     normalize_ai_providers,
     reconcile_model_capability_routes,
@@ -25,25 +26,23 @@ from src.webui.access_password import hash_access_password
 from src.webui.cors import invalid_cors_origins, normalize_cors_origins
 
 SECRET_CONFIG_KEYS = frozenset({
-    "api_key", "embedding_api_key", "fallback1_api_key", "fallback2_api_key",
-    "access_token", "bot_token", "napcat_token", "tts_api_key", "asr_api_key", "imagegen_api_key",
+    "access_token", "bot_token", "napcat_token",
 })
 STRING_CONFIG_KEYS = frozenset({
-    "base_url", "model", "embedding_base_url", "embedding_model", "web_cors_origins",
-    "fallback1_base_url", "fallback1_model", "fallback2_base_url", "fallback2_model",
+    "model", "embedding_model", "web_cors_origins",
+    "fallback1_model", "fallback2_model",
     "public_base_url", "napcat_host", "napcat_connection_id",
-    "tts_base_url", "tts_model", "tts_default_voice", "tts_gm_voice", "tts_player_voice",
-    "asr_base_url", "asr_model",
-    "imagegen_base_url", "imagegen_model", "imagegen_square_size",
+    "tts_model", "tts_default_voice", "tts_gm_voice", "tts_player_voice",
+    "asr_model",
+    "imagegen_model", "imagegen_square_size",
     "imagegen_landscape_size", "imagegen_quality", "imagegen_style_prefix",
     *PROVIDER_REF_KEYS,
 })
-API_FORMAT_KEYS = frozenset({"api_format", "fallback1_api_format", "fallback2_api_format"})
 CONFIG_KEYS = (
-    "api_key", "base_url", "model", "api_format", "web_port", "web_cors_origins", "embedding_enabled",
-    "embedding_base_url", "embedding_model", "embedding_api_key", "embedding_max_input",
-    "fallback1_enabled", "fallback1_base_url", "fallback1_model", "fallback1_api_format", "fallback1_api_key",
-    "fallback2_enabled", "fallback2_base_url", "fallback2_model", "fallback2_api_format", "fallback2_api_key",
+    "model", "web_port", "web_cors_origins", "embedding_enabled",
+    "embedding_model", "embedding_max_input",
+    "fallback1_enabled", "fallback1_model",
+    "fallback2_enabled", "fallback2_model",
     "narrative_max_tokens", "character_gen_max_tokens", "summary_max_tokens", "brief_max_tokens",
     "analysis_max_tokens", "text_gen_max_tokens", "proxy_enabled", "proxy_url", "public_base_url", "access_token",
     "qq_bot_enabled", "napcat_host", "napcat_port", "napcat_token", "napcat_heartbeat_sec",
@@ -52,21 +51,21 @@ CONFIG_KEYS = (
     "napcat_chat_filter_enabled", "napcat_show_dropped_logs", "napcat_group_list_mode", "napcat_group_list",
     "napcat_private_list_mode", "napcat_private_list", "napcat_blocked_users", "napcat_block_official_bots",
     "update_channel",
-    "tts_provider", "tts_base_url", "tts_api_key", "tts_model", "tts_audio_format",
+    "tts_provider", "tts_model", "tts_audio_format",
     "tts_default_voice", "tts_gm_voice", "tts_player_voice", "tts_timeout_seconds", "tts_cache_mb",
-    "asr_provider", "asr_base_url", "asr_api_key", "asr_model", "asr_timeout_seconds",
-    "imagegen_enabled", "imagegen_auto_scene", "imagegen_provider", "imagegen_base_url",
-    "imagegen_api_key", "imagegen_model", "imagegen_square_size", "imagegen_landscape_size",
+    "asr_provider", "asr_model", "asr_timeout_seconds",
+    "imagegen_enabled", "imagegen_auto_scene", "imagegen_provider",
+    "imagegen_model", "imagegen_square_size", "imagegen_landscape_size",
     "imagegen_quality", "imagegen_style_prefix", "imagegen_timeout_seconds", "test_timeout_seconds",
     "economy_auto_reward_enabled", "economy_auto_reward_gold_cap",
     "model_request_timeout_seconds",
     "ai_providers", *PROVIDER_REF_KEYS,
 )
 MODEL_RUNTIME_CONFIG_KEYS = frozenset({
-    "api_key", "base_url", "model", "api_format",
-    "embedding_enabled", "embedding_base_url", "embedding_model", "embedding_api_key", "embedding_max_input",
-    "fallback1_enabled", "fallback1_base_url", "fallback1_model", "fallback1_api_format", "fallback1_api_key",
-    "fallback2_enabled", "fallback2_base_url", "fallback2_model", "fallback2_api_format", "fallback2_api_key",
+    "model",
+    "embedding_enabled", "embedding_model", "embedding_max_input",
+    "fallback1_enabled", "fallback1_model",
+    "fallback2_enabled", "fallback2_model",
     "narrative_max_tokens", "summary_max_tokens", "brief_max_tokens", "analysis_max_tokens",
     "model_request_timeout_seconds",
     "proxy_enabled", "proxy_url",
@@ -75,11 +74,11 @@ MODEL_RUNTIME_CONFIG_KEYS = frozenset({
 })
 API_RUNTIME_CONFIG_KEYS = frozenset({
     "character_gen_max_tokens", "text_gen_max_tokens",
-    "tts_provider", "tts_base_url", "tts_api_key", "tts_model", "tts_audio_format",
+    "tts_provider", "tts_model", "tts_audio_format",
     "tts_default_voice", "tts_gm_voice", "tts_player_voice", "tts_timeout_seconds", "tts_cache_mb",
-    "asr_provider", "asr_base_url", "asr_api_key", "asr_model", "asr_timeout_seconds",
-    "imagegen_enabled", "imagegen_auto_scene", "imagegen_provider", "imagegen_base_url",
-    "imagegen_api_key", "imagegen_model", "imagegen_square_size", "imagegen_landscape_size",
+    "asr_provider", "asr_model", "asr_timeout_seconds",
+    "imagegen_enabled", "imagegen_auto_scene", "imagegen_provider",
+    "imagegen_model", "imagegen_square_size", "imagegen_landscape_size",
     "imagegen_quality", "imagegen_style_prefix", "imagegen_timeout_seconds",
     "ai_providers", "tts_provider_ref", "asr_provider_ref", "imagegen_provider_ref",
 })
@@ -99,27 +98,25 @@ def provider_runtime_changed(changed_keys: frozenset[str]) -> bool:
 
 
 def _degrade_speech_engines_lost_provider(candidate: dict[str, Any], refs_before: dict[str, str]) -> None:
-    """服务商被删除导致 TTS/ASR 引用悬空且无内联地址时，回退到零配置引擎。
-
-    否则 Speech/Asr 服务构造校验会失败，把"删除服务商"整个操作卡死。
-    仅在引用因删除被清空的场景触发；手动开启引擎但不填地址仍走原有报错。
-    """
+    """解除服务商绑定时停用依赖它的能力，不允许残留直填配置恢复连接。"""
     tts_ref_cleared = bool(refs_before.get("tts_provider_ref")) and not str(candidate.get("tts_provider_ref") or "").strip()
     if (tts_ref_cleared
-            and candidate.get("tts_provider") == "openai-compatible"
-            and not str(candidate.get("tts_base_url") or "").strip()):
+            and candidate.get("tts_provider") in {"openai-compatible", "gpt-sovits"}):
         candidate["tts_provider"] = "browser"
     asr_ref_cleared = bool(refs_before.get("asr_provider_ref")) and not str(candidate.get("asr_provider_ref") or "").strip()
     if (asr_ref_cleared
-            and candidate.get("asr_provider") == "openai-compatible"
-            and not str(candidate.get("asr_base_url") or "").strip()):
+            and candidate.get("asr_provider") == "openai-compatible"):
         candidate["asr_provider"] = "disabled"
 
     imagegen_ref_cleared = bool(refs_before.get("imagegen_provider_ref")) and not str(
         candidate.get("imagegen_provider_ref") or ""
     ).strip()
-    if imagegen_ref_cleared and not str(candidate.get("imagegen_base_url") or "").strip():
+    if imagegen_ref_cleared:
         candidate["imagegen_enabled"] = False
+    for capability in ("fallback1", "fallback2", "embedding"):
+        ref_key = f"{capability}_provider_ref"
+        if refs_before.get(ref_key) and not candidate.get(ref_key):
+            candidate[f"{capability}_enabled"] = False
 BOT_CONFIG_MAP = {
     "qq_bot_enabled": "enabled",
     "napcat_host": "host",
@@ -161,7 +158,14 @@ def normalize_api_format(value: Any) -> str:
 
 
 def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> PreparedConfigUpdate:
-    candidate = dict(current)
+    unsupported = sorted(set(body) & UNSUPPORTED_AI_CONFIG_KEYS)
+    if unsupported:
+        return PreparedConfigUpdate(
+            dict(current), frozenset(), False,
+            "unsupported AI config fields: " + ", ".join(unsupported)
+            + "; use ai_providers and *_provider_ref",
+        )
+    candidate = {key: value for key, value in current.items() if key not in UNSUPPORTED_AI_CONFIG_KEYS}
     changed_keys = frozenset(set(body).intersection(CONFIG_KEYS)
                              | {key for key in body
                                 if is_provider_secret_key(key) and clean_text_value(body[key])})
@@ -183,9 +187,7 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
                 if value:
                     candidate[key] = hash_access_password(value) if key == "access_token" else value
                 continue
-            if key in API_FORMAT_KEYS:
-                candidate[key] = normalize_api_format(raw)
-            elif key == "web_cors_origins":
+            if key == "web_cors_origins":
                 invalid = invalid_cors_origins(raw)
                 if invalid:
                     return PreparedConfigUpdate(
@@ -302,8 +304,8 @@ def prepare_config_update(current: dict[str, Any], body: dict[str, Any]) -> Prep
     refs_before = {key: str(candidate.get(key) or "").strip() for key in PROVIDER_REF_KEYS}
     strip_orphan_provider_secrets(candidate)
     strip_dangling_provider_refs(candidate)
-    _degrade_speech_engines_lost_provider(candidate, refs_before)
     cleared_model_routes = reconcile_model_capability_routes(candidate)
+    _degrade_speech_engines_lost_provider(candidate, refs_before)
 
     imagegen_ref = str(candidate.get("imagegen_provider_ref") or "").strip()
     if imagegen_ref:

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from src.ai_providers import (
+    UNSUPPORTED_AI_CONFIG_KEYS,
     is_provider_secret_key,
     normalize_ai_providers,
     provider_secret_key,
@@ -40,13 +41,6 @@ from src.webui.services import legal as legal_svc
 
 _SECRET_KEYS = frozenset(
     {
-        "api_key",
-        "embedding_api_key",
-        "fallback1_api_key",
-        "fallback2_api_key",
-        "tts_api_key",
-        "asr_api_key",
-        "imagegen_api_key",
         "access_token",
         "bot_token",
         "napcat_token",
@@ -164,14 +158,7 @@ class ConfigStore:
         generation_defaults_migrated = migrate_generation_defaults(saved)
         env = self.environ
 
-        api_key = env.get("TRPG_LLM_API_KEY") or secret_values.get("api_key") or ""
-        base_url = env.get("TRPG_LLM_BASE_URL") or saved.get(
-            "base_url", "https://api.deepseek.com/v1"
-        )
-        model = env.get("TRPG_LLM_MODEL") or saved.get("model", "deepseek-v4-flash")
-        api_format = env.get("TRPG_LLM_API_FORMAT") or saved.get(
-            "api_format", "openai"
-        )
+        model = saved.get("model", "")
         port = int(env.get("TRPG_WEB_PORT") or saved.get("web_port", 18000))
         host = str(env.get("TRPG_WEB_HOST") or saved.get("web_host", "0.0.0.0"))
         transport_config = parse_web_transport(saved.get("web_transport"), env)
@@ -183,15 +170,7 @@ class ConfigStore:
         cors_env_value = str(env.get("TRPG_WEB_CORS_ORIGINS") or "").strip()
         cors_config_value = cors_env_value or str(saved.get("web_cors_origins") or "")
         embedding_enabled = saved.get("embedding_enabled", False)
-        embedding_base_url = saved.get("embedding_base_url", "")
-        embedding_model = env.get("TRPG_EMBEDDING_MODEL") or saved.get(
-            "embedding_model", "nomic-embed-text"
-        )
-        embedding_api_key = (
-            env.get("TRPG_EMBEDDING_API_KEY")
-            or secret_values.get("embedding_api_key")
-            or ""
-        )
+        embedding_model = saved.get("embedding_model", "nomic-embed-text")
         access_token = next(
             (
                 password
@@ -213,10 +192,7 @@ class ConfigStore:
 
         state: dict[str, Any] = {
             "generation_defaults_version": GENERATION_DEFAULTS_VERSION,
-            "api_key": api_key,
-            "base_url": base_url,
             "model": model,
-            "api_format": api_format,
             "web_port": port,
             "web_cors_origins": normalize_cors_origins(cors_config_value),
             "ai_providers": normalize_ai_providers(saved.get("ai_providers")),
@@ -233,70 +209,29 @@ class ConfigStore:
                 if is_provider_secret_key(key)
             },
             "embedding_enabled": embedding_enabled,
-            "embedding_base_url": embedding_base_url,
             "embedding_model": embedding_model,
-            "embedding_api_key": embedding_api_key,
+            "embedding_max_input": int(saved.get("embedding_max_input", 0)),
             "fallback1_enabled": saved.get("fallback1_enabled", False),
-            "fallback1_base_url": saved.get("fallback1_base_url", ""),
             "fallback1_model": saved.get("fallback1_model", ""),
-            "fallback1_api_format": saved.get("fallback1_api_format", "openai"),
-            "fallback1_api_key": secret_values.get("fallback1_api_key") or "",
             "fallback2_enabled": saved.get("fallback2_enabled", False),
-            "fallback2_base_url": saved.get("fallback2_base_url", ""),
             "fallback2_model": saved.get("fallback2_model", ""),
-            "fallback2_api_format": saved.get("fallback2_api_format", "openai"),
-            "fallback2_api_key": secret_values.get("fallback2_api_key") or "",
-            "tts_provider": str(
-                env.get("TRPG_TTS_PROVIDER") or saved.get("tts_provider", "browser")
-            ),
-            "tts_base_url": str(
-                env.get("TRPG_TTS_BASE_URL") or saved.get("tts_base_url", "")
-            ),
-            "tts_api_key": env.get("TRPG_TTS_API_KEY")
-            or secret_values.get("tts_api_key")
-            or "",
-            "tts_model": str(
-                env.get("TRPG_TTS_MODEL") or saved.get("tts_model", "tts-1")
-            ),
-            "tts_audio_format": str(
-                env.get("TRPG_TTS_AUDIO_FORMAT")
-                or saved.get("tts_audio_format", "mp3")
-            ),
-            "tts_default_voice": str(
-                env.get("TRPG_TTS_VOICE") or saved.get("tts_default_voice", "alloy")
-            ),
+            "tts_provider": str(saved.get("tts_provider", "browser")),
+            "tts_model": str(saved.get("tts_model", "tts-1")),
+            "tts_audio_format": str(saved.get("tts_audio_format", "mp3")),
+            "tts_default_voice": str(saved.get("tts_default_voice", "alloy")),
             "tts_gm_voice": str(saved.get("tts_gm_voice", "")),
             "tts_player_voice": str(saved.get("tts_player_voice", "")),
             "tts_timeout_seconds": float(saved.get("tts_timeout_seconds", 60)),
             "tts_cache_mb": int(saved.get("tts_cache_mb", 256)),
-            "asr_provider": str(
-                env.get("TRPG_ASR_PROVIDER") or saved.get("asr_provider", "disabled")
-            ),
-            "asr_base_url": str(
-                env.get("TRPG_ASR_BASE_URL") or saved.get("asr_base_url", "")
-            ),
-            "asr_api_key": env.get("TRPG_ASR_API_KEY")
-            or secret_values.get("asr_api_key")
-            or "",
-            "asr_model": str(
-                env.get("TRPG_ASR_MODEL") or saved.get("asr_model", "whisper-1")
-            ),
+            "asr_provider": str(saved.get("asr_provider", "disabled")),
+            "asr_model": str(saved.get("asr_model", "whisper-1")),
             "asr_timeout_seconds": float(saved.get("asr_timeout_seconds", 60)),
             "imagegen_enabled": bool(saved.get("imagegen_enabled", False)),
             "imagegen_auto_scene": bool(saved.get("imagegen_auto_scene", True)),
             "imagegen_provider": str(
                 saved.get("imagegen_provider") or "openai-compatible"
             ),
-            "imagegen_base_url": str(
-                env.get("TRPG_IMAGEGEN_BASE_URL")
-                or saved.get("imagegen_base_url", "")
-            ),
-            "imagegen_api_key": env.get("TRPG_IMAGEGEN_API_KEY")
-            or secret_values.get("imagegen_api_key")
-            or "",
-            "imagegen_model": str(
-                env.get("TRPG_IMAGEGEN_MODEL") or saved.get("imagegen_model", "")
-            ),
+            "imagegen_model": str(saved.get("imagegen_model", "")),
             "imagegen_square_size": str(
                 saved.get("imagegen_square_size", "1024x1024")
             ),
@@ -444,6 +379,7 @@ class ConfigStore:
             for key, value in state.items()
             if key not in _SECRET_KEYS
             and key != "web_transport"
+            and key not in UNSUPPORTED_AI_CONFIG_KEYS
             and not is_provider_secret_key(key)
         }
         public["ai_providers"] = [
@@ -456,13 +392,6 @@ class ConfigStore:
             for entry in state.get("ai_providers", [])
         ]
         for key in (
-            "api_key",
-            "embedding_api_key",
-            "fallback1_api_key",
-            "fallback2_api_key",
-            "tts_api_key",
-            "asr_api_key",
-            "imagegen_api_key",
             "bot_token",
             "napcat_token",
         ):
@@ -497,13 +426,15 @@ class ConfigStore:
             for key, value in state.items()
             if key not in _SECRET_KEYS
             and key != "qq_bot_running"
+            and key not in UNSUPPORTED_AI_CONFIG_KEYS
             and not is_provider_secret_key(key)
         }
         self.atomic_write_json(self.paths.config_file, non_sensitive)
         sensitive = {
             key: value
             for key, value in state.items()
-            if key in _SECRET_KEYS or is_provider_secret_key(key)
+            if (key in _SECRET_KEYS or is_provider_secret_key(key))
+            and key not in UNSUPPORTED_AI_CONFIG_KEYS
         }
         if self.environ.get("TRPG_ACCESS_TOKEN"):
             sensitive.pop("access_token", None)

--- a/tests/test_ai_providers.py
+++ b/tests/test_ai_providers.py
@@ -6,6 +6,7 @@ import pytest
 
 import web_server
 from src.ai_providers import (
+    UNSUPPORTED_AI_CONFIG_KEYS,
     is_provider_secret_key,
     normalize_ai_providers,
     provider_secret_key,
@@ -256,18 +257,19 @@ def test_config_update_rejects_anthropic_imagegen_provider():
     assert prepared.error == "图像生成仅支持 OpenAI 兼容服务商"
 
 
-def test_config_update_keeps_speech_engine_when_inline_base_url_remains():
+@pytest.mark.parametrize("engine", ["openai-compatible", "gpt-sovits"])
+def test_config_update_disables_speech_even_when_inline_base_url_remains(engine):
     current = _state(
         ai_providers=[_provider()],
-        tts_provider="openai-compatible", tts_provider_ref="sf",
+        tts_provider=engine, tts_provider_ref="sf",
         tts_base_url="https://inline.example/v1", tts_model="tts-1",
     )
 
     prepared = prepare_config_update(current, {"ai_providers": []})
 
     assert prepared.error == ""
-    assert prepared.state["tts_provider"] == "openai-compatible"
-    assert prepared.state["tts_base_url"] == "https://inline.example/v1"
+    assert prepared.state["tts_provider"] == "browser"
+    assert "tts_base_url" not in prepared.state
 
 
 def test_config_update_invalid_provider_secret_key_ignored():
@@ -276,6 +278,68 @@ def test_config_update_invalid_provider_secret_key_ignored():
     assert prepared.error == ""
     assert provider_runtime_changed(prepared.changed_keys) is False
     assert "ai_provider_key_bad id" not in prepared.state
+
+
+@pytest.mark.parametrize("key", sorted(UNSUPPORTED_AI_CONFIG_KEYS))
+def test_old_update_payload_is_explicitly_unsupported_and_atomic(key):
+    current = _state(model="kept")
+    prepared = prepare_config_update(current, {key: "obsolete", "model": "changed"})
+    assert "unsupported" in prepared.error
+    assert key in prepared.error
+    assert prepared.state == current
+    assert not prepared.changed_keys
+
+
+@pytest.mark.parametrize("ref", ["", "missing"])
+@pytest.mark.parametrize("engine", ["openai-compatible", "gpt-sovits"])
+def test_unconfigured_api_capabilities_cannot_revive_inline_credentials(ref, engine):
+    from src.webui.composition import RuntimeComposition
+
+    config = _state(tts_provider=engine, asr_provider="openai-compatible", imagegen_enabled=True)
+    for capability in ("tts", "asr", "imagegen"):
+        config[f"{capability}_provider_ref"] = ref
+        config[f"{capability}_base_url"] = "https://obsolete.example/v1"
+        config[f"{capability}_api_key"] = "obsolete-secret"
+    resolved = RuntimeComposition.config_with_resolved_api_refs(config)
+    assert resolved["tts_provider"] == "browser"
+    assert resolved["asr_provider"] == "disabled"
+    assert resolved["imagegen_enabled"] is False
+    for capability in ("tts", "asr", "imagegen"):
+        assert resolved[f"{capability}_base_url"] == ""
+        assert resolved[f"{capability}_api_key"] == ""
+
+
+@pytest.mark.parametrize("engine", ["browser", "edge-tts"])
+def test_zero_configuration_engines_need_no_provider(engine):
+    from src.webui.composition import RuntimeComposition
+
+    config = _state(tts_provider=engine, asr_provider="disabled")
+    prepared = prepare_config_update(config, {"tts_provider": engine})
+    assert not prepared.error
+    resolved = RuntimeComposition.config_with_resolved_api_refs(prepared.state)
+    assert resolved["tts_provider"] == engine
+    assert resolved["asr_provider"] == "disabled"
+
+
+def test_local_gpt_sovits_provider_works_without_key():
+    from src.webui.composition import RuntimeComposition
+
+    config = _state(ai_providers=[_provider(base_url="http://localhost:9880")],
+                    tts_provider="gpt-sovits", tts_provider_ref="sf", tts_api_key="old-secret")
+    resolved = RuntimeComposition.config_with_resolved_api_refs(config)
+    assert resolved["tts_provider"] == "gpt-sovits"
+    assert resolved["tts_base_url"] == "http://localhost:9880"
+    assert resolved["tts_api_key"] == ""
+
+
+@pytest.mark.asyncio
+async def test_http_old_update_is_rejected_before_persistence_or_runtime_build(monkeypatch):
+    monkeypatch.setattr(web_server, "save_config", lambda: pytest.fail("unsupported update must not persist"))
+    monkeypatch.setattr(web_server, "_build_subsystems", lambda **kwargs: pytest.fail("unsupported update must not build"))
+    response = await web_server.api_config_post(_ConfigRequest({"api_key": "old-key"}, {}))
+    assert response.status == 400
+    assert "unsupported AI config fields" in response.text
+    assert "old-key" not in response.text
 
 
 # ---------- 运行时解析 ----------
@@ -311,7 +375,8 @@ def test_build_subsystems_resolves_llm_and_embedding_refs(monkeypatch):
     assert captured["model_request_timeout_seconds"] == 245
 
 
-def test_build_subsystems_keeps_inline_fallback_when_ref_empty(monkeypatch):
+@pytest.mark.parametrize("ref", ["", "missing"])
+def test_build_subsystems_never_uses_inline_credentials(monkeypatch, ref):
     captured = {}
 
     def fake_create(**kwargs):
@@ -322,15 +387,20 @@ def test_build_subsystems_keeps_inline_fallback_when_ref_empty(monkeypatch):
     config = _state(
         base_url="https://inline.example/v1", api_key="sk-inline", model="m1", api_format="openai",
         fallback1_enabled=True, fallback1_base_url="https://fb.example/v1", fallback1_model="fb-model",
-        fallback1_api_key="",  # 回退主 key 的既有语义
-        embedding_enabled=False,
+        fallback1_api_key="sk-fallback",
+        llm_provider_ref=ref, fallback1_provider_ref=ref, embedding_provider_ref=ref,
+        embedding_enabled=True, embedding_base_url="https://old-embedding.example", embedding_api_key="sk-old",
         proxy_enabled=False, proxy_url="",
     )
 
     web_server._build_subsystems(config=config)
 
-    fallback = captured["providers"][1]
-    assert fallback.api_key == "sk-inline"
+    assert len(captured["providers"]) == 1
+    assert captured["providers"][0].base_url == ""
+    assert captured["providers"][0].api_key == ""
+    assert captured["embedding_enabled"] is False
+    assert captured["embedding_base_url"] == ""
+    assert captured["embedding_api_key"] == ""
 
 
 def test_build_subsystems_fallback_ref_does_not_leak_inline_key(monkeypatch):

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -149,14 +149,16 @@ def test_service_validates_enabled_base_url():
 def test_config_update_accepts_asr_keys():
     prepared = prepare_config_update(_config(), {
         "asr_provider": "openai-compatible",
-        "asr_base_url": "https://api.example.com",
+        "ai_providers": [{"id": "local", "base_url": "https://api.example.com"}],
+        "asr_provider_ref": "local",
         "asr_model": "whisper-1",
         "asr_timeout_seconds": 90,
     })
 
     assert prepared.error == ""
     assert prepared.state["asr_provider"] == "openai-compatible"
-    assert prepared.state["asr_base_url"] == "https://api.example.com"
+    assert prepared.state["asr_provider_ref"] == "local"
+    assert "asr_base_url" not in prepared.state
     assert prepared.state["asr_timeout_seconds"] == 90
 
 
@@ -172,8 +174,9 @@ def test_config_update_rejects_out_of_range_asr_timeout():
     assert prepared.error == "ASR 超时必须在 5–300 秒之间"
 
 
-def test_config_update_keeps_existing_asr_secret_when_blank():
+def test_config_update_rejects_old_asr_secret_even_when_blank():
     prepared = prepare_config_update(_config(asr_api_key="sk-old"), {"asr_api_key": ""})
 
-    assert prepared.error == ""
-    assert prepared.state["asr_api_key"] == "sk-old"
+    assert "unsupported" in prepared.error
+    assert "asr_api_key" in prepared.error
+    assert not prepared.changed_keys

--- a/tests/test_config_runtime_reload.py
+++ b/tests/test_config_runtime_reload.py
@@ -191,18 +191,21 @@ async def test_tts_config_reload_rebuilds_only_api_facade(monkeypatch):
     def make_api(subsystems, plugin_host=None, config=None):
         assert subsystems is runtime
         assert config["tts_provider"] == "openai-compatible"
-        assert config["tts_base_url"] == "http://127.0.0.1:8880/v1"
+        assert config["tts_provider_ref"] == "local"
+        assert "tts_base_url" not in config
         return new_api
 
     monkeypatch.setattr(web_server, "_make_api", make_api)
     monkeypatch.setitem(web_server.STATE, "tts_provider", "browser")
-    monkeypatch.setitem(web_server.STATE, "tts_base_url", "")
+    monkeypatch.setitem(web_server.STATE, "ai_providers", [{
+        "id": "local", "name": "Local", "base_url": "http://127.0.0.1:8880/v1", "api_format": "openai",
+    }])
     monkeypatch.setitem(web_server.STATE, "proxy_enabled", False)
     monkeypatch.setitem(web_server.STATE, "proxy_url", "")
 
     response = await web_server.api_config_post(_ConfigRequest({
         "tts_provider": "openai-compatible",
-        "tts_base_url": "http://127.0.0.1:8880/v1",
+        "tts_provider_ref": "local",
     }, app))
 
     assert response.status == 200

--- a/tests/test_model_config_contracts.py
+++ b/tests/test_model_config_contracts.py
@@ -1,0 +1,163 @@
+"""Provider routing persistence and entrypoint contracts, isolated from user data."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from src.ai_providers import is_llm_config_ready, provider_secret_key, resolve_provider
+from src.webui.config_update import prepare_config_update
+from src.webui.runtime_config import ConfigStore, RuntimePaths
+
+
+def _provider(provider_id="local"):
+    return {
+        "id": provider_id, "name": provider_id,
+        "base_url": "http://localhost:8000/v1", "api_format": "openai",
+        "models": ["chat", "embed", "speech", "transcribe", "image"],
+        "model_capabilities": {
+            "chat": "chat", "embed": "embedding", "speech": "tts",
+            "transcribe": "asr", "image": "image",
+        },
+    }
+
+
+@pytest.mark.parametrize("overrides,ready", [
+    ({}, True),
+    ({"ai_provider_key_local": "sk-test"}, True),
+    ({"llm_provider_ref": ""}, False),
+    ({"llm_provider_ref": "missing"}, False),
+    ({"model": "   "}, False),
+    ({"ai_providers": []}, False),
+    ({"ai_providers": [{**_provider(), "base_url": " "}]}, False),
+])
+def test_main_model_readiness_requires_route_endpoint_and_model(overrides, ready):
+    config = {
+        "ai_providers": [_provider()], "llm_provider_ref": "local", "model": "chat",
+        "base_url": "https://legacy.example/v1", "api_key": "legacy-key",
+        **overrides,
+    }
+    assert is_llm_config_ready(config) is ready
+
+
+def test_all_model_routes_and_credentials_roundtrip(tmp_path):
+    store = ConfigStore(RuntimePaths.from_root(tmp_path, {}), {})
+    update = {
+        "ai_providers": [_provider(), _provider("cloud")],
+        provider_secret_key("cloud"): "sk-cloud-roundtrip",
+        "llm_provider_ref": "cloud", "model": "chat",
+        "fallback1_enabled": True, "fallback1_provider_ref": "local", "fallback1_model": "chat",
+        "fallback2_enabled": True, "fallback2_provider_ref": "cloud", "fallback2_model": "chat",
+        "embedding_enabled": True, "embedding_provider_ref": "local",
+        "embedding_model": "embed", "embedding_max_input": 12345,
+        "tts_provider": "openai-compatible", "tts_provider_ref": "cloud",
+        "tts_model": "speech", "tts_default_voice": "nova",
+        "tts_audio_format": "wav", "tts_gm_voice": "onyx", "tts_player_voice": "alloy",
+        "tts_timeout_seconds": 75, "tts_cache_mb": 512,
+        "asr_provider": "openai-compatible", "asr_provider_ref": "local",
+        "asr_model": "transcribe", "asr_timeout_seconds": 80,
+        "imagegen_enabled": True, "imagegen_auto_scene": False,
+        "imagegen_provider": "openai-compatible", "imagegen_provider_ref": "cloud",
+        "imagegen_model": "image", "imagegen_square_size": "512x512",
+        "imagegen_landscape_size": "1536x1024", "imagegen_quality": "high",
+        "imagegen_style_prefix": "watercolor", "imagegen_timeout_seconds": 150,
+        "proxy_enabled": True, "proxy_url": "http://localhost:7890",
+    }
+    prepared = prepare_config_update(store.load().state, update)
+    assert not prepared.error
+    store.save(prepared.state)
+
+    loaded = store.load()
+    for key, value in update.items():
+        assert loaded.state[key] == value, key
+    assert is_llm_config_ready(loaded.state)
+    assert resolve_provider(loaded.state, "local")["api_key"] == ""
+    assert resolve_provider(loaded.state, "cloud")["api_key"] == "sk-cloud-roundtrip"
+    public = store.public_view(loaded)
+    assert public["ai_providers"][0]["api_key"]["configured"] is False
+    assert public["ai_providers"][1]["api_key"]["configured"] is True
+    assert "sk-cloud-roundtrip" not in json.dumps(public)
+    assert "sk-cloud-roundtrip" not in store.paths.config_file.read_text(encoding="utf-8")
+    assert json.loads(store.paths.secrets_file.read_text(encoding="utf-8"))[provider_secret_key("cloud")] == "sk-cloud-roundtrip"
+
+
+@pytest.mark.parametrize("mode,voice", [("browser", "alloy"), ("edge-tts", "zh-CN-XiaoxiaoNeural")])
+def test_reference_free_speech_roundtrip(tmp_path, mode, voice):
+    store = ConfigStore(RuntimePaths.from_root(tmp_path, {}), {})
+    prepared = prepare_config_update(store.load().state, {
+        "ai_providers": [], "tts_provider": mode, "tts_provider_ref": "",
+        "tts_default_voice": voice, "asr_provider": "disabled", "asr_provider_ref": "",
+    })
+    assert not prepared.error
+    store.save(prepared.state)
+    reloaded = store.load().state
+    assert reloaded["ai_providers"] == []
+    assert reloaded["tts_provider"] == mode
+    assert reloaded["tts_default_voice"] == voice
+    assert reloaded["asr_provider"] == "disabled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_cli_passes_effective_proxy_to_local_keyless_model(monkeypatch, tmp_path, enabled):
+    from scripts.dev import run_cli_game
+
+    monkeypatch.setattr(run_cli_game, "ROOT", tmp_path)
+    monkeypatch.setattr(run_cli_game, "DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr(run_cli_game.os, "environ", {})
+    store = ConfigStore(RuntimePaths.from_root(tmp_path, {}), {})
+    state = store.load().state
+    state.update({
+        "ai_providers": [_provider()], "llm_provider_ref": "local", "model": "chat",
+        "proxy_enabled": enabled, "proxy_url": "http://localhost:7890",
+    })
+    store.save(state)
+
+    class StopAfterClient(Exception):
+        pass
+
+    client = Mock(side_effect=StopAfterClient)
+    monkeypatch.setattr(run_cli_game, "LLMClient", client)
+    with pytest.raises(StopAfterClient):
+        await run_cli_game.main()
+    kwargs = client.call_args.kwargs
+    assert kwargs["proxy_url"] == ("http://localhost:7890" if enabled else "")
+    assert kwargs["providers"][0].base_url == "http://localhost:8000/v1"
+    assert kwargs["providers"][0].api_key == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_web_composition_passes_proxy_and_keyless_embedding_settings(monkeypatch, tmp_path, enabled):
+    import src.common_factory as factory
+    from src.webui.composition import RuntimeComposition, RuntimePaths as CompositionPaths
+
+    # Reuse inert stores so actual client construction never opens databases or sends requests.
+    reuse = SimpleNamespace(
+        registry=object(), lorebook_store=object(), lorebook_matcher=object(),
+        memory_store=SimpleNamespace(embedding_client=None),
+    )
+    monkeypatch.setattr(factory, "GameHandler", Mock())
+    monkeypatch.setattr(factory, "build_default_ruleset_registry", Mock())
+    config = {
+        "ai_providers": [_provider()], "llm_provider_ref": "local", "model": "chat",
+        "embedding_enabled": True, "embedding_provider_ref": "local", "embedding_model": "embed",
+        "embedding_max_input": 12345, "proxy_enabled": enabled, "proxy_url": "http://localhost:7890",
+    }
+    composition = RuntimeComposition(
+        paths=CompositionPaths(tmp_path, tmp_path, tmp_path, tmp_path, tmp_path),
+        state=config, save_config=lambda: None,
+    )
+    runtime = composition.build_subsystems(reuse=reuse)
+    try:
+        embedding = runtime.memory_store.embedding_client
+        assert embedding is not None
+        assert embedding.base_url == "http://localhost:8000/v1"
+        assert embedding.api_key == ""
+        assert embedding.model == "embed"
+        assert embedding.max_input_chars == 12345
+        assert embedding.proxy_url == runtime.llm_client.proxy_url == ("http://localhost:7890" if enabled else "")
+    finally:
+        await runtime.llm_client.close()
+        await runtime.memory_store.embedding_client.close()

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -14,7 +14,7 @@ def _store(tmp_path, environ=None):
     return ConfigStore(paths, environment), paths
 
 
-def test_environment_overrides_secrets_and_config(tmp_path):
+def test_legacy_ai_environment_and_files_are_ignored_but_web_env_has_priority(tmp_path):
     store, paths = _store(
         tmp_path,
         {
@@ -43,8 +43,10 @@ def test_environment_overrides_secrets_and_config(tmp_path):
 
     runtime = store.load()
 
-    assert runtime.state["api_key"] == "env-key"
-    assert runtime.state["base_url"] == "https://env.example/v1"
+    assert "api_key" not in runtime.state
+    assert "base_url" not in runtime.state
+    assert runtime.state["ai_providers"] == []
+    assert json.loads(paths.secrets_file.read_text(encoding="utf-8"))["api_key"] == "secret-key"
     assert runtime.port == 19001
     assert runtime.state["web_port"] == 19001
     assert runtime.cors_origins == frozenset({"https://ui.example"})
@@ -72,7 +74,7 @@ def test_save_splits_public_and_provider_secrets(tmp_path):
     assert "api_key" not in public
     assert secret_key not in public
     assert "qq_bot_running" not in public
-    assert secrets["api_key"] == "sk-main"
+    assert "api_key" not in secrets
     assert secrets[secret_key] == "sk-provider"
 
 
@@ -110,11 +112,14 @@ def test_public_view_masks_secrets_and_reports_sources(tmp_path):
         },
     )
     runtime = store.load()
-    runtime.state["api_key"] = "sk-12345678"
+    runtime.state["ai_providers"] = [{"id": "local", "name": "Local", "base_url": "http://localhost:8000/v1"}]
+    runtime.state[provider_secret_key("local")] = "sk-12345678"
+    runtime.state["api_key"] = "unsupported-secret"
 
     public = store.public_view(runtime)
 
-    assert public["api_key"] == {"configured": True, "masked": "***5678"}
+    assert "api_key" not in public
+    assert public["ai_providers"][0]["api_key"] == {"configured": True, "masked": "***5678"}
     assert public["bot_token_source"] == "env"
     assert public["proxy_source"] == "env"
     assert "password" not in public["proxy_url"]

--- a/tests/test_webui_create_flow.py
+++ b/tests/test_webui_create_flow.py
@@ -671,13 +671,13 @@ async def test_unconfigured_model_is_rejected_before_creating_save_data(web_api)
 
     assert result["ok"] is False
     assert result["error_code"] == "llm_not_configured"
-    assert result["missing"] == ["base_url", "model", "api_key"]
+    assert result["missing"] == ["base_url", "model"]
     assert registry.list_all() == []
     assert fake_llm.calls == []
 
 
 @pytest.mark.asyncio
-async def test_ai_generation_reports_unconfigured_model_without_calling_it(web_api):
+async def test_local_model_without_api_key_is_ready(web_api):
     api, _lorebook, _registry, fake_llm, _worlds_dir = web_api
     fake_llm.providers = {
         "fake": SimpleNamespace(
@@ -688,12 +688,10 @@ async def test_ai_generation_reports_unconfigured_model_without_calling_it(web_a
         ),
     }
 
-    result = await api.generate_rule("测试规则", "freeform_fantasy")
+    readiness = api._llm_configuration_status()
 
-    assert result["ok"] is False
-    assert result["error_code"] == "llm_not_configured"
-    assert result["missing"] == ["api_key"]
-    assert fake_llm.calls == []
+    assert readiness["ready"] is True
+    assert readiness["missing"] == []
 
 
 @pytest.mark.asyncio

--- a/web_server.py
+++ b/web_server.py
@@ -14,6 +14,7 @@ from src.runtime_logging import RETENTION_DAYS, configure_runtime_logging
 
 load_project_env(Path(__file__).resolve().with_name(".env"))
 
+from src.ai_providers import is_llm_config_ready
 from src.common_factory import TRPGSubsystems, create_trpg_subsystems
 from src.migrations.config import (
     DEFAULT_NARRATIVE_MAX_TOKENS,
@@ -75,7 +76,6 @@ TRANSPORT = RUNTIME_CONFIG.transport
 WEB_CORS_ENV_VALUE = RUNTIME_CONFIG.cors_env_value
 WEB_CORS_CONFIG_VALUE = RUNTIME_CONFIG.cors_config_value
 WEB_CORS_ORIGINS = RUNTIME_CONFIG.cors_origins
-API_KEY = str(STATE.get("api_key", ""))
 
 PROMPTS_DIR = RUNTIME_PATHS.prompts_dir
 BUILTIN_RULES_DIR = RUNTIME_PATHS.builtin_rules_dir
@@ -269,8 +269,8 @@ if __name__ == "__main__":
     if TRANSPORT.degraded_error:
         logger.critical("%s", TRANSPORT.degraded_error)
     print(f"DiceFrame WebUI: {TRANSPORT.endpoint.url('127.0.0.1')}  (host={HOST})")
-    if not API_KEY:
-        print("请在 WebUI 设置页填写 API Key")
+    if not is_llm_config_ready(STATE):
+        print("请在 WebUI 的 AI 服务商与模型配置中设置主模型。")
     runtime_loop = asyncio.new_event_loop()
     install_runtime_exception_handler(runtime_loop)
     web.run_app(

--- a/web_ui.bat
+++ b/web_ui.bat
@@ -3,7 +3,7 @@ chcp 65001 >nul
 cd /d "%~dp0"
 echo ========================================
 echo   TRPG WebUI - port from data/config.json web_port, see console
-echo   首次使用请在浏览器设置页填写 API Key
+echo   首次使用请在浏览器设置页添加 AI 服务商并选择主模型
 echo ========================================
 echo.
 


### PR DESCRIPTION
## Summary

应用 AI 配置统一使用 `ai_providers`、`ai_provider_key_<id>` 与能力级 `*_provider_ref`。旧直填地址、密钥、API 格式和旧 AI 环境入口不再驱动主备模型、向量、语音或生图；例如只有 `asr_base_url` 的配置不会再启用 ASR，旧字段更新请求返回 HTTP 400。

Web 设置与 CLI 同步使用新契约，保留 Edge TTS 无需引用、本地服务商无需密钥的能力。同步更新 AGENTS.md、架构文档和部署示例，并修复空目录下选择 Edge TTS、默认音色保存、CLI 代理传递与启动就绪提示。

## Why

旧内联配置与服务商引用并行解析，会在引用丢失后重新启用残留地址或凭据，也使客户端可用性判断与实际运行时不一致。此次明确停止支持旧配置，所有 AI 连接均由共享服务商解析。

## Impact

- [x] API
- [x] Persisted Data / Save / Database（仅应用配置及凭据持久化）
- [ ] Migration
- [x] Compatibility / Breaking Change
- [x] Security / Permission / Privacy（凭据来源与隔离；权限模型未变）
- [ ] Multiplayer / Actor / Turn Authority
- [ ] Ruleset Mechanics
- [x] Architecture / Dependency Boundary
- [ ] Plugin / Content / Extension Contract
- [ ] UI only

## Module / Boundary

配置 owner 为 `ai_providers`、`ConfigStore`、`prepare_config_update` 和 `RuntimeComposition`。Web 设置负责生成引用配置，语音、模型和生图服务继续接收 composition 解析出的内部连接参数。未改存档、规则或插件兼容边界。

## Design / Migration Notes

- **Breaking change**：旧公开配置字段的更新请求整体拒绝，不构造候选 runtime、不持久化；旧 AI 环境入口不再读取。
- 不自动迁移或猜测创建服务商。使用旧配置的部署需在设置页创建服务商并重新绑定各能力；正常保存仅写新配置和对应凭据。
- 缺失或未知引用不会回退旧值；相关能力保持未配置或停用，应用仍可启动进入设置。删除服务商会清理引用与孤儿凭据，覆盖 GPT-SoVITS。
- `browser`、`edge-tts` 和 disabled ASR 无需引用；本地服务商允许空 key，向量不再借用主模型 key。
- 引用解析生成的内部 `*_base_url` / `*_api_key`、服务商连接测试的临时输入继续有效。

## Validation

- [x] Relevant backend tests：配置、服务商、热重载、ASR、TTS、生图、创建流程及新契约回归，**230 passed / 6 skipped**；测试数据隔离到临时目录。
- [x] Relevant frontend tests：ASR、模型就绪、路由设置、服务商相关 **6 files / 48 tests passed**。
- [x] Build / typecheck where applicable：`vue-tsc --noEmit` 与变更相关 ESLint 通过。
- [x] Architecture / security checks where applicable：两轮子代理审查；覆盖旧字段拒绝、残留凭据隔离、保存/加载、运行时失败保留及空 key 行为；`git diff --check` 通过。
- [ ] Manual verification where meaningful：未进行真实外部 AI 请求。

## Contract Check

- [x] 用户数据不会被无意覆盖或丢失（不修改对局/存档；旧应用配置不再支持的影响已明确说明）
- [x] 权限 / private data 边界未退化
- [ ] 若改 persisted identity，已处理旧引用
- [x] 若改关键产品契约，已更新对应测试
- [x] 若架构事实发生变化，已更新 `docs/ARCHITECTURE_*.md`
