### PR TITLE
chore: prepare v2.5.3 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,117 +1,59 @@
-# DiceFrame v2.5.2
+# DiceFrame v2.5.3
 
-> 稳定版。v2.5.2 延续 v2.5.1 的功能，修复实测发现的购买结算链路问题：首次询价的购买现在会在 GM 报价的同一回合弹出付款确认，叙事交付无法再绕过付款，成交后也不会每回合重复弹窗；并修复物品数量后缀与结算文案、放宽奖励自动结算默认上限。重要战役升级前，请先备份完整的 `data/` 文件夹。
+> 增量更新。v2.5.3 在 v2.5.2 的基础上收敛经济与支付的实现语义，并修复两个实测问题（奖励被误拦截、结算提示不消失）。2.5 产品的完整特性介绍见 v2.5.0–v2.5.2 的历史发布页，本页只描述相对 v2.5.2 的变化。重要战役升级前，请先备份完整的 `data/` 文件夹。
 
 ## 中文
 
-### 冒险与 D&D 2024
+### 本版重点：经济与支付收敛
 
-- **D&D 2024 专业玩法**：完整的角色创建、角色资料、战役记录、休息/升级、权威战斗与统一游戏时间线现已提供。战斗仍在同一条故事流中进行，不会把叙事和结算拆成两套游戏。
-- **统一对局与 AI GM**：剧情、公共消息、行动输入、队伍状态与 GM 控制台使用同一条对局流程；AI GM 可在玩家行动后推进剧情、收集多人行动、处理检定并唤醒符合当前节点的遭遇，GM 仍可随时裁定或接管。
-- **冒险包正式可用**：冒险包负责剧情流程、场景、NPC、地图位置与专属遭遇；世界书仍负责世界设定和长期 lore。两者可以组合，但不会互相覆盖。
-- **更好用的冒险编辑器**：编辑器按“概览 / 流程 / 遭遇 / 预览 / JSON”分区，提供可视化流程、明确的起点、分支与可达性检查，以及步骤与遭遇的绑定。
-- **结构化遭遇和怪物**：可直接编辑遭遇难度、怪物、HP、AC 与攻击动作。服务端会校验数据范围，阻止不完整或无效的战斗配置进入对局。
-- **AI 生成可控草稿**：AI 可以从自然语言起草冒险；在编辑器中只生成当前所在分区的概览、流程或遭遇内容。结果先进入草稿，只有经过人工检查和冒险包校验后才会保存。
-- **更清楚的战斗反馈**：公共战斗历史会标出最新记录与结算结果；死亡豁免、回合反馈和敌方行动的展示更容易追踪。重开/重置不会携带上一局的会话派生记忆或旧战斗状态。
-- **叙事视角与语音输入**：创建对局时可选择第一或第三人称叙事，GM 也可以在对局中调整；在 HTTPS 或 localhost 下，可配置 OpenAI 兼容的语音识别模型，将麦克风输入转成行动文本。
+- **每局奖励策略**：GM 控台顶层新增「对局设置」，可直接选择剧情奖励发放方式——自动发放小额现金，或所有奖励都需 GM 确认；自动发放的上限也按局设置。只有单角色、纯货币、上限内的奖励才会免点击自动到账；带物品、多人、超上限的奖励一律交给 GM。策略解析顺序为 本局设置 → 规则模板默认 → 服务器全局兜底，全局默认上限从 10000 收紧到 500。
+- **购买链路更快更简单**：移除了同一回合内的第二次 AI 价格复检。GM 在叙事中口述价格后，支付窗口会在下一轮自动出现；等不及可以用 GM 控台「发起支付」立即定价。未定价商品的叙事交付拦截保持不变，仍然不可能白拿货。
+- **整轮回滚**：回滚或重写第 N 轮时，该轮及之后的所有经济结算一并撤销；早于该轮创建、在其后才结算的报价会重新弹回待确认，玩家不为已被抹掉的剧情付钱。物品恢复改用整快照与绝对结算前镜像，删除了易错的库存差分逻辑；历史重写（swipe）同时会截断目标轮之后的日志分支。
+- **退役无人的转账/手续费/团队分摊**：这些提案类型早已没有创建入口（旧的 PAY/TEAM_PAY 标签协议在 schema 6 就已停用），本次彻底移除其结算与展示代码。
 
-### 世界书、内容与多人游玩
+### 修复
 
-- **世界书可见性管理**：可按 GM、全队或指定角色设置 lore 可见性，并用视角检查器确认每名玩家真正能看到什么。AI 生成世界书时也受到同一套可见性边界约束。
-- **世界图库**：世界书支持封面、自定义排序和分页浏览，管理大量世界时更容易定位内容。
-- **桌边协作**：新增全队桌边交流与玩家向 GM 提问的入口；玩家提问保持只读边界，不会绕过 GM 权限或直接改写权威状态。
-- **内容工作区**：世界书、规则、角色与管理入口的组织更清晰，窄屏下的导航和常用编辑操作也进行了适配。
+- **奖励被误拦截**：叙事奖励不再被"任务完成证据"启发式吞掉。此前叙述里只要出现"如果/以后"等词或缺少"完成/击败"等关键词，奖励就会被静默丢弃并提示"任务确认完成前不会发放奖励"——即使它根本不是任务（实测第 5 轮奖励未入账事故）。现在叙事奖励一律进入提案，由奖励策略与 GM 决定。
+- **结算提示不消失**：钱到账后，回合里过期的「结算待确认：关联结果尚未生效」提示现在会自动清除；单人局的结算确认消息直接显示在公开时间线，不再藏进私聊记录（多人局维持原有可见性规则：公开交易公开显示，GM 私下交易只有当事人可见）。
 
-### 模型、连接与运维
+### 破坏性变更与升级提示
 
-- **模型目录与主模型**：可以在模型目录中直接指定主模型；写入失败时会回滚，避免界面显示与实际配置不一致。
-- **更清晰的连接安全说明**：设置页补充本地 HTTPS、局域网/外网访问、证书与 Android 连接的说明，并改善相关移动端布局。
-- **运行日志与诊断**：运行日志可持久化与导出；需要排查时，内置助手可以在明确授权后阅读受限、脱敏的 DiceFrame 运行诊断上下文。
-- **Docker 托管更新**：容器可下载并校验应用更新包，经过健康检查与观察期后切换版本；失败时可回到上一应用版本，业务数据仍独立保留。
-
-### 本版重点更新
-
-- **同轮购买确认闭环**：玩家首次询价购买时，若本轮 GM 叙事中出现了真人报出的价格，系统会在同一回合弹出付款人确认窗；叙事中尚未有价格时，系统会先拦截该商品的叙事交付，价格明确后才进入确认，绝不再“白拿货”。
-- **购买防重复弹窗**：GM 规划器现在能看到最近的购买历史（状态、商品、数量、金额），浏览、询问、使用已购物品不再被误判成新的购买；同一商品已有待确认报价时不会再叠加第二份确认窗，成交或拒绝后也不重复弹窗，除非玩家再次明确要求购买。
-- **奖励自动结算上限放宽**：普通奖励自动结算的默认金币上限从 50 提高到 10000，大部分叙事奖励不再退回 GM 手动确认；仍可在设置中按局调低。
-
-### 修复、兼容与更新可靠性
-
-- **物品数量后缀**：LOOT 物品串结尾的 `xN` / `×N` 数量后缀会被正确解析，不再出现“回复药水x5 ×1”式的脏行；同名物品按数量正确堆叠，购买交付也并入原有物品行。
-- **结算文案**：结算卡不再出现双句号（提案原因自带句号时的拼接问题）。
-- **购买提案迁移**：旧购买请求和订单字段迁移时安全丢弃，不影响已经结算的余额、物品和交易流水。
-- **规则边界**：D&D 专属自动化继续限制在 D&D 运行时边界内，不会自动改变传统规则、CoC、赛博朋克或 generic d20 的玩法。
-
-### 升级提示
-
-- 从 **v2.3.2** 升级时，请先备份完整 `data/`。便携版或源码包更新应用文件时，不要覆盖、删除或手动清空你的 `data/`。
-- 首次启动会在可安全判断的前提下升级内置模板与兼容数据；已经被用户修改的世界书或内容不会被系统模板无条件覆盖，无法安全判断时会保留原样。
-- 已绑定到存档的冒险包继续保持只读、不可删除，确保重开时始终使用同一份已验证的内容。
-- “重开”和“重置”会清理该局的会话派生记忆，避免叙事串到新局；它们不会删除其它存档。
-- 奖励自动结算默认开启，上限已放宽到 10000 金币；如需恢复严格确认模式，可在配置中调低 `economy_auto_reward_gold_cap` 或关闭 `economy_auto_reward_enabled`。
-- 存档迁移到 schema 7 时会移除旧的 `purchase_requests` 和 `purchase_orders` 字段；未确认的旧购买请求不保证保留。
-- Docker 托管更新包当前支持 `linux-amd64`。
+- **AI 服务必须使用共享服务商引用**：对话、向量、语音识别、生图不再接受旧的独立 base_url/api_key 兼容配置。从旧版升级后，请到管理页服务商设置确认各能力的服务商引用；已在使用服务商引用的配置无需改动。
+- **存档迁移到 schema 8**：待处理的转账/手续费/分摊提案会被作废（它们从未扣款），已成交的交易流水、余额与物品完全不受影响。
+- 奖励自动结算的全局默认上限为 500；可在每局「对局设置」中按本局经济规模调整（D&D 金币与 COC 美元的量级各自独立）。
+- 从 v2.5.2 升级无需额外操作；重要战役升级前仍建议备份完整 `data/`。
 
 ### 下载与校验
 
-- **普通 Windows 用户**：`DiceFrame-v2.5.2-windows-portable.zip`
-- **源码运行用户**：`DiceFrame-v2.5.2-windows.zip`
-- **托管 Docker 更新**：`DiceFrame-v2.5.2-docker-update-linux-amd64.zip`
+- **普通 Windows 用户**：`DiceFrame-v2.5.3-windows-portable.zip`
+- **源码运行用户**：`DiceFrame-v2.5.3-windows.zip`
+- **托管 Docker 更新**：`DiceFrame-v2.5.3-docker-update-linux-amd64.zip`
 - 下载后请使用 Release 中的 `SHA256SUMS` 统一校验；重要战役建议保留旧版程序与数据备份，便于回退。
 
 ## English
 
-### Adventures and D&D 2024
+### Highlights: economy and payment convergence
 
-- **D&D 2024 advanced play**: Full character creation, character records, campaign tracking, resting and advancement, authoritative combat, and the unified game timeline are now available. Combat remains in the same story flow rather than becoming a separate game.
-- **Unified play and AI GM**: Narrative, public messages, action input, party state, and the GM console use one game flow. After player actions, the AI GM can advance the story, collect multiplayer actions, resolve checks, and awaken encounters that fit the current node, while the GM can always adjudicate or take over.
-- **Adventure packages are ready for play**: Packages provide story flow, scenes, NPCs, map locations, and package-specific encounters. Worldbooks continue to provide setting and long-term lore; the two can be combined without overwriting each other.
-- **A clearer adventure editor**: Overview, Flow, Encounters, Preview, and JSON sections provide a visual flow, an explicit start node, branch and reachability diagnostics, and step-to-encounter binding.
-- **Structured encounters and monsters**: Edit encounter difficulty, monsters, HP, AC, and attacks directly. Server-side validation blocks incomplete or invalid combat data from reaching a game.
-- **Controlled AI drafts**: AI can draft an adventure from natural language. Inside the editor it generates only the active Overview, Flow, or Encounters section. Results remain drafts until reviewed and validated before saving.
-- **Clearer combat feedback**: The public combat history marks the latest record and resolution results; death saves, turn feedback, and enemy actions are easier to follow. Restart and reset no longer carry session-derived memory or stale combat state into a new game.
-- **Narrative perspective and voice input**: Choose first- or third-person narration when creating a game, and let the GM adjust it during play. Under HTTPS or localhost, an OpenAI-compatible speech-recognition model can turn microphone input into action text.
+- **Per-game reward policy**: The GM console top-level "Game settings" dialog now chooses how narrative rewards are granted — auto-grant small cash rewards, or require GM confirmation for everything — with a per-game cap. Only single-recipient, pure-currency, within-cap rewards settle without a click; item rewards, multi-recipient grants, and over-cap amounts always go to the GM. Resolution order: game override → rule-template default → server global fallback, with the global default cap tightened from 10000 to 500.
+- **Faster, simpler purchases**: The second same-round AI pricing pass is gone. When the GM narrates a price, the payer dialog appears next round; "Create payment" prices it immediately. Narrative delivery interception for unpriced items is unchanged — free handouts remain impossible.
+- **Whole-round rollback**: Rolling back or rewriting round N withdraws every settlement from N onward; an offer created earlier but settled inside the erased era reopens as pending, so players never pay for fiction that no longer exists. Item recovery now uses whole snapshots and absolute before-images instead of fragile inventory diffs, and a historical swipe branch-cuts the log after the target round.
+- **Retired unused transfer/fee/team-split proposals**: These kinds lost their creation entry points long ago (the PAY/TEAM_PAY tag protocol was retired in schema 6); their settlement and display code is now removed entirely.
 
-### Worldbooks, content, and table play
+### Fixes
 
-- **Worldbook visibility management**: Set lore visibility for the GM, the party, or named characters, then verify what each player can actually see with the perspective inspector. AI-generated lore follows the same visibility boundaries.
-- **World gallery**: Worldbooks support cover images, custom sorting, and pagination for easier management of larger libraries.
-- **Table collaboration**: Party table talk and player-to-GM questions are available from the game experience. Player questions remain read-only and cannot bypass GM authority or alter authoritative state.
-- **Content workspaces**: Worlds, rules, characters, and management entry points are organized more clearly, with improved narrow-screen navigation and editing actions.
+- **Rewards wrongly swallowed**: Narrative rewards are no longer dropped by a "completion evidence" heuristic. Previously any conditional word ("if", "later") — or the absence of words like "completed/defeated" — silently discarded a reward with a misleading quest notice, even when it was not quest payment (a real round-5 incident where gold never arrived). Rewards now always become proposals decided by policy and the GM.
+- **Stale settlement notice**: After the money settled, the round kept showing "结算待确认：关联结果尚未生效" forever. The notice is now cleared once every decision has resolved, and solo tables show settlement confirmations directly on the shared timeline (multiplayer visibility routing is unchanged: public deals stay public, GM's private deals stay private).
 
-### Models, connectivity, and operations
+### Breaking changes and upgrade notes
 
-- **Provider catalog and main model**: Choose the main model directly from the catalog. Configuration writes roll back on failure so the UI and stored configuration cannot silently diverge.
-- **Clearer connection guidance**: Settings now explain local HTTPS, LAN/public access, certificates, and Android connectivity, with improved mobile layouts for related controls.
-- **Runtime logs and diagnostics**: Runtime logs can be retained and exported. With explicit permission, the built-in assistant can inspect a bounded, redacted DiceFrame diagnostic context for troubleshooting.
-- **Managed Docker updates**: Containers can download and verify an application update package, switch versions after health checks and a probation period, and return to the prior application version on failure while business data remains separate.
-
-### Included in this release
-
-- **Same-round purchase confirmation**: When a player's first purchase request is priced by a human-stated number in that round's narration, the payer confirmation dialog now appears in the same round. While no price exists, narrative delivery of the item is intercepted — the purchase only completes through explicit payer confirmation, never free handouts.
-- **No more repeated purchase dialogs**: The GM planner now sees recent purchase history (status, items, quantity, amount). Browsing, questions, and using bought items are no longer misread as new purchases; a pending quote is never stacked with a second dialog, and settled or declined deals do not reopen unless the player explicitly buys again.
-- **Relaxed automatic reward settlement**: The default gold cap for auto-settled plain rewards rises from 50 to 10000, so most narrative rewards settle automatically; per-game configuration can lower it again.
-
-### Fixes, compatibility, and update reliability
-
-- **Item quantity suffixes**: Trailing `xN` / `×N` quantity suffixes in LOOT item strings are parsed correctly, eliminating junk rows like "回复药水x5 ×1"; same-name items stack by quantity, including purchase deliveries.
-- **Settlement card text**: Settlement cards no longer render a doubled full stop when the model-written reason already ends with one.
-- **Purchase proposal migration**: Legacy purchase request and order fields are safely removed during migration without changing already-settled balances, items, or transaction history.
-- **Ruleset boundaries**: D&D-specific automation remains inside the D&D runtime boundary and does not automatically alter traditional rules, Call of Cthulhu, cyberpunk, or generic d20 play.
-
-### Upgrade notes
-
-- When upgrading from **v2.3.2**, back up the complete `data/` directory first. When replacing application files with a portable or source package, do not overwrite, delete, or manually clear `data/`.
-- On first startup, bundled templates and compatibility data are upgraded only when this is safe to determine. User-edited worldbooks and content are never unconditionally overwritten; uncertain cases are preserved unchanged.
-- Adventure packages bound to saves remain read-only and undeletable so restarts always use the same validated content.
-- Restart and reset clear session-derived memory for that game to prevent narrative carry-over; they do not delete other saves.
-- Automatic reward settlement is enabled by default with the cap raised to 10000 gold; lower `economy_auto_reward_gold_cap` or disable `economy_auto_reward_enabled` in the configuration to return to strict confirmation.
-- Save migration to schema 7 removes legacy `purchase_requests` and `purchase_orders`; unconfirmed legacy purchase requests are not guaranteed to survive.
-- Managed Docker updates currently support `linux-amd64`.
+- **AI services require shared provider references**: Narrative LLM, embeddings, speech recognition, and image generation no longer accept the legacy standalone base_url/api_key configuration. After upgrading, confirm each capability's provider reference in the admin provider settings; configurations already using provider references need no change.
+- **Save migration to schema 8**: Pending transfer/fee/team-split proposals are superseded (they never charged anyone); committed transactions, balances, and items are untouched.
+- The global default cap for auto-settled rewards is now 500; adjust it per game in "Game settings" to match each table's economy (D&D gold and CoC dollars scale independently).
+- Upgrading from v2.5.2 needs no extra steps; backing up the complete `data/` directory before upgrading remains recommended for important campaigns.
 
 ### Downloads and verification
 
-- **Regular Windows users**: `DiceFrame-v2.5.2-windows-portable.zip`
-- **Source-run users**: `DiceFrame-v2.5.2-windows.zip`
-- **Managed Docker update**: `DiceFrame-v2.5.2-docker-update-linux-amd64.zip`
+- **Regular Windows users**: `DiceFrame-v2.5.3-windows-portable.zip`
+- **Source-run users**: `DiceFrame-v2.5.3-windows.zip`
+- **Managed Docker update**: `DiceFrame-v2.5.3-docker-update-linux-amd64.zip`
 - Verify downloads with the Release `SHA256SUMS`. For important campaigns, keep the prior program version and a data backup so rollback remains possible.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
Release prep for v2.5.3.

- RELEASE_NOTES.md switches to a delta-only format (only changes since v2.5.2; the full 2.5 feature tour stays on the historical release pages) covering the economy/payment convergence (#233), the reward-swallowing and stale-notice fixes, and the breaking provider-reference config refactor (#232).
- `src/version.py` bumps to 2.5.3.

