### PR TITLE
fix(web): serve frontend scripts with stable MIME types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,75 +1,33 @@
-# DiceFrame v2.5.4
+# DiceFrame v2.5.5-beta.1
 
-> 战斗扩展正式版。v2.5.4 合并 Issue 212 的通用战斗能力、`freeform_wuxia` 首个规则接入，以及战斗结算与剧情叙事的衔接修复。升级重要战役前，请先备份完整的 `data/` 文件夹。
+> Windows 便携版前端加载修复测试版。
 
 ## 中文
 
-### 本版重点：通用战斗扩展
+### 修复内容
 
-- **公式化战斗效果**：新增受限 JSON 公式 DSL，服务端统一计算伤害、资源消耗和属性效果，客户端提交的数值不会成为结算依据。
-- **资源池与护盾**：支持 HP、内力等规则资源，以及独立护盾池；伤害按规则先处理护盾，再处理 HP。
-- **行动条调度**：新增 round-robin、initiative 和 threshold（ATB）调度器。阈值行动条由服务器推进，速度、阈值、溢出和消耗策略由规则声明。
-- **D&D 2024 适配**：D&D 2024 的伤害与治疗骰式接入通用公式求值，法术位、专注、豁免、濒死和胜负判定仍由 D&D 规则运行时负责。
-
-### `freeform_wuxia` 战斗接入
-
-- 规则模板可以声明战斗调度器、资源池和动作目录。
-- 内置内力掌、回春丹、属性 Buff 和护盾配置示例。
-- 新增服务端权威战斗动作接口、GM 操作、目标选择、库存消耗和存档持久化。
-- 管理端新增战斗扩展编辑器，游戏面板显示资源、行动条和参与实体。
-
-### 剧情衔接与可靠性
-
-- 已结算的战斗动作会作为可信事实交给下一次 GM 叙事，明确描写 NPC 受击、伤害和后果。
-- 叙事生成失败时保留待叙事事件；成功写入剧情后才消费，避免重复扣除或重复结算。
-- 历史日志中的状态变动会继续进入后续上下文，旧存档不会因为升级而丢失已有战斗结果。
-- 加强战斗事务、快照回滚、NPC 目标投影、编辑器布局和多人可见性处理。
-
-### 升级提示
-
-- 本版新增的战斗扩展状态是增量字段，旧存档可以继续加载；重要战役升级前仍建议备份 `data/`。
-- 只有声明 `combat` 能力的规则会启用战斗扩展；其他规则保持原有玩法。
-- 当前通用动作目录使用 `spell:*` 等 canonical action id 表达具体法术，状态类效果仍需后续规则能力继续扩展。
+- 修复部分 Windows 系统将 `.js` 静态资源标记为 `text/plain`，导致浏览器严格 MIME 检查拒绝执行脚本、页面只显示背景的问题。
+- 为 JavaScript、CSS、JSON、HTML 和 SVG 前端资源设置稳定的响应类型，不再依赖 Windows 注册表中的 MIME 关联。
+- 增加回归测试，模拟系统返回错误 MIME 类型并验证模块脚本仍以 `text/javascript` 提供。
 
 ### 下载与校验
 
-- **普通 Windows 用户**：`DiceFrame-v2.5.4-windows-portable.zip`
-- **源码运行用户**：`DiceFrame-v2.5.4-windows.zip`
-- **托管 Docker 更新**：`DiceFrame-v2.5.4-docker-update-linux-amd64.zip`
+- **普通 Windows 用户**：`DiceFrame-v2.5.5-beta.1-windows-portable.zip`
+- **源码运行用户**：`DiceFrame-v2.5.5-beta.1-windows.zip`
+- **托管 Docker 更新**：`DiceFrame-v2.5.5-beta.1-docker-update-linux-amd64.zip`
 - 下载后请使用 Release 中的 `SHA256SUMS` 校验文件。
 
 ## English
 
-### Highlights: generic combat extension
+### Fix
 
-- **Formula-driven combat effects**: a restricted JSON formula DSL evaluates damage, resource costs, and stat effects on the server; client-supplied totals are never authoritative.
-- **Resource pools and barriers**: rules can declare HP, qi, and other pools, including an independent barrier pool that absorbs damage before HP.
-- **Turn scheduling**: round-robin, initiative, and threshold (ATB) schedulers are available. Threshold advancement is server-authoritative and configured by the ruleset.
-- **D&D 2024 adapter**: D&D damage and healing dice use the generic formula evaluator while spell slots, concentration, saves, dying, and victory remain D&D-owned.
-
-### `freeform_wuxia` combat consumer
-
-- Rule templates can declare schedulers, resource pools, and action catalogs.
-- The built-in example includes qi palm, healing pill, stat buffs, and barriers.
-- Server-authoritative actions, GM control, target selection, inventory consumption, and persistence are wired end to end.
-- The admin editor and play panel expose the declared combat capability without reimplementing mechanics in the frontend.
-
-### Narrative continuity and reliability
-
-- Resolved combat actions are handed to the next GM narration as trusted facts, so NPC hits and consequences are described explicitly.
-- Failed narration keeps pending events; successful persistence consumes them exactly once, preventing duplicate mechanics.
-- Historical state changes remain available to later context, including saves created before this release.
-- Combat transactions, snapshot rollback, NPC projection, editor layout, and multiplayer visibility are hardened.
-
-### Upgrade notes
-
-- The new combat extension fields are additive, so existing saves remain loadable. Back up `data/` before upgrading important campaigns.
-- The extension is enabled only for rules that explicitly declare the `combat` capability; other rules keep their existing behavior.
-- Concrete spells use canonical action ids such as `spell:*`; status effects remain a follow-up capability.
+- Fixes a blank UI on Windows systems that associate `.js` files with `text/plain`, causing browsers to reject module scripts during strict MIME checking.
+- Serves JavaScript, CSS, JSON, HTML, and SVG frontend assets with stable content types independent of Windows registry MIME associations.
+- Adds regression coverage that simulates an incorrect system MIME mapping and verifies module scripts are still served as `text/javascript`.
 
 ### Downloads and verification
 
-- **Regular Windows users**: `DiceFrame-v2.5.4-windows-portable.zip`
-- **Source-run users**: `DiceFrame-v2.5.4-windows.zip`
-- **Managed Docker update**: `DiceFrame-v2.5.4-docker-update-linux-amd64.zip`
+- **Regular Windows users**: `DiceFrame-v2.5.5-beta.1-windows-portable.zip`
+- **Source-run users**: `DiceFrame-v2.5.5-beta.1-windows.zip`
+- **Managed Docker update**: `DiceFrame-v2.5.5-beta.1-docker-update-linux-amd64.zip`
 - Verify downloads with the `SHA256SUMS` file attached to the Release.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.5.4"
+__version__ = "2.5.5-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 

--- a/src/webui/routes/pages.py
+++ b/src/webui/routes/pages.py
@@ -66,6 +66,15 @@ async def v2_static_file(request: web.Request) -> web.FileResponse:
 
 _CHARSET_SUFFIXES = (".js", ".mjs", ".css", ".json", ".html", ".htm", ".svg", ".xml", ".txt")
 _STATIC_CONTENT_TYPES = {
+    # Windows registry MIME associations can label scripts as text/plain.
+    # Pin frontend types so browsers can load modules with strict MIME checks.
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+    ".json": "application/json",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".svg": "image/svg+xml",
     ".avif": "image/avif",
     ".webp": "image/webp",
     ".woff2": "font/woff2",

--- a/tests/test_search_engine_blocking.py
+++ b/tests/test_search_engine_blocking.py
@@ -9,6 +9,7 @@ from src.webui.routes.pages import (
     _guess_content_type,
     add_response_security_headers,
     robots_txt,
+    register_pages,
 )
 
 
@@ -71,3 +72,36 @@ def test_frontend_html_declares_noindex():
 def test_static_image_types_do_not_depend_on_the_windows_mime_registry():
     assert _guess_content_type(Path("avatar.webp")) == "image/webp"
     assert _guess_content_type(Path("background.avif")) == "image/avif"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("index.js", "text/javascript"),
+        ("module.mjs", "text/javascript"),
+        ("INDEX.JS", "text/javascript"),
+        ("index.css", "text/css"),
+    ],
+)
+async def test_frontend_assets_load_with_incorrect_system_mime_types(
+    tmp_path, monkeypatch, filename, content_type
+):
+    monkeypatch.setattr(
+        "src.webui.routes.pages.mimetypes.guess_type",
+        lambda *args, **kwargs: ("text/plain", None),
+    )
+    asset = b"/* frontend asset */"
+    (tmp_path / filename).write_bytes(asset)
+    app = web.Application()
+    app["static_v2_dir"] = tmp_path
+    app.on_response_prepare.append(add_response_security_headers)
+    register_pages(app)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get(f"/v2-assets/{filename}")
+        assert response.status == 200
+        assert response.content_type == content_type
+        assert response.charset == "utf-8"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert await response.read() == asset


### PR DESCRIPTION
## Summary

Fix the Windows portable blank page caused when the system MIME registry maps `.js` files to `text/plain`. Frontend scripts and other executable/static asset types now use stable server-defined content types, and the application version is prepared as `2.5.5-beta.1`.

## Why

Browsers enforce strict MIME checking for module scripts. A successful `200` response with `Content-Type: text/plain` still prevents Vue from starting, leaving only the background visible.

## Impact

- [x] UI only

## Module / Boundary

WebUI static asset route.

## Design / Migration Notes

N/A. No persisted data, API, permission, ruleset, or migration contract changes.

## Validation

- [x] `python -m pytest tests/test_search_engine_blocking.py -q` — 8 passed
- [x] `python -m pytest -q` — 2041 passed, 37 skipped
- [x] `python -m ruff check src/webui/routes/pages.py tests/test_search_engine_blocking.py`
- [x] `python scripts/build_release.py --allow-dirty`
- [x] Release archive privacy and forbidden-path inspection

## Contract Check

- [x] User data is not modified.
- [x] Permission and private-data boundaries are unchanged.
- [x] The regression is covered by an HTTP response test with a simulated bad Windows MIME mapping.
