### PR TITLE
fix(lorebook): 编辑条目因保留字列名未加引号而 500

### DIFF
--- a/src/lorebook/store.py
+++ b/src/lorebook/store.py
@@ -190,7 +190,9 @@ class LorebookStore:
             fields[k] = v
         if not fields:
             return
-        set_clause = ", ".join(f"{k} = ?" for k in fields)
+        # 列名必须加引号：白名单里的 order / group 都是 SQL 保留字，
+        # 裸写会让 SQLite 直接语法错误（add_entry 的 INSERT 同样是加引号的）。
+        set_clause = ", ".join(f'"{k}" = ?' for k in fields)
         params.extend(fields.values())
         params.append(entry_id)
         self._execute(

--- a/tests/test_lorebook_store.py
+++ b/tests/test_lorebook_store.py
@@ -119,6 +119,35 @@ class TestEntryCRUD:
             store.close()
             path.unlink(missing_ok=True)
 
+    def test_update_entry_supports_reserved_word_columns(self):
+        """回归：order / group 是 SQL 保留字，编辑条目必须能保存。
+
+        前端保存会把整条条目 PUT 上来（含 order/group）。修复前列名未加引号，
+        UPDATE 会拼出 `SET order = ?` 并抛 sqlite3.OperationalError: near "order"，
+        表现为「世界书保存按钮失效」（路由 500）。
+        """
+        store, path = _temp_store()
+        try:
+            store.create_world("w1", "测试")
+            store.add_entry({"id": "e1", "world_id": "w1", "name": "草药师",
+                            "keywords": ["草药"], "content": "旧内容"})
+            store.update_entry("e1", {
+                "content": "新内容",
+                "order": 42,
+                "group": "NPC",
+                "group_weight": 3,
+                "probability": 80,
+            })
+            entry = store.get_entry("e1")
+            assert entry["content"] == "新内容"
+            assert entry["order"] == 42
+            assert entry["group"] == "NPC"
+            assert entry["group_weight"] == 3
+            assert entry["probability"] == 80
+        finally:
+            store.close()
+            path.unlink(missing_ok=True)
+
     def test_list_entries_by_world(self):
         store, path = _temp_store()
         try:

--- a/tests/test_webui_lorebook_flow.py
+++ b/tests/test_webui_lorebook_flow.py
@@ -179,3 +179,33 @@ async def test_copy_lorebook_copies_selected_source_entries(web_api):
     assert entries[0]["world_id"] == "template_world_copy_case"
 
 
+@pytest.mark.asyncio
+async def test_update_entry_accepts_frontend_payload_with_reserved_word_fields(web_api):
+    """回归：前端保存已有条目会整份提交（含 order/group），路由必须能落盘。
+
+    修复前 SET 子句列名未加引号，UPDATE 拼出 `SET "order" = ?` 的反例
+    （裸 `order = ?`）→ sqlite3.OperationalError: near "order" → 路由 500，
+    用户看到的就是「世界书保存按钮失效」。
+    """
+    api, lorebook, _registry, _llm, _worlds = web_api
+    lorebook.create_world("edit_world", "编辑世界")
+    lorebook.add_entry({
+        "id": "npc_herbalist", "world_id": "edit_world", "name": "草药师",
+        "type": "npc", "keywords": ["草药"], "content": "旧内容",
+    })
+
+    api.update_entry("npc_herbalist", {
+        "id": "npc_herbalist", "world_id": "edit_world", "name": "草药师", "type": "npc",
+        "keywords": ["草药", "药草"], "content": "新内容",
+        "visible_to": [], "connected_to": [], "triggers_recursive": [],
+        "order": 42, "group": "NPC", "group_weight": 3, "probability": 80,
+    })
+
+    entry = lorebook.get_entry("npc_herbalist")
+    assert entry["content"] == "新内容"
+    assert entry["keywords"] == ["草药", "药草"]
+    assert entry["order"] == 42
+    assert entry["group"] == "NPC"
+    assert entry["group_weight"] == 3
+
+


### PR DESCRIPTION
## 症状

世界书里编辑已有条目后点保存没有任何反应（前端把错误写进页面错误区），后端日志：

```
PUT /api/lorebook/npc_herbalist -> 500
  src/webui/routes/worlds.py:120 api_lorebook_update
  src/lorebook/store.py:196 update_entry
  src/lorebook/store.py:100 _execute
sqlite3.OperationalError: near "order": syntax error
```

## 根因

`LorebookStore.update_entry` 拼 SET 子句时**列名没有加引号**：

```python
set_clause = ", ".join(f"{k} = ?" for k in fields)   # order / group 是 SQL 保留字
```

而它的白名单里包含 `order` 与 `group` → 生成 `UPDATE lorebook_entries SET order = ?, ...` → SQLite 语法错误。
对照 `add_entry` 的 INSERT 是加引号的（`"order"`, `"group"`），所以**新建条目正常、编辑保存必挂**；前端保存会把整条条目（含 order/group）整份 PUT 上来，因此每次保存都会 500。

## 改动

- `src/lorebook/store.py`：SET 列名统一加引号（列名来自硬编码白名单，值仍参数化）。
- `tests/test_lorebook_store.py`：store 级回归——带 `order/group/group_weight/probability` 编辑并校验落盘。
- `tests/test_webui_lorebook_flow.py`：路由级回归——模拟前端整份提交（`api.update_entry`，与路由同一接缝）。

顺带确认 `src/memory/delta.py` 的同类动态列名写法使用的是非保留字硬编码键，无需修改。

## 验证

- 把修复临时退回后，两条新测试都复现 `sqlite3.OperationalError: near "order"`（与生产日志一致），恢复后全绿——测试确实能抓到该 bug。
- lorebook 相关 4 个测试文件 66 passed；全量后端 2083 passed / 1 skipped / 0 failed。
- `ruff` 与 `mypy` 通过。
