### PR TITLE
chore(release): prepare v2.5.5-beta.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,37 @@
-# DiceFrame v2.5.5-beta.1
+# DiceFrame v2.5.5-beta.2
 
-> Windows 便携版前端加载修复测试版。
+> 回合推进失败恢复与 GM 中止生成测试版。
 
 ## 中文
 
 ### 修复内容
 
-- 修复部分 Windows 系统将 `.js` 静态资源标记为 `text/plain`，导致浏览器严格 MIME 检查拒绝执行脚本、页面只显示背景的问题。
-- 为 JavaScript、CSS、JSON、HTML 和 SVG 前端资源设置稳定的响应类型，不再依赖 Windows 注册表中的 MIME 关联。
-- 增加回归测试，模拟系统返回错误 MIME 类型并验证模块脚本仍以 `text/javascript` 提供。
+- 修复判定/叙事生成失败后对局永久停在「正在生成剧情」的问题：失败会把本回合退回行动阶段，玩家不再遇到提交行动 409、界面无限等待、只能重启容器的卡死场景。
+- 失败回滚改为一致回滚：玩家血量、幸运决定、本轮检定与战斗结算缓存一起回到本轮开始前的状态；旧版 hp_based 路径对怪物造成的伤害也会回滚，重试不会再出现「结算记录显示受伤、实际血量却是满血」，也不会重复扣血。
+- GM 的「强制推进」现在会中止正在进行的生成：等待中的玩家会收到「本轮已被 GM 中止，已退回行动阶段」的明确提示，随后本回合按当前行动重新处理，不必再等模型超时。
+- 所有推进入口（玩家提交行动、幸运超时、命令行调试、`/stream-action`）共用同一恢复边界，任一入口失败都会回滚并落盘，不再有绕过服务层的卡死入口。
+- 剧情概览在落卡前校验来源日志：生成期间被回滚重写的回合不会再被挂上过期的旧概览。
 
 ### 下载与校验
 
-- **普通 Windows 用户**：`DiceFrame-v2.5.5-beta.1-windows-portable.zip`
-- **源码运行用户**：`DiceFrame-v2.5.5-beta.1-windows.zip`
-- **托管 Docker 更新**：`DiceFrame-v2.5.5-beta.1-docker-update-linux-amd64.zip`
+- **普通 Windows 用户**：`DiceFrame-v2.5.5-beta.2-windows-portable.zip`
+- **源码运行用户**：`DiceFrame-v2.5.5-beta.2-windows.zip`
+- **托管 Docker 更新**：`DiceFrame-v2.5.5-beta.2-docker-update-linux-amd64.zip`
 - 下载后请使用 Release 中的 `SHA256SUMS` 校验文件。
 
 ## English
 
-### Fix
+### Fixes
 
-- Fixes a blank UI on Windows systems that associate `.js` files with `text/plain`, causing browsers to reject module scripts during strict MIME checking.
-- Serves JavaScript, CSS, JSON, HTML, and SVG frontend assets with stable content types independent of Windows registry MIME associations.
-- Adds regression coverage that simulates an incorrect system MIME mapping and verifies module scripts are still served as `text/javascript`.
+- Fixes rounds getting permanently stuck on "Generating story" after a failed judgment/narration: the round now rolls back to the action phase instead of leaving players with 409s, an endless spinner, and a container restart as the only way out.
+- Rollback is now consistent: player HP, luck decisions, the round's checks and the combat resolution cache all return to the state from the start of the round. Legacy hp_based damage to NPCs is rolled back as well, so a retry no longer reports damage the HP never took — and never applies it twice.
+- GM "Force advance" now aborts a running generation: waiting players are told the GM stopped the round and that it is back in the action phase, and the round is reprocessed from the current actions instead of waiting out the model timeout.
+- Every advance entry point (player submit, luck timeout, CLI debug loop, `/stream-action`) shares one recovery boundary, so a failure on any of them rolls back and persists instead of leaving the game stuck.
+- Story recaps validate their source log before being attached, so a stale recap is never pinned onto a round that was rolled back and rewritten while it was generating.
 
 ### Downloads and verification
 
-- **Regular Windows users**: `DiceFrame-v2.5.5-beta.1-windows-portable.zip`
-- **Source-run users**: `DiceFrame-v2.5.5-beta.1-windows.zip`
-- **Managed Docker update**: `DiceFrame-v2.5.5-beta.1-docker-update-linux-amd64.zip`
+- **Regular Windows users**: `DiceFrame-v2.5.5-beta.2-windows-portable.zip`
+- **Source-run users**: `DiceFrame-v2.5.5-beta.2-windows.zip`
+- **Managed Docker update**: `DiceFrame-v2.5.5-beta.2-docker-update-linux-amd64.zip`
 - Verify downloads with the `SHA256SUMS` file attached to the Release.

--- a/src/version.py
+++ b/src/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "DiceFrame"
-__version__ = "2.5.5-beta.1"
+__version__ = "2.5.5-beta.2"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
 
 


### PR DESCRIPTION
## 背景

`v2.5.5-beta.2` 的 tag / Release / Docker 镜像都已发布完成，但发布提交（版本号 + 发布说明）没能进入 `main`：`main` 的 ruleset 要求「必须走 PR + 3 个必需状态检查」，直接推送被 GH013 拒绝。本 PR 按仓库既有的 release PR 约定（参考 #238 / #239）把这一步补上。

## 内容

只改两个文件，与 tag `v2.5.5-beta.2` 指向的提交完全一致：

- `src/version.py`：`2.5.5-beta.1` → `2.5.5-beta.2`
- `RELEASE_NOTES.md`：本版双语发布说明（判定/叙事失败恢复、GM 中止在飞生成、回滚一致性、概览来源校验）

## 验证

- tag `v2.5.5-beta.2` 已发布，Release 资产齐全（portable / windows / docker-update + `SHA256SUMS`），我已下载 portable 包核对 sha256 与公布值一致，包内 `__version__ = "2.5.5-beta.2"` 且含「强制推进」UI
- Release 已按预发布标记（`releases/latest` 仍指向 v2.5.4），Docker `2.5.5-beta.2` 已推送且 `:latest` 未被推动
- 合并后 `main` 的版本号与 tag 一致
