### PR TITLE
feat(web): HTTP 与 HTTPS 可同时监听，支持多地址绑定（重做 #242）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,18 @@
 # Docker host port. Container still listens on 9876.
 DICEFRAME_HTTP_PORT=9876
 
+# Additional listen addresses (host names or IPs, comma or space separated).
+# TRPG_WEB_HOST stays the primary address; TRPG_WEB_HOSTS only appends more.
+# Example for IPv4 + IPv6: TRPG_WEB_HOST=0.0.0.0 and TRPG_WEB_HOSTS=::
+TRPG_WEB_HOSTS=
+
+# Optional extra listeners so HTTP and HTTPS can run at the same time.
+# TRPG_WEB_HTTPS_PORT needs an enabled TLS mode (TRPG_TLS_MODE=self_signed or
+# lets_encrypt); it is skipped with a startup warning when HTTPS is off.
+# Example: HTTPS on 18000 (TRPG_TLS_MODE=self_signed) plus HTTP on 18080.
+TRPG_WEB_HTTP_PORT=
+TRPG_WEB_HTTPS_PORT=
+
 # Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;
 # set another IANA zone here (e.g. Europe/Berlin) to override it.
 TZ=Asia/Shanghai

--- a/src/web_transport/listeners.py
+++ b/src/web_transport/listeners.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""监听器拓扑：把主机地址、端口与传输配置展开成 "每个地址一个 site" 的计划。
+
+web_server 只负责执行计划；解析与校验都在这里，因此可以脱离 aiohttp 运行时
+单测。与 transport 一致：构建失败不抛异常，而是返回 warning，由调用方写入
+启动日志，绝不静默丢弃用户显式配置的监听地址。
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from aiohttp import web
+
+from src.web_transport.transport import ServerTransport
+
+logger = logging.getLogger("trpg.web_transport")
+
+MAX_PORT = 65535
+_HOST_SEPARATORS = re.compile(r"[,\s]+")
+DEFAULT_HOST = "0.0.0.0"
+
+
+@dataclass(frozen=True)
+class ListenerPlan:
+    """一个监听器：地址 + 端口 + 是否使用 TLS。"""
+
+    host: str
+    port: int
+    tls: bool
+
+    @property
+    def scheme(self) -> str:
+        return "https" if self.tls else "http"
+
+    @property
+    def address(self) -> str:
+        host = f"[{self.host}]" if ":" in self.host else self.host
+        return f"{host}:{self.port}"
+
+    def url(self, display_host: str = "127.0.0.1") -> str:
+        host = f"[{display_host}]" if ":" in str(display_host) else str(display_host)
+        return f"{self.scheme}://{host}:{self.port}"
+
+
+def split_hosts(raw: object) -> list[str]:
+    """把 "a,b c" 形式的主机串拆成列表；空白项与重复项会被丢弃。"""
+
+    return [item for item in _HOST_SEPARATORS.split(str(raw or "").strip()) if item]
+
+
+def normalize_hosts(raw: Iterable[object]) -> list[str]:
+    """规范化监听地址：只接受裸主机名或 IP（不接受 scheme / 端口 / 路径）。"""
+
+    hosts: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        value = str(item or "").strip()
+        if not value:
+            continue
+        if value.startswith("[") and value.endswith("]"):
+            value = value[1:-1].strip()
+        if not value:
+            continue
+        if "://" in value or "/" in value:
+            logger.warning("忽略无效的监听地址 %r：只接受主机名或 IP，不要带协议或路径", value)
+            continue
+        if ":" in value:
+            try:
+                ipaddress.IPv6Address(value)
+            except ValueError:
+                logger.warning("忽略无效的监听地址 %r：包含冒号但不是合法 IPv6 地址", value)
+                continue
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        hosts.append(value)
+    return hosts
+
+
+def parse_port(value: object) -> int | None:
+    """解析可选端口：非法或越界返回 None（由调用方给出 warning）。"""
+
+    if value is None or value == "":
+        return None
+    try:
+        port = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return port if 1 <= port <= MAX_PORT else None
+
+
+def build_listener_plan(
+    *,
+    hosts: Sequence[str],
+    port: int,
+    transport: ServerTransport,
+    http_port: int | None = None,
+    https_port: int | None = None,
+) -> tuple[list[ListenerPlan], list[str]]:
+    """展开监听计划。返回 (计划, 警告列表)；警告必须由调用方记录，不静默。"""
+
+    warnings: list[str] = []
+    primary_hosts = normalize_hosts(hosts) or [DEFAULT_HOST]
+    primary_tls = transport.ssl_context is not None
+    plan: list[ListenerPlan] = []
+
+    def add(host: str, item_port: int, tls: bool) -> bool:
+        if any(existing.host == host and existing.port == item_port for existing in plan):
+            return False
+        plan.append(ListenerPlan(host=host, port=item_port, tls=tls))
+        return True
+
+    for host in primary_hosts:
+        add(host, port, primary_tls)
+
+    def add_extra(raw_port: object, *, tls: bool, env_name: str) -> None:
+        if raw_port is None or raw_port == "":
+            return
+        extra_port = parse_port(raw_port)
+        if extra_port is None:
+            warnings.append(f"忽略 {env_name}={raw_port!r}：端口必须是 1-{MAX_PORT} 的整数")
+            return
+        if extra_port == port:
+            warnings.append(f"忽略 {env_name}={extra_port}：与主端口相同")
+            return
+        if tls and transport.ssl_context is None:
+            detail = f"（{transport.degraded_error}）" if transport.degraded_error else ""
+            warnings.append(
+                f"忽略 {env_name}={extra_port}：当前未启用 HTTPS，没有可用的 TLS 上下文{detail}"
+            )
+            return
+        added = [host for host in primary_hosts if add(host, extra_port, tls)]
+        if not added:
+            warnings.append(f"忽略 {env_name}={extra_port}：该端口已由其它监听器占用")
+
+    add_extra(http_port, tls=False, env_name="TRPG_WEB_HTTP_PORT")
+    add_extra(https_port, tls=True, env_name="TRPG_WEB_HTTPS_PORT")
+    return plan, warnings
+
+
+async def start_listeners(
+    runner: web.AppRunner,
+    plan: Sequence[ListenerPlan],
+    transport: ServerTransport,
+) -> tuple[list[ListenerPlan], list[str]]:
+    """按计划启动监听器。单个地址失败不影响其它地址，失败原因原样返回。"""
+
+    started: list[ListenerPlan] = []
+    failures: list[str] = []
+    for item in plan:
+        site = web.TCPSite(
+            runner,
+            host=item.host,
+            port=item.port,
+            ssl_context=transport.ssl_context if item.tls else None,
+        )
+        try:
+            await site.start()
+        except OSError as exc:
+            failure = f"{item.scheme}://{item.address} 监听失败：{exc}"
+            failures.append(failure)
+            logger.error("%s", failure)
+            continue
+        started.append(item)
+    return started, failures

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -34,6 +34,7 @@ from src.network_proxy import (
     mask_proxy_url,
 )
 from src.web_transport import ServerTransport, build_server_transport, parse_web_transport
+from src.web_transport.listeners import normalize_hosts, parse_port, split_hosts
 from src.webui.access_password import mask_access_password, normalize_access_password
 from src.webui.cors import normalize_cors_origins, parse_cors_origins
 from src.webui.services import legal as legal_svc
@@ -97,6 +98,10 @@ class RuntimeConfig:
     secrets: dict[str, Any]
     host: str
     port: int
+    # 额外监听拓扑：hosts 至少含 host；两个可选端口用于同时提供 HTTP/HTTPS。
+    hosts: tuple[str, ...]
+    http_port: int | None
+    https_port: int | None
     transport: ServerTransport
     cors_env_value: str
     cors_config_value: str
@@ -161,6 +166,13 @@ class ConfigStore:
         model = saved.get("model", "")
         port = int(env.get("TRPG_WEB_PORT") or saved.get("web_port", 18000))
         host = str(env.get("TRPG_WEB_HOST") or saved.get("web_host", "0.0.0.0"))
+        # 多地址监听：TRPG_WEB_HOSTS 只做追加，不改变 TRPG_WEB_HOST 的既有语义。
+        extra_hosts = normalize_hosts(
+            split_hosts(env.get("TRPG_WEB_HOSTS") or saved.get("web_hosts") or "")
+        )
+        hosts = normalize_hosts([host, *extra_hosts]) or [host]
+        http_port = parse_port(env.get("TRPG_WEB_HTTP_PORT") or saved.get("web_http_port"))
+        https_port = parse_port(env.get("TRPG_WEB_HTTPS_PORT") or saved.get("web_https_port"))
         transport_config = parse_web_transport(saved.get("web_transport"), env)
         transport = build_server_transport(
             transport_config,
@@ -356,6 +368,9 @@ class ConfigStore:
                 "legal_privacy_acknowledged_version", ""
             ),
             "web_transport": dict(saved.get("web_transport") or {}),
+            "web_hosts": ",".join(hosts),
+            "web_http_port": http_port or "",
+            "web_https_port": https_port or "",
         }
         return RuntimeConfig(
             paths=self.paths,
@@ -364,6 +379,9 @@ class ConfigStore:
             secrets=secret_values,
             host=host,
             port=port,
+            hosts=tuple(hosts),
+            http_port=http_port,
+            https_port=https_port,
             transport=transport,
             cors_env_value=cors_env_value,
             cors_config_value=cors_config_value,

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -14,6 +14,59 @@ def _store(tmp_path, environ=None):
     return ConfigStore(paths, environment), paths
 
 
+def test_web_listen_topology_reads_env_and_config(tmp_path):
+    """多地址与附加 HTTP/HTTPS 端口：env 优先，且不改变 TRPG_WEB_HOST 语义。"""
+
+    store, paths = _store(
+        tmp_path,
+        {
+            "TRPG_WEB_PORT": "19001",
+            "TRPG_WEB_HOST": "0.0.0.0",
+            "TRPG_WEB_HOSTS": "::,127.0.0.1,",
+            "TRPG_WEB_HTTP_PORT": "19080",
+            "TRPG_WEB_HTTPS_PORT": "not-a-port",
+        },
+    )
+    paths.data_dir.mkdir(parents=True)
+    paths.config_file.write_text(
+        json.dumps({"web_hosts": "10.0.0.9", "web_http_port": 9000, "web_https_port": 9443}),
+        encoding="utf-8",
+    )
+
+    runtime = store.load()
+
+    # env 覆盖配置：hosts 为主地址 + 追加地址；非法 https 端口被忽略。
+    assert runtime.host == "0.0.0.0"
+    assert runtime.hosts == ("0.0.0.0", "::", "127.0.0.1")
+    assert runtime.http_port == 19080
+    assert runtime.https_port is None
+    assert runtime.state["web_hosts"] == "0.0.0.0,::,127.0.0.1"
+    assert runtime.state["web_http_port"] == 19080
+    assert runtime.state["web_https_port"] == ""
+
+
+def test_web_listen_topology_falls_back_to_saved_config(tmp_path):
+    store, paths = _store(tmp_path)
+    paths.data_dir.mkdir(parents=True)
+    paths.config_file.write_text(
+        json.dumps(
+            {
+                "web_host": "127.0.0.1",
+                "web_hosts": "10.0.0.9",
+                "web_http_port": 9000,
+                "web_https_port": 9443,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = store.load()
+
+    assert runtime.hosts == ("127.0.0.1", "10.0.0.9")
+    assert runtime.http_port == 9000
+    assert runtime.https_port == 9443
+
+
 def test_legacy_ai_environment_and_files_are_ignored_but_web_env_has_priority(tmp_path):
     store, paths = _store(
         tmp_path,

--- a/tests/test_web_listener_plan.py
+++ b/tests/test_web_listener_plan.py
@@ -1,0 +1,248 @@
+"""监听拓扑：HTTP/HTTPS 同时监听、多地址展开与真实双协议连通性。
+
+需求来自社区 PR #242（IPv4/IPv6 下 HTTP 与 HTTPS 同时运行）。这里按仓库既有
+transport 契约实现：TLS 上下文仍由 build_server_transport 提供，本模块只做
+"哪个地址、哪个端口、要不要 TLS" 的展开与启动。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from src.web_transport.config import TLS_MODE_OFF, TLS_MODE_SELF_SIGNED, WebTransportConfig
+from src.web_transport.listeners import (
+    ListenerPlan,
+    build_listener_plan,
+    normalize_hosts,
+    parse_port,
+    split_hosts,
+    start_listeners,
+)
+from src.web_transport.transport import ServerTransport, build_server_transport
+
+
+def _http_transport() -> ServerTransport:
+    return ServerTransport(
+        scheme="http",
+        tls_mode=TLS_MODE_OFF,
+        ssl_context=None,
+        endpoint=build_server_transport(
+            WebTransportConfig(), Path("."), 18000
+        ).endpoint,
+    )
+
+
+def _tls_transport(tmp_path: Path, port: int = 18000) -> ServerTransport:
+    transport = build_server_transport(
+        WebTransportConfig(tls_mode=TLS_MODE_SELF_SIGNED), tmp_path, port
+    )
+    assert transport.ssl_context is not None, transport.degraded_error
+    return transport
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_single_host_plan_keeps_the_previous_behaviour() -> None:
+    plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=_http_transport(),
+    )
+
+    assert plan == [ListenerPlan(host="0.0.0.0", port=18000, tls=False)]
+    assert warnings == []
+    assert plan[0].url() == "http://127.0.0.1:18000"
+
+
+def test_http_and_https_listen_side_by_side(tmp_path: Path) -> None:
+    """社区 PR #242 的核心诉求：TLS 开着的同时再开一个 HTTP 端口。"""
+
+    transport = _tls_transport(tmp_path)
+    plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=transport, http_port=18080,
+    )
+
+    assert warnings == []
+    assert [(item.port, item.scheme) for item in plan] == [(18000, "https"), (18080, "http")]
+
+
+def test_https_extra_port_requires_a_tls_context() -> None:
+    plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=_http_transport(), https_port=18443,
+    )
+
+    assert [(item.port, item.scheme) for item in plan] == [(18000, "http")]
+    assert len(warnings) == 1
+    assert "TRPG_WEB_HTTPS_PORT=18443" in warnings[0]
+    assert "未启用 HTTPS" in warnings[0]
+
+
+def test_degraded_transport_reports_why_https_is_unavailable() -> None:
+    transport = _http_transport()
+    transport.degraded_error = "本地 HTTPS 启用失败，已暂时回退 HTTP：证书缺失"
+
+    _plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=transport, https_port=18443,
+    )
+
+    assert "证书缺失" in warnings[0]
+
+
+def test_multiple_hosts_expand_to_one_listener_each() -> None:
+    plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0", "::"], port=18000, transport=_http_transport(),
+        http_port=18080,
+    )
+
+    assert warnings == []
+    assert [(item.host, item.port) for item in plan] == [
+        ("0.0.0.0", 18000), ("::", 18000), ("0.0.0.0", 18080), ("::", 18080),
+    ]
+    assert plan[1].address == "[::]:18000"
+    assert plan[1].url("::") == "http://[::]:18000"
+
+
+def test_duplicate_addresses_and_ports_collapse_without_duplicating_sites() -> None:
+    plan, warnings = build_listener_plan(
+        hosts=["0.0.0.0", "0.0.0.0", "[::]"], port=18000,
+        transport=_http_transport(), http_port=18000, https_port=18000,
+    )
+
+    assert [(item.host, item.port) for item in plan] == [("0.0.0.0", 18000), ("::", 18000)]
+    assert warnings == [
+        "忽略 TRPG_WEB_HTTP_PORT=18000：与主端口相同",
+        "忽略 TRPG_WEB_HTTPS_PORT=18000：与主端口相同",
+    ]
+
+
+def test_invalid_hosts_and_ports_are_skipped_with_warnings() -> None:
+    plan, warnings = build_listener_plan(
+        hosts=["http://example.com", "host:8080", "good.example", "/tmp/x"],
+        port=18000, transport=_http_transport(),
+        http_port="70000", https_port="abc",
+    )
+
+    assert [item.host for item in plan] == ["good.example"]
+    assert len(warnings) == 2
+    assert "TRPG_WEB_HTTP_PORT='70000'" in warnings[0]
+    assert "TRPG_WEB_HTTPS_PORT='abc'" in warnings[1]
+
+
+def test_all_invalid_hosts_fall_back_to_the_default_bind() -> None:
+    plan, _warnings = build_listener_plan(
+        hosts=["http://x", ""], port=18000, transport=_http_transport(),
+    )
+
+    assert [item.host for item in plan] == ["0.0.0.0"]
+
+
+def test_host_helpers() -> None:
+    assert split_hosts("0.0.0.0, ::  127.0.0.1") == ["0.0.0.0", "::", "127.0.0.1"]
+    assert split_hosts(None) == []
+    assert normalize_hosts(["127.0.0.1", "127.0.0.1", " :: "]) == ["127.0.0.1", "::"]
+    assert parse_port("18080") == 18080
+    assert parse_port(0) is None
+    assert parse_port("65536") is None
+    assert parse_port("") is None
+
+
+@pytest.mark.asyncio
+async def test_dual_listeners_actually_serve_http_and_https(tmp_path: Path) -> None:
+    """真实起两个监听器：HTTPS 主端口 + HTTP 附加端口，两边都要能连上。"""
+
+    https_port = _free_port()
+    http_port = _free_port()
+    transport = _tls_transport(tmp_path, https_port)
+    plan, warnings = build_listener_plan(
+        hosts=["127.0.0.1"], port=https_port, transport=transport, http_port=http_port,
+    )
+    assert warnings == []
+
+    async def health(_request: web.Request) -> web.Response:
+        return web.json_response({"ok": True})
+
+    app = web.Application()
+    app.router.add_get("/api/system/update/health", health)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        started, failures = await start_listeners(runner, plan, transport)
+        assert failures == []
+        assert {(item.port, item.scheme) for item in started} == {
+            (https_port, "https"), (http_port, "http"),
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{http_port}/api/system/update/health") as response:
+                assert response.status == 200
+                assert await response.json() == {"ok": True}
+            async with session.get(
+                f"https://127.0.0.1:{https_port}/api/system/update/health", ssl=False,
+            ) as response:
+                assert response.status == 200
+                assert await response.json() == {"ok": True}
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_one_failed_address_does_not_stop_the_others(tmp_path: Path) -> None:
+    """多地址里某个地址被占用时，其余监听器仍要能用（失败原因显式返回）。"""
+
+    busy_port = _free_port()
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", busy_port))
+    listener.listen(1)
+    try:
+        plan, _warnings = build_listener_plan(
+            hosts=["127.0.0.1"], port=busy_port, transport=_http_transport(),
+            http_port=_free_port(),
+        )
+        app = web.Application()
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            started, failures = await start_listeners(runner, plan, _http_transport())
+            assert [item.port for item in started] == [plan[1].port]
+            assert len(failures) == 1
+            assert str(busy_port) in failures[0]
+        finally:
+            await runner.cleanup()
+    finally:
+        listener.close()
+
+
+@pytest.mark.asyncio
+async def test_plan_start_is_idempotent_for_a_single_site() -> None:
+    """单监听器计划（默认配置）行为与改造前一致：只起一个 http site。"""
+
+    port = _free_port()
+    transport = _http_transport()
+    plan, _warnings = build_listener_plan(hosts=["127.0.0.1"], port=port, transport=transport)
+
+    app = web.Application()
+
+    async def root(_request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/", root)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        started, failures = await start_listeners(runner, plan, transport)
+        assert failures == [] and len(started) == 1
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{port}/") as response:
+                assert response.status == 200
+                assert await response.text() == "ok"
+    finally:
+        await runner.cleanup()
+        await asyncio.sleep(0)

--- a/web_server.py
+++ b/web_server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import asyncio
 import logging
 import os
+import signal
 import sys
 
 from aiohttp import web
@@ -41,6 +42,7 @@ from src.webui.bootstrap import (
     WebUIBootstrap,
 )
 from src.webui.access_control import WebAccessControl
+from src.web_transport.listeners import build_listener_plan, start_listeners
 from src.webui.config_controller import (
     ConfigController,
     ConfigControllerDependencies,
@@ -263,23 +265,63 @@ def _application_dependencies() -> ApplicationDependencies:
 
 app = create_app(_application_dependencies())
 
+
+async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
+    """按配置启动所有监听器；返回是否需要重启进程。
+
+    HTTP 与 HTTPS 可以同时监听（TRPG_WEB_HTTP_PORT / TRPG_WEB_HTTPS_PORT），
+    多地址（TRPG_WEB_HOSTS）则每个地址一个 site。计划构建与单个地址失败
+    处理都在 web_transport.listeners 里，未启动任何监听器时按原语义抛错退出。
+    """
+
+    plan, warnings = build_listener_plan(
+        hosts=RUNTIME_CONFIG.hosts,
+        port=PORT,
+        transport=TRANSPORT,
+        http_port=RUNTIME_CONFIG.http_port,
+        https_port=RUNTIME_CONFIG.https_port,
+    )
+    for message in warnings:
+        logger.warning("%s", message)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        started, failures = await start_listeners(runner, plan, TRANSPORT)
+        if not started:
+            raise OSError(failures[0] if failures else "没有可用的监听地址")
+        for item in started:
+            print(f"DiceFrame WebUI: {item.url('127.0.0.1')}  (host={item.host})")
+        stop_event = asyncio.Event()
+        try:
+            loop.add_signal_handler(signal.SIGINT, stop_event.set)
+            loop.add_signal_handler(signal.SIGTERM, stop_event.set)
+        except NotImplementedError:
+            # Windows 的事件循环不支持 add_signal_handler；Ctrl+C 仍会中断
+            # 主线程并由下面的 except 走清理路径。
+            pass
+        try:
+            await stop_event.wait()
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+    finally:
+        await runner.cleanup()
+    return bool(app["runtime_control"]["restart_requested"])
+
+
 if __name__ == "__main__":
     runtime_log_path = configure_runtime_logging(DATA_DIR)
     logger.info("运行日志写入 %s（保留 %s 天）", runtime_log_path, RETENTION_DAYS)
     if TRANSPORT.degraded_error:
         logger.critical("%s", TRANSPORT.degraded_error)
-    print(f"DiceFrame WebUI: {TRANSPORT.endpoint.url('127.0.0.1')}  (host={HOST})")
     if not is_llm_config_ready(STATE):
         print("请在 WebUI 的 AI 服务商与模型配置中设置主模型。")
     runtime_loop = asyncio.new_event_loop()
     install_runtime_exception_handler(runtime_loop)
-    web.run_app(
-        app,
-        host=HOST,
-        port=PORT,
-        ssl_context=TRANSPORT.ssl_context,
-        loop=runtime_loop,
-    )
-    if app["runtime_control"]["restart_requested"]:
+    try:
+        restart_requested = runtime_loop.run_until_complete(_serve(runtime_loop))
+    finally:
+        runtime_loop.close()
+    if restart_requested:
         logger.info("DiceFrame 清理完成，正在重新启动")
         os.execv(sys.executable, [sys.executable, *sys.argv])


### PR DESCRIPTION
## 背景

社区 PR #242（`@Sheng-wu-dev`）想要「IPv4/IPv6 下 HTTP 与 HTTPS 端口同时运行」。目标合理，但原实现绕开并回退了仓库已有的传输契约，无法直接合并：

- 新 HTTPS 监听器硬编码 `./data/server.crt` / `server.key` 和端口 **18800**，`except Exception: pass`（连 warning 都注释了）→ 与 `src/web_transport` 的「失败要显式降级并带 `degraded_error`」相反，而且实际监听不再使用 `TRANSPORT.ssl_context`，用户在安全页配的 HTTPS / Let's Encrypt 会被静默忽略；
- `loop.add_signal_handler(...)` 没做保护，Windows 上抛 `NotImplementedError`（aiohttp 自己在 `AppRunner.setup()` 里就是 `try/except` 处理的）→ 本仓库主要分发物是 Windows 便携包，一启动就挂；
- `host = str(...).split(",")` 把 `RuntimeConfig.host: str` 变成 list，而 `web.TCPSite` 只接受单个 host → 多地址根本没实现；
- 顺带丢掉 `install_runtime_exception_handler`，无测试、无文档。

本 PR 保留它的目标，改在既有 `web_transport` 契约内实现。

## 做了什么

- **新增 `src/web_transport/listeners.py`**：把「主机 + 端口 + 传输配置」展开成"每个地址一个 site"的监听计划。解析与校验和 aiohttp 运行时分离，可独立单测；单个地址绑定失败只记录并继续，**全部**失败才按原语义抛错退出。
- **`TRPG_WEB_HOSTS`**：追加额外监听地址（逗号或空格分隔，`TRPG_WEB_HOST` 仍是主地址，语义不变）。例如 IPv4 + IPv6：`TRPG_WEB_HOST=0.0.0.0` + `TRPG_WEB_HOSTS=::`。
- **`TRPG_WEB_HTTP_PORT` / `TRPG_WEB_HTTPS_PORT`**：可选附加端口，让 HTTP 与 HTTPS 同时可用。HTTPS 附加端口在没有 TLS 上下文时按**启动警告**忽略，并带上 `degraded_error` 的原因，不静默。
- **`web_server.py`** 改用 `AppRunner` 逐 site 启动（`web.run_app` 只支持单监听器），保留 `install_runtime_exception_handler`，并对 Windows 不支持 `add_signal_handler` 的情况显式降级；启动时为每个监听器打印 URL。
- `.env.example` 补三个变量的说明与示例；新值也进 `runtime_config.state` 便于 `/api/config` 查看。

## 验证

```
python -m pytest tests -q                       # 2132 passed, 1 skipped
python -m ruff check src/ tests/ web_server.py  # All checks passed
python -m mypy                                  # Success（新模块单独 --no-incremental 也通过）
```

新增测试 `tests/test_web_listener_plan.py`：
- `test_http_and_https_listen_side_by_side`（主 HTTPS + 附加 HTTP）
- `test_https_extra_port_requires_a_tls_context` + `test_degraded_transport_reports_why_https_is_unavailable`（不静默）
- `test_multiple_hosts_expand_to_one_listener_each`（`0.0.0.0` + `::` 各一个 site，IPv6 URL 加方括号）
- `test_duplicate_addresses_and_ports_collapse_without_duplicating_sites`、`test_invalid_hosts_and_ports_are_skipped_with_warnings`、`test_all_invalid_hosts_fall_back_to_the_default_bind`
- `test_dual_listeners_actually_serve_http_and_https`（真实起两个监听器，自签 HTTPS 与附加 HTTP 同时返回 200）
- `test_one_failed_address_does_not_stop_the_others`（单地址被占用时其余仍可用）

真实启动验证（临时 data 目录，`TRPG_TLS_MODE=self_signed` + `TRPG_WEB_HOST=127.0.0.1` + `TRPG_WEB_HTTP_PORT=18097`）：

```
$ curl -sk -o /dev/null -w '%{http_code}' https://127.0.0.1:18098/api/system/update/health   # 200
$ curl  -s -o /dev/null -w '%{http_code}' http://127.0.0.1:18097/api/system/update/health    # 200
$ curl  -s -o /dev/null -w '%{http_code}' http://127.0.0.1:18098/api/system/update/health    # 000（TLS 端口不接受明文）
启动输出：
DiceFrame WebUI: https://127.0.0.1:18098  (host=127.0.0.1)
DiceFrame WebUI: http://127.0.0.1:18097  (host=127.0.0.1)
```

## 兼容性

默认配置（不设新变量）仍是「单个 HTTP 监听器」，行为与改造前一致；`TRPG_WEB_HOST` / `TRPG_WEB_PORT` / `web_transport.tls_mode` 语义未变。无存档迁移。

原 PR #242 可以关闭（`@Sheng-wu-dev` 的目标已在本 PR 内实现，感谢提出）。
