### PR TITLE
feat(ui): GM 流程分组常驻「强制推进」并精简支付提案文案

### DIFF
--- a/frontend-v2/src/components/play/GmToolbar.vue
+++ b/frontend-v2/src/components/play/GmToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { NIcon } from 'naive-ui'
 import {
   PlayForwardOutline, ArrowUndoOutline, ShareOutline, BugOutline,
@@ -8,13 +8,18 @@ import {
   TrashOutline, SendOutline, ImageOutline, MapOutline,
   ReaderOutline,
   CashOutline,
+  StopCircleOutline,
 } from '@vicons/ionicons5'
 import type { GameDetail, Player } from '@/api/types'
 import { useLocale } from '@/composables/useLocale'
 
 const props = defineProps<{ detail: GameDetail; players: Player[]; isGm: boolean; recapBusy?: boolean }>()
+// 强制推进 = 中止在飞生成并重新处理本回合；只有本轮真的在判定/生成时才有意义
+// （平时点它等同于「推进」，所以平时禁用，避免两个按钮行为重复）。
+const forceAdvanceAvailable = computed(() => props.detail?.state === 'active_judgment')
 const emit = defineEmits<{
   advance: []
+  'force-advance': []
   rollback: []
   recap: []
   invite: []
@@ -77,6 +82,12 @@ function awardXp(userId: string) {
     <div class="gm-group gm-flow-group">
       <h4>{{ t('flow') }}</h4>
       <button @click="emit('advance')"><NIcon :component="PlayForwardOutline" size="14" /> {{ t('advance') }}</button>
+      <button
+        type="button"
+        :disabled="!forceAdvanceAvailable"
+        :title="t('gmForceAdvanceHint')"
+        @click="emit('force-advance')"
+      ><NIcon :component="StopCircleOutline" size="14" /> {{ t('gmForceAdvance') }}</button>
       <button @click="emit('rollback')"><NIcon :component="ArrowUndoOutline" size="14" /> {{ t('rollback') }}</button>
       <button @click="emit('payment')"><NIcon :component="CashOutline" size="14" /> {{ t('createPaymentProposal') }}</button>
       <button :disabled="recapBusy" @click="emit('recap')"><NIcon :component="ReaderOutline" size="14" /> {{ recapBusy ? t('storyRecapGenerating') : t('storyRecapGenerate') }}</button>

--- a/frontend-v2/src/features/play/PlayView.vue
+++ b/frontend-v2/src/features/play/PlayView.vue
@@ -1259,6 +1259,7 @@ onBeforeUnmount(() => {
           :is-gm="game.isGm.value"
           :recap-busy="storyRecapBusy"
           @advance="command('advance', { force: true })"
+          @force-advance="onForceAdvance"
           @rollback="command('rollback')"
           @recap="generateStoryRecap"
           @invite="invite"

--- a/frontend-v2/src/i18n/messages/zh-CN.ts
+++ b/frontend-v2/src/i18n/messages/zh-CN.ts
@@ -623,7 +623,7 @@ export const zhCN = {
   gmPaymentRewards: '确认后获得：{items}',
   gmPaymentReason: '（{reason}）',
   gmPaymentHelp: '确认后才会扣款并交付关联物品或结果；拒绝不会扣款。关闭窗口等同“稍后处理”，可从桌面顶部重新打开。',
-  createPaymentProposal: '发起支付提案',
+  createPaymentProposal: '支付提案',
   paymentPayer: '付款角色',
   paymentRecipient: '物品接收角色',
   paymentAmount: '金额',

--- a/frontend-v2/tests/GmToolbar.test.ts
+++ b/frontend-v2/tests/GmToolbar.test.ts
@@ -13,6 +13,27 @@ function findSelectWithOption(wrapper: VueWrapper, value: string) {
 }
 
 describe('GmToolbar',()=>{
+  it('exposes force advance inside the flow group and only enables it while generating',async()=>{
+    i18n.global.locale.value = 'zh-CN'
+    const mountWithState=(state:string)=>mount(GmToolbar,{global:{plugins:[i18n]},props:{
+      detail:{game_key:'web|room|bot',round_number:4,state},
+      players:[],
+      isGm:true,
+    }})
+
+    const idle=mountWithState('active_action')
+    const idleButton=idle.findAll('button').find(item => item.text().includes('强制推进'))
+    expect(idleButton, '强制推进应常驻在 GM 控台里，否则用户找不到').toBeTruthy()
+    expect(idleButton!.element.closest('.gm-flow-group'), '应放在「流程」分组里').toBeTruthy()
+    expect(idleButton!.attributes('disabled'), '非判定阶段应禁用，避免与「推进」行为重复').toBeDefined()
+
+    const busy=mountWithState('active_judgment')
+    const busyButton=busy.findAll('button').find(item => item.text().includes('强制推进'))!
+    expect(busyButton.attributes('disabled')).toBeUndefined()
+    await busyButton.trigger('click')
+    expect(busy.emitted('force-advance')).toHaveLength(1)
+  })
+
   it('emits one recap request and exposes its busy state',async()=>{
     i18n.global.locale.value = 'en'
     const wrapper=mount(GmToolbar,{global:{plugins:[i18n]},props:{


### PR DESCRIPTION
## 背景

PR #241 已经让后端支持「GM 强制推进中止在飞生成」，但前端入口只有判定阶段才出现的横幅面板，GM 在控台里找不到它。

## 改动

- **「流程」分组常驻入口**：`GmToolbar.vue` 的 `.gm-flow-group` 里、紧邻「推进」新增「强制推进」按钮。
  - 判定/生成中（`state === 'active_judgment'`）可点；其余时间 **disabled**，因为此时它与「推进」等价（`advance` 本身就是 `force=true`），两个都可点会变成行为重复的按钮。
  - 悬停 `title` 显示完整说明（复用既有 `gmForceAdvanceHint`，未新增 i18n key）。
  - 点击 emit `force-advance` → `PlayView` 复用既有确认框 + `advance?force=true`。
- **文案精简**：中文「发起支付提案」→「支付提案」（`createPaymentProposal`，仅 zh-CN；en/ja 已是短文案，保持不变）。
- **回归测试**：`tests/GmToolbar.test.ts` 新增用例，钉住"常驻存在 / 在 `.gm-flow-group` 内 / 非判定阶段 disabled / 生成中可点并 emit `force-advance`"。

## 验证

- `vue-tsc`、`eslint --max-warnings 0` 通过
- 前端全量：82 files / 394 tests 通过
- `static-v2` 重建后产物含 `gm-flow-group` 与「支付提案」，旧文案已消失

判定阶段上方原有的横幅面板保持不变（它是"卡住时的显眼提示"）。
