### PR TITLE
fix(play): only submit reward policy when the GM actually changed it

### DIFF
--- a/frontend-v2/src/features/play/PlayView.vue
+++ b/frontend-v2/src/features/play/PlayView.vue
@@ -43,7 +43,7 @@ import { ruleSceneUrl } from '@/composables/useBackgroundImages'
 import { fileToBase64, resolveGameSceneImageUrl, revokeSceneImageUrl, sceneImageStyle } from '@/api/sceneImages'
 import { fetchRulesetAvailableActions } from '@/api/rulesets'
 import { currencyLabel } from '@/utils/ruleSchema'
-import { isEconomyProposalActionable, isNonBlockingPersonalPurchase, nextEconomyProposal } from '@/features/play/economyPrompts'
+import { buildRewardPolicySave, isEconomyProposalActionable, isNonBlockingPersonalPurchase, nextEconomyProposal } from '@/features/play/economyPrompts'
 
 defineOptions({ name: 'PlayView' })
 
@@ -61,7 +61,7 @@ const { locale, setLocale, t } = useLocale()
 const help = ref(false), ruleMeta = ref<RuleMeta>({}), preview = ref(false), delegate = ref(false), cards = ref<CharacterCard[]>([]), showCards = ref(false), health = ref<HealthResponse>({ events: [] })
 const showKpQuestion = ref(false)
 const worldCandidates = ref<WorldCandidate[]>([]), showWorldSwitch = ref(false), showRoomPassword = ref(false), roomPasswordInput = ref(''), luckTimeoutInput = ref('')
-const rewardPolicyMode = ref(''), rewardPolicyCap = ref('')
+const rewardPolicyMode = ref(''), rewardPolicyCap = ref(''), rewardPolicyTouched = ref(false)
 const sidebarCollapsed = ref(localStorage.getItem('play_sidebar_collapsed') === '1')
 const mobilePanel = ref<'sidebar' | 'controls' | ''>('')
 const showMap = ref(false)
@@ -493,6 +493,9 @@ function onRoomPassword() {
   const policy = game.detail.value?.economy_reward_policy || {}
   rewardPolicyMode.value = policy.mode || ''
   rewardPolicyCap.value = policy.auto_reward_cap ? String(policy.auto_reward_cap) : ''
+  // 只有 GM 真正改动了奖励策略字段才提交：detail 未加载或未触碰时提交
+  // 会把空 mode 当作“清除本局覆盖”，改密码/超时就会误重置奖励策略。
+  rewardPolicyTouched.value = false
   showRoomPassword.value = true
 }
 async function setRoomPassword() {
@@ -506,13 +509,15 @@ async function setRoomPassword() {
       if (ltR.error || ltR.ok === false) throw new Error(ltR.error || t('settingFailed'))
       toast.success(t('luckTimeoutSaved', { seconds: lt }))
     }
-    // 奖励策略总是提交：mode 为空表示清除本局覆盖、回退规则/服务器默认。
-    const capRaw = String(rewardPolicyCap.value || '').trim()
-    const rewardBody: Record<string, unknown> = { mode: rewardPolicyMode.value }
-    if (capRaw !== '') rewardBody.auto_reward_cap = Number(capRaw)
-    const rpR = await api<{ ok?: boolean; error?: string }>(`/games/${encodeURIComponent(game.currentGame.value)}/settings/reward-policy`, { method: 'POST', body: JSON.stringify(rewardBody) })
-    if (rpR.error || rpR.ok === false) throw new Error(rpR.error || t('settingFailed'))
-    if (rewardPolicyMode.value !== '') toast.success(t('rewardPolicySaved'))
+    // 奖励策略仅在 GM 实际改动过时提交；显式选“跟随默认”仍会清除覆盖。
+    const rewardSave = buildRewardPolicySave(
+      rewardPolicyTouched.value, rewardPolicyMode.value, rewardPolicyCap.value,
+    )
+    if (rewardSave) {
+      const rpR = await api<{ ok?: boolean; error?: string }>(`/games/${encodeURIComponent(game.currentGame.value)}/settings/reward-policy`, { method: 'POST', body: JSON.stringify(rewardSave) })
+      if (rpR.error || rpR.ok === false) throw new Error(rpR.error || t('settingFailed'))
+      if (rewardPolicyMode.value !== '') toast.success(t('rewardPolicySaved'))
+    }
     showRoomPassword.value = false
     toast.success(roomPasswordInput.value ? t('roomPasswordUpdated') : t('roomPasswordCleared'))
     await game.refresh()
@@ -1361,13 +1366,13 @@ onBeforeUnmount(() => {
         <label>{{ t('newPassword') }}<input type="password" v-model="roomPasswordInput" :placeholder="t('emptyCancelsPassword')" @keyup.enter="setRoomPassword"></label>
         <label>{{ t('luckTimeoutSeconds') }}<input type="number" v-model="luckTimeoutInput" :placeholder="t('luckTimeoutPlaceholder')" min="0" max="3600"></label>
         <label>{{ t('rewardPolicyMode') }}
-          <select v-model="rewardPolicyMode">
+          <select v-model="rewardPolicyMode" @change="rewardPolicyTouched = true">
             <option value="">{{ t('rewardPolicyFollowDefault') }}</option>
             <option value="auto_small_cash">{{ t('rewardPolicyAutoSmallCash') }}</option>
             <option value="gm_confirm">{{ t('rewardPolicyGmConfirm') }}</option>
           </select>
         </label>
-        <label v-if="rewardPolicyMode === 'auto_small_cash'">{{ t('rewardPolicyCap') }}<input type="number" v-model="rewardPolicyCap" :placeholder="t('rewardPolicyCapPlaceholder')" min="1"></label>
+        <label v-if="rewardPolicyMode === 'auto_small_cash'">{{ t('rewardPolicyCap') }}<input type="number" v-model="rewardPolicyCap" :placeholder="t('rewardPolicyCapPlaceholder')" min="1" @input="rewardPolicyTouched = true"></label>
         <div class="actions">
           <button @click="showRoomPassword = false">{{ t('cancel') }}</button>
           <button class="primary" @click="setRoomPassword">{{ t('saveAction') }}</button>

--- a/frontend-v2/src/features/play/economyPrompts.ts
+++ b/frontend-v2/src/features/play/economyPrompts.ts
@@ -39,3 +39,26 @@ export function nextEconomyProposal(
       && isEconomyProposalActionable(proposal, actorId, gmUid)
   })
 }
+
+/**
+ * Build the reward-policy save payload, or null when nothing should be sent.
+ *
+ * The game-settings dialog shares one save button with the room password and
+ * luck timeout. Submitting the reward policy unconditionally would clear the
+ * game's override whenever `economy_reward_policy` was missing from the
+ * loaded detail (empty mode means "clear" on the server). The request is
+ * therefore only built when the GM actually touched the reward fields;
+ * explicitly selecting the follow-default mode still clears the override.
+ */
+export function buildRewardPolicySave(
+  touched: boolean,
+  mode: string,
+  cap: string,
+): { mode: string; auto_reward_cap: number | null } | null {
+  if (!touched) return null
+  const trimmed = String(cap || '').trim()
+  return {
+    mode,
+    auto_reward_cap: trimmed !== '' ? Number(trimmed) : null,
+  }
+}

--- a/frontend-v2/tests/economyPrompts.test.ts
+++ b/frontend-v2/tests/economyPrompts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { PendingPayment } from '@/api/types'
-import { isEconomyProposalActionable, isNonBlockingPersonalPurchase, nextEconomyProposal } from '@/features/play/economyPrompts'
+import { buildRewardPolicySave, isEconomyProposalActionable, isNonBlockingPersonalPurchase, nextEconomyProposal } from '@/features/play/economyPrompts'
 
 const pending = (values: Partial<PendingPayment>): PendingPayment => ({
   id: 'proposal',
@@ -32,5 +32,35 @@ describe('economy prompt authority', () => {
     expect(nextEconomyProposal([first, second], 'player', 'gm', new Set(['first']))).toBe(second)
     expect(nextEconomyProposal([first], 'player', 'gm', new Set(['first']))).toBeUndefined()
     expect(nextEconomyProposal([first], 'player', 'gm', new Set())).toBe(first)
+  })
+})
+
+describe('reward policy save gating', () => {
+  it('skips the request when the GM never touched the reward fields', () => {
+    // 修改密码/幸运超时时不得顺带提交：detail 未加载时 mode 为空会被后端
+    // 解释为清除本局覆盖。
+    expect(buildRewardPolicySave(false, 'auto_small_cash', '120')).toBeNull()
+    expect(buildRewardPolicySave(false, '', '')).toBeNull()
+  })
+
+  it('submits exactly what the GM chose once the fields were touched', () => {
+    expect(buildRewardPolicySave(true, 'auto_small_cash', '120')).toEqual({
+      mode: 'auto_small_cash',
+      auto_reward_cap: 120,
+    })
+    // 留空上限 = 沿用规则/服务器默认。
+    expect(buildRewardPolicySave(true, 'auto_small_cash', '')).toEqual({
+      mode: 'auto_small_cash',
+      auto_reward_cap: null,
+    })
+    // 显式选择“跟随默认”= 清除本局覆盖。
+    expect(buildRewardPolicySave(true, '', '')).toEqual({
+      mode: '',
+      auto_reward_cap: null,
+    })
+    expect(buildRewardPolicySave(true, 'gm_confirm', '')).toEqual({
+      mode: 'gm_confirm',
+      auto_reward_cap: null,
+    })
   })
 })


### PR DESCRIPTION
Fixes the P1 review finding on #233: saving room password / luck timeout in the game-settings dialog could silently clear the game's reward-policy override when `game.detail` had not loaded `economy_reward_policy` (untouched empty mode = "clear" on the server).

Now the reward-policy request is only submitted when the GM actually touched the reward select / cap inputs; explicitly selecting follow-default still clears the override. Payload construction is extracted into `buildRewardPolicySave()` with vitest coverage for untouched / touched-with-cap / touched-without-cap / explicit-clear paths.

Risk surface: UI only (frontend gating; backend route semantics unchanged).
