### PR TITLE
fix(web): 修复 Windows 重启路径并补齐多监听器外围（#253 follow-up）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ TRPG_WEB_HOSTS=
 TRPG_WEB_HTTP_PORT=
 TRPG_WEB_HTTPS_PORT=
 
+# Docker: a listener inside the container is unreachable until its port is
+# published too, so set the ports above and start with the optional override:
+#   docker compose -f docker-compose.yml -f docker-compose.extra-ports.yml up -d
+# (TRPG_WEB_HOSTS alone needs no extra mapping as long as you use the main port.)
+
 # Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;
 # set another IANA zone here (e.g. Europe/Berlin) to override it.
 TZ=Asia/Shanghai

--- a/docker-compose.extra-ports.yml
+++ b/docker-compose.extra-ports.yml
@@ -1,0 +1,23 @@
+# 让容器里的 DiceFrame 同时对外提供 HTTP 与 HTTPS（可选叠加文件）。
+#
+# Docker 的端口映射无法"按需"生效：只要写在 ports 里就会占用宿主端口，所以默认的
+# docker-compose.yml 保持只发布主端口 9876（不额外开端口）。需要双协议时：
+#
+#   1) 在 .env 里设置（宿主机端口 = 容器端口，便于对照）：
+#        TRPG_WEB_HTTP_PORT=18080
+#        TRPG_WEB_HTTPS_PORT=18443
+#        TRPG_TLS_MODE=self_signed        # 或用安全页启用 Let's Encrypt
+#   2) docker compose -f docker-compose.yml -f docker-compose.extra-ports.yml up -d
+#
+# 只需要其中一个协议时，把不需要的那两行删掉即可。
+#
+# 注意：TRPG_TLS_MODE 等 TLS 设置仍由 data/config.json（安全页）或环境变量提供，
+# 本文件只负责发布端口，不改变 TLS 契约。
+services:
+  web:
+    environment:
+      TRPG_WEB_HTTP_PORT: "${TRPG_WEB_HTTP_PORT:?请在 .env 设置 TRPG_WEB_HTTP_PORT}"
+      TRPG_WEB_HTTPS_PORT: "${TRPG_WEB_HTTPS_PORT:?请在 .env 设置 TRPG_WEB_HTTPS_PORT}"
+    ports:
+      - "${TRPG_WEB_HTTP_PORT:?}:${TRPG_WEB_HTTP_PORT:?}"
+      - "${TRPG_WEB_HTTPS_PORT:?}:${TRPG_WEB_HTTPS_PORT:?}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
     environment:
       TRPG_WEB_HOST: "0.0.0.0"
       TRPG_WEB_PORT: "9876"
+      # 额外监听地址（例如 IPv6 的 ::）与附加 HTTP/HTTPS 端口。
+      # 注意：容器里监听了端口还需要在 ports 里映射出来，见
+      # docker-compose.extra-ports.yml 与 .env.example 的说明。
+      TRPG_WEB_HOSTS: "${TRPG_WEB_HOSTS:-}"
+      TRPG_WEB_HTTP_PORT: "${TRPG_WEB_HTTP_PORT:-}"
+      TRPG_WEB_HTTPS_PORT: "${TRPG_WEB_HTTPS_PORT:-}"
       TRPG_DATA_DIR: "/app/data"
       # The image already defaults to Asia/Shanghai; set TZ in .env to change it.
       TZ: "${TZ:-Asia/Shanghai}"

--- a/src/web_transport/endpoint.py
+++ b/src/web_transport/endpoint.py
@@ -13,10 +13,8 @@ from dataclasses import dataclass
 class ServerEndpoint:
     scheme: str
     port: int
-
-    @property
-    def local_host(self) -> str:
-        return "127.0.0.1"
+    # 本机内部调用（插件、健康检查）使用的回环地址；纯 IPv6 监听时为 ::1。
+    local_host: str = "127.0.0.1"
 
     def url(self, host: str | None = None, path: str = "") -> str:
         target = host or self.local_host

--- a/src/web_transport/lifecycle.py
+++ b/src/web_transport/lifecycle.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""进程生命周期辅助：把 "运行到收到停止信号" 与 "清理后是否重启" 分开。
+
+Windows 的事件循环不支持 ``loop.add_signal_handler``，DiceFrame 自己的重启接口
+（``signal.raise_signal(signal.SIGINT)``，见系统更新 / HTTPS 切换 / 证书续期）
+在那里会以 ``KeyboardInterrupt`` 的形式在 ``run_until_complete()`` **之外**抛出。
+如果只是让异常穿透，serve 协程的 ``finally``（``runner.cleanup()``）不会执行，
+``os.execv`` 也不会被触发 —— 便携版会表现为"点重启后进程直接退出"。
+
+本模块把这段控制流固定下来，便于单测。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable
+
+
+def run_with_graceful_shutdown(
+    loop: asyncio.AbstractEventLoop,
+    task: "asyncio.Task[Any] | asyncio.Future[Any]",
+    restart_requested: Callable[[], bool],
+    *,
+    wait: Callable[[Awaitable[Any]], Any] | None = None,
+) -> bool:
+    """运行 ``task`` 直到停止；被中断时先跑完清理再返回是否重启。
+
+    正常路径返回 ``task`` 的结果（约定为 bool）。
+    中断路径（``await`` 之外的 ``KeyboardInterrupt``）：cancel 任务并把任务跑完，
+    让协程的 ``finally`` 执行清理，然后按 ``restart_requested()`` 决定是否重启。
+    """
+
+    run = wait or loop.run_until_complete
+    try:
+        return bool(run(task))
+    except KeyboardInterrupt:
+        task.cancel()
+        try:
+            run(task)
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            pass
+        return bool(restart_requested())

--- a/src/web_transport/listeners.py
+++ b/src/web_transport/listeners.py
@@ -42,9 +42,30 @@ class ListenerPlan:
         host = f"[{self.host}]" if ":" in self.host else self.host
         return f"{host}:{self.port}"
 
-    def url(self, display_host: str = "127.0.0.1") -> str:
-        host = f"[{display_host}]" if ":" in str(display_host) else str(display_host)
+    def display_host(self) -> str:
+        """启动日志里给人看的地址：通配地址按同族回环展示。"""
+
+        if self.host in {"", "*", "0.0.0.0", "::"}:
+            return "::1" if ":" in self.host else "127.0.0.1"
+        return self.host
+
+    def url(self, display_host: str | None = None) -> str:
+        host = str(display_host) if display_host else self.display_host()
+        host = f"[{host}]" if ":" in host else host
         return f"{self.scheme}://{host}:{self.port}"
+
+
+def internal_loopback_host(hosts: Sequence[str]) -> str:
+    """内部客户端（插件、健康检查）应连接的回环地址。
+
+    只要绑定地址里存在 IPv4（含 0.0.0.0）就用 127.0.0.1；纯 IPv6 监听时用 ::1，
+    否则插件会去连一个根本没在监听的 IPv4 localhost。
+    """
+
+    normalized = normalize_hosts(hosts)
+    if normalized and all(":" in host for host in normalized):
+        return "::1"
+    return "127.0.0.1"
 
 
 def split_hosts(raw: object) -> list[str]:

--- a/src/web_transport/transport.py
+++ b/src/web_transport/transport.py
@@ -52,8 +52,17 @@ def _build_ssl_context(cert_path: Path, key_path: Path) -> ssl.SSLContext:
     return context
 
 
-def build_server_transport(config: WebTransportConfig, data_dir: Path, port: int) -> ServerTransport:
-    """根据配置构建 ServerTransport。off 模式 ssl_context=None。"""
+def build_server_transport(
+    config: WebTransportConfig,
+    data_dir: Path,
+    port: int,
+    local_host: str = "127.0.0.1",
+) -> ServerTransport:
+    """根据配置构建 ServerTransport。off 模式 ssl_context=None。
+
+    ``local_host`` 是本机内部调用（插件、健康检查）使用的回环地址，跟随实际
+    监听地址族：纯 IPv6 监听时传 ``::1``，否则插件会连一个没在监听的地址。
+    """
     store = CertificateStore(data_dir)
 
     def http_transport(error: str = "") -> ServerTransport:
@@ -61,7 +70,7 @@ def build_server_transport(config: WebTransportConfig, data_dir: Path, port: int
             scheme="http",
             tls_mode=TLS_MODE_OFF,
             ssl_context=None,
-            endpoint=ServerEndpoint(scheme="http", port=port),
+            endpoint=ServerEndpoint(scheme="http", port=port, local_host=local_host),
             degraded_error=error,
             provider=None,
             store=store,
@@ -110,7 +119,7 @@ def build_server_transport(config: WebTransportConfig, data_dir: Path, port: int
         scheme="https",
         tls_mode=config.tls_mode,
         ssl_context=ssl_context,
-        endpoint=ServerEndpoint(scheme="https", port=port),
+        endpoint=ServerEndpoint(scheme="https", port=port, local_host=local_host),
         provider=provider,
         store=store,
         config=config,

--- a/src/webui/bootstrap.py
+++ b/src/webui/bootstrap.py
@@ -132,7 +132,9 @@ class WebUIBootstrap:
             dependencies.paths.data_dir / "plugins",
             builtin_dir=dependencies.paths.root / "plugins",
             base_env={
-                "TRPG_API_BASE": dependencies.transport.endpoint.url("127.0.0.1")
+                # 跟随实际监听地址族：纯 IPv6 监听时为 [::1]，避免插件连不上
+                # 根本没在监听的 127.0.0.1。
+                "TRPG_API_BASE": dependencies.transport.endpoint.url()
             },
             on_plugin_stopped=on_plugin_stopped,
             hub_client=hub_client,

--- a/src/webui/runtime_config.py
+++ b/src/webui/runtime_config.py
@@ -34,7 +34,12 @@ from src.network_proxy import (
     mask_proxy_url,
 )
 from src.web_transport import ServerTransport, build_server_transport, parse_web_transport
-from src.web_transport.listeners import normalize_hosts, parse_port, split_hosts
+from src.web_transport.listeners import (
+    internal_loopback_host,
+    normalize_hosts,
+    parse_port,
+    split_hosts,
+)
 from src.webui.access_password import mask_access_password, normalize_access_password
 from src.webui.cors import normalize_cors_origins, parse_cors_origins
 from src.webui.services import legal as legal_svc
@@ -156,6 +161,18 @@ class ConfigStore:
                 self.logger.error("%s无法读取且未能隔离：%s", label, exc)
             return {}
 
+    def _optional_port(self, raw: Any, name: str) -> int | None:
+        """解析可选端口；非法值必须显式告警，不能静默丢弃用户配置。"""
+
+        if raw is None or raw == "":
+            return None
+        port = parse_port(raw)
+        if port is None:
+            self.logger.warning(
+                "忽略 %s=%r：端口必须是 1-65535 的整数", name, raw
+            )
+        return port
+
     def load(self) -> RuntimeConfig:
         self.paths.data_dir.mkdir(parents=True, exist_ok=True)
         saved = self.load_json_object(self.paths.config_file, "主配置")
@@ -171,13 +188,20 @@ class ConfigStore:
             split_hosts(env.get("TRPG_WEB_HOSTS") or saved.get("web_hosts") or "")
         )
         hosts = normalize_hosts([host, *extra_hosts]) or [host]
-        http_port = parse_port(env.get("TRPG_WEB_HTTP_PORT") or saved.get("web_http_port"))
-        https_port = parse_port(env.get("TRPG_WEB_HTTPS_PORT") or saved.get("web_https_port"))
+        http_port = self._optional_port(
+            env.get("TRPG_WEB_HTTP_PORT") or saved.get("web_http_port"),
+            "TRPG_WEB_HTTP_PORT",
+        )
+        https_port = self._optional_port(
+            env.get("TRPG_WEB_HTTPS_PORT") or saved.get("web_https_port"),
+            "TRPG_WEB_HTTPS_PORT",
+        )
         transport_config = parse_web_transport(saved.get("web_transport"), env)
         transport = build_server_transport(
             transport_config,
             self.paths.data_dir,
             port,
+            internal_loopback_host(hosts),
         )
         cors_env_value = str(env.get("TRPG_WEB_CORS_ORIGINS") or "").strip()
         cors_config_value = cors_env_value or str(saved.get("web_cors_origins") or "")

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -67,6 +67,35 @@ def test_web_listen_topology_falls_back_to_saved_config(tmp_path):
     assert runtime.https_port == 9443
 
 
+def test_invalid_extra_ports_warn_instead_of_disappearing(tmp_path, caplog):
+    """非法端口必须在读取配置时就告警：planner 只拿到 None，看不到原始值。"""
+
+    store, _paths = _store(
+        tmp_path, {"TRPG_WEB_HTTP_PORT": "abc", "TRPG_WEB_HTTPS_PORT": "70000"}
+    )
+
+    with caplog.at_level("WARNING"):
+        runtime = store.load()
+
+    assert runtime.http_port is None
+    assert runtime.https_port is None
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("TRPG_WEB_HTTP_PORT='abc'" in message for message in messages)
+    assert any("TRPG_WEB_HTTPS_PORT='70000'" in message for message in messages)
+
+
+def test_internal_loopback_follows_ipv6_only_listen_addresses(tmp_path):
+    """纯 IPv6 监听时插件 API 基址要指向 [::1]，否则插件连不上。"""
+
+    ipv4_store, _paths = _store(tmp_path / "v4", {"TRPG_WEB_HOST": "0.0.0.0"})
+    assert ipv4_store.load().transport.endpoint.url() == "http://127.0.0.1:18000"
+
+    ipv6_store, _paths = _store(
+        tmp_path / "v6", {"TRPG_WEB_HOST": "::", "TRPG_WEB_PORT": "19001"}
+    )
+    assert ipv6_store.load().transport.endpoint.url() == "http://[::1]:19001"
+
+
 def test_legacy_ai_environment_and_files_are_ignored_but_web_env_has_priority(tmp_path):
     store, paths = _store(
         tmp_path,

--- a/tests/test_web_listener_plan.py
+++ b/tests/test_web_listener_plan.py
@@ -19,6 +19,7 @@ from src.web_transport.config import TLS_MODE_OFF, TLS_MODE_SELF_SIGNED, WebTran
 from src.web_transport.listeners import (
     ListenerPlan,
     build_listener_plan,
+    internal_loopback_host,
     normalize_hosts,
     parse_port,
     split_hosts,
@@ -152,6 +153,36 @@ def test_host_helpers() -> None:
     assert parse_port(0) is None
     assert parse_port("65536") is None
     assert parse_port("") is None
+
+
+def test_startup_url_uses_the_same_address_family() -> None:
+    """启动日志不能对 IPv6-only 监听打印一个不可用的 IPv4 回环地址。"""
+
+    ipv6_plan, _warnings = build_listener_plan(
+        hosts=["::"], port=18000, transport=_http_transport(),
+    )
+    assert ipv6_plan[0].url() == "http://[::1]:18000"
+
+    ipv4_plan, _warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=_http_transport(),
+    )
+    assert ipv4_plan[0].url() == "http://127.0.0.1:18000"
+
+    explicit, _warnings = build_listener_plan(
+        hosts=["10.0.0.9"], port=18000, transport=_http_transport(),
+    )
+    assert explicit[0].url() == "http://10.0.0.9:18000"
+
+
+def test_internal_loopback_follows_the_bound_family() -> None:
+    """插件用的 TRPG_API_BASE 必须指向真的在监听的地址族。"""
+
+    assert internal_loopback_host(["0.0.0.0"]) == "127.0.0.1"
+    assert internal_loopback_host(["0.0.0.0", "::"]) == "127.0.0.1"
+    assert internal_loopback_host(["127.0.0.1"]) == "127.0.0.1"
+    assert internal_loopback_host(["::"]) == "::1"
+    assert internal_loopback_host(["::", "::1"]) == "::1"
+    assert internal_loopback_host([]) == "127.0.0.1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_restart.py
+++ b/tests/test_web_server_restart.py
@@ -1,0 +1,94 @@
+"""Windows 重启路径：中断必须跑完清理并按 restart_requested 重启。
+
+Windows 没有 asyncio signal handler，DiceFrame 自己的重启接口
+（signal.raise_signal(SIGINT)：系统更新 / HTTPS 切换 / 证书续期）会变成
+run_until_complete() 之外的 KeyboardInterrupt。这里固定住修复后的行为：
+cancel 任务 → 让协程的 finally 执行 → 读取重启标记。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.web_transport.lifecycle import run_with_graceful_shutdown
+
+
+def _loop_with_interrupt() -> tuple[asyncio.AbstractEventLoop, dict[str, int], list[bool]]:
+    """返回 (loop, run_until_complete 调用计数, 清理标记)。
+
+    第一次 run_until_complete() 先把事件循环跑起来（真实场景里中断发生在循环运行
+    期间，任务已经启动并停在 await 上），然后抛 KeyboardInterrupt 模拟 Windows：
+    没有 asyncio signal handler，中断在 run_until_complete() 之外抛出。
+    """
+
+    loop = asyncio.new_event_loop()
+    calls = {"count": 0}
+    cleaned: list[bool] = []
+    original = loop.run_until_complete
+
+    def flaky(future: Any) -> Any:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            original(asyncio.sleep(0.05))
+            raise KeyboardInterrupt
+        return original(future)
+
+    loop.run_until_complete = flaky  # type: ignore[method-assign]
+    return loop, calls, cleaned
+
+
+def test_interrupt_still_runs_cleanup_and_reports_restart() -> None:
+    loop, calls, cleaned = _loop_with_interrupt()
+
+    async def serve() -> bool:
+        try:
+            await asyncio.sleep(3600)
+        finally:
+            cleaned.append(True)
+        return False
+
+    task = loop.create_task(serve())
+    try:
+        restart = run_with_graceful_shutdown(loop, task, lambda: True)
+    finally:
+        loop.close()
+
+    assert calls["count"] == 2, "中断后必须再把任务跑完，否则清理不会执行"
+    assert cleaned == [True], "runner.cleanup() 一类的收尾必须执行"
+    assert restart is True
+    assert task.cancelled() or task.done()
+
+
+def test_interrupt_without_restart_flag_exits_cleanly() -> None:
+    loop, _calls, cleaned = _loop_with_interrupt()
+
+    async def serve() -> bool:
+        try:
+            await asyncio.sleep(3600)
+        finally:
+            cleaned.append(True)
+        return False
+
+    task = loop.create_task(serve())
+    try:
+        restart = run_with_graceful_shutdown(loop, task, lambda: False)
+    finally:
+        loop.close()
+
+    assert cleaned == [True]
+    assert restart is False
+
+
+def test_normal_stop_returns_the_task_result() -> None:
+    loop = asyncio.new_event_loop()
+
+    async def serve() -> bool:
+        return True
+
+    task = loop.create_task(serve())
+    try:
+        assert run_with_graceful_shutdown(loop, task, lambda: False) is True
+        assert loop.run_until_complete(asyncio.sleep(0)) is None
+    finally:
+        loop.close()

--- a/web_server.py
+++ b/web_server.py
@@ -42,6 +42,7 @@ from src.webui.bootstrap import (
     WebUIBootstrap,
 )
 from src.webui.access_control import WebAccessControl
+from src.web_transport.lifecycle import run_with_graceful_shutdown
 from src.web_transport.listeners import build_listener_plan, start_listeners
 from src.webui.config_controller import (
     ConfigController,
@@ -291,19 +292,16 @@ async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
         if not started:
             raise OSError(failures[0] if failures else "没有可用的监听地址")
         for item in started:
-            print(f"DiceFrame WebUI: {item.url('127.0.0.1')}  (host={item.host})")
+            print(f"DiceFrame WebUI: {item.url()}  (host={item.host})")
         stop_event = asyncio.Event()
         try:
             loop.add_signal_handler(signal.SIGINT, stop_event.set)
             loop.add_signal_handler(signal.SIGTERM, stop_event.set)
         except NotImplementedError:
-            # Windows 的事件循环不支持 add_signal_handler；Ctrl+C 仍会中断
-            # 主线程并由下面的 except 走清理路径。
+            # Windows 的事件循环不支持 add_signal_handler；停止信号由
+            # run_with_graceful_shutdown 统一处理（Ctrl+C 与重启接口都走那里）。
             pass
-        try:
-            await stop_event.wait()
-        except (KeyboardInterrupt, asyncio.CancelledError):
-            pass
+        await stop_event.wait()
     finally:
         await runner.cleanup()
     return bool(app["runtime_control"]["restart_requested"])
@@ -318,8 +316,13 @@ if __name__ == "__main__":
         print("请在 WebUI 的 AI 服务商与模型配置中设置主模型。")
     runtime_loop = asyncio.new_event_loop()
     install_runtime_exception_handler(runtime_loop)
+    serve_task = runtime_loop.create_task(_serve(runtime_loop))
     try:
-        restart_requested = runtime_loop.run_until_complete(_serve(runtime_loop))
+        restart_requested = run_with_graceful_shutdown(
+            runtime_loop,
+            serve_task,
+            lambda: bool(app["runtime_control"]["restart_requested"]),
+        )
     finally:
         runtime_loop.close()
     if restart_requested:


### PR DESCRIPTION
## 背景

#253 把多监听器做进了既有传输契约，但外围没跟上。逐条修完：

### 1. 🔴 Windows 重启路径（blocker）

`#253` 用 `run_until_complete(_serve())` 直接跑协程，而 Windows 没有 asyncio signal handler：项目自己的重启接口 `signal.raise_signal(SIGINT)`（`routes/updater.py`、`routes/security.py`、`bootstrap.py`）会以 `KeyboardInterrupt` 形式在 `run_until_complete()` **之外**抛出，穿透后进程直接退出，既不执行 `os.execv` 也不跑 `runner.cleanup()`。

新增 `src/web_transport/lifecycle.py::run_with_graceful_shutdown()`：中断时 `task.cancel()` 并把任务跑完（让 `finally` 里的 `runner.cleanup()` 执行），再按 `restart_requested()` 决定是否重启。

**真机（Windows）成对验证**，同一路径 POST `/api/system/restart`：

| | restart 后监听 | restart 后 health | 进程 |
|---|---|---|---|
| #253 原样 | 0 | **000** | 退出，未重启（stderr 见 `KeyboardInterrupt` at `updater.py:18`） |
| 修复后 | 1 | **200** | execv 重启（新 PID 接管端口），无 Traceback / Task was destroyed |

### 2. 🔴 Docker 未接通

`docker-compose.yml` 补 `TRPG_WEB_HOSTS` / `TRPG_WEB_HTTP_PORT` / `TRPG_WEB_HTTPS_PORT` 透传；新增 `docker-compose.extra-ports.yml`：Docker 端口映射无法按需生效，所以默认 compose 保持只发布 9876（不额外开端口），需要双协议时叠加该文件：

```
docker compose -f docker-compose.yml -f docker-compose.extra-ports.yml up -d
```

`.env.example` 补了 Docker 侧说明。`TRPG_WEB_HOSTS` 单独使用无需额外映射。

### 3. 🟡 非法端口静默

`runtime_config` 提前把值转成 `int | None`，planner 只拿到 `None`，永远看不到原始的 `abc`，所以那条 warning 在真实启动路径上不会触发。改为在读取配置处告警（`ConfigStore._optional_port`），planner 的兜底保留给直接调用方。

### 4. 🟡 IPv6-only 未打通

- 启动日志固定 `item.url('127.0.0.1')` → 改为按同族回环展示（`0.0.0.0`→127.0.0.1，`::`→`[::1]`，具体地址原样）。
- 插件用的 `TRPG_API_BASE` 固定 `127.0.0.1`（`bootstrap.py` + `endpoint.local_host`）→ `ServerEndpoint.local_host` 跟随绑定地址族，纯 IPv6 监听时为 `::1`；`bootstrap` 改用 `endpoint.url()`。

## 验证

```
python -m pytest tests -q                       # 2139 passed, 1 skipped
python -m ruff check src/ tests/ web_server.py  # All checks passed
python -m mypy                                  # Success；新模块单独 --no-incremental 亦通过
```

新增/补充测试：
- `tests/test_web_server_restart.py`：中断后必须再跑一次任务（`calls == 2`）、清理标记被执行、重启标记被读取；无重启标记时干净退出；正常停止返回任务结果。
- `tests/test_web_listener_plan.py`：`::` 展示为 `[::1]`、`0.0.0.0` 展示为 `127.0.0.1`、`internal_loopback_host` 的六种组合。
- `tests/test_runtime_config.py`：非法端口在读取配置时告警（caplog）、纯 IPv6 时 `endpoint.url() == http://[::1]:19001`。

## 兼容性

默认配置行为不变（单 HTTP 监听器、`TRPG_API_BASE=http://127.0.0.1:9876`、默认 compose 只开 9876）。`ServerEndpoint` 的 `local_host` 是带默认值的字段，`build_server_transport` 的 `local_host` 参数同样有默认值，既有调用点语义不变。
