### PR TITLE
ipv4/6协议地址下http/s端口同时运行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Docker host port. Container still listens on 9876.
 DICEFRAME_HTTP_PORT=9876
 
+#TRPG_WEB_PORT=18000
+TRPG_WEB_HOST=0.0.0.0,::
+
 # Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;
 # set another IANA zone here (e.g. Europe/Berlin) to override it.
 TZ=Asia/Shanghai

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -160,7 +160,7 @@ class ConfigStore:
 
         model = saved.get("model", "")
         port = int(env.get("TRPG_WEB_PORT") or saved.get("web_port", 18000))
-        host = str(env.get("TRPG_WEB_HOST") or saved.get("web_host", "0.0.0.0"))
+        host = str(env.get("TRPG_WEB_HOST") or saved.get("web_host", "0.0.0.0")).split(',')
         transport_config = parse_web_transport(saved.get("web_transport"), env)
         transport = build_server_transport(
             transport_config,

--- a/web_server.py
+++ b/web_server.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 import os
 import sys
+import signal
+import ssl
 
 from aiohttp import web
 
@@ -263,23 +265,56 @@ def _application_dependencies() -> ApplicationDependencies:
 
 app = create_app(_application_dependencies())
 
+async def main():
+
+    ssl_context = None
+    try:
+        ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_context.load_cert_chain('./data/server.crt', './data/server.key')
+    except Exception as exc:
+        # logger.warning("HTTPS 证书加载失败，仅启动 HTTP")
+        pass
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    sites = []
+
+    http_site = web.TCPSite(runner, host=HOST, port=PORT)
+    await http_site.start()
+    sites.append(http_site)
+    print(f"DiceFrame WebUI: {TRANSPORT.endpoint.url('127.0.0.1')}  (host={HOST})")
+
+    if ssl_context is not None:
+        https_site = web.TCPSite(
+            runner, host=HOST, port=18800, ssl_context=ssl_context
+        )
+        await https_site.start()
+        sites.append(https_site)
+        print(f"DiceFrame WebUI: 'https://127.0.0.1:18800'  (host={HOST})")
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGINT, stop_event.set)
+    loop.add_signal_handler(signal.SIGTERM, stop_event.set)
+
+    try:
+        await stop_event.wait()
+    finally:
+        await runner.cleanup()
+
+    if app.get("runtime_control", {}).get("restart_requested", False):
+        logger.info("DiceFrame 清理完成，正在重新启动")
+        return True
+    return False
+
 if __name__ == "__main__":
     runtime_log_path = configure_runtime_logging(DATA_DIR)
     logger.info("运行日志写入 %s（保留 %s 天）", runtime_log_path, RETENTION_DAYS)
     if TRANSPORT.degraded_error:
         logger.critical("%s", TRANSPORT.degraded_error)
-    print(f"DiceFrame WebUI: {TRANSPORT.endpoint.url('127.0.0.1')}  (host={HOST})")
     if not is_llm_config_ready(STATE):
         print("请在 WebUI 的 AI 服务商与模型配置中设置主模型。")
-    runtime_loop = asyncio.new_event_loop()
-    install_runtime_exception_handler(runtime_loop)
-    web.run_app(
-        app,
-        host=HOST,
-        port=PORT,
-        ssl_context=TRANSPORT.ssl_context,
-        loop=runtime_loop,
-    )
-    if app["runtime_control"]["restart_requested"]:
-        logger.info("DiceFrame 清理完成，正在重新启动")
+
+    restart = asyncio.run(main())
+    if restart:
         os.execv(sys.executable, [sys.executable, *sys.argv])


### PR DESCRIPTION
## Summary

添加http与https多协议端口同时运行，修改配置读取方式允许监听多种地址，配置文件里面ipv6端口之类的环境变量名具体叫什么我懒得想了你们加油

## Why

不是什么很重要的功能，但是我本地的其他服务都是走IPv6到设置了严格TLS的Cloudflare代理，没有这些小功能我会很难受。