### PR TITLE
fix(web): Docker 发布 ACME 验证端口，内部 API 跟随实际监听器

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ TRPG_TLS_ACME_CHALLENGE_PORT=
 # published too, so set the port above and add the matching override file:
 #   extra HTTP port:  docker compose -f docker-compose.yml -f docker-compose.extra-http-port.yml up -d
 #   extra HTTPS port: docker compose -f docker-compose.yml -f docker-compose.extra-https-port.yml up -d
+#   lets_encrypt:     docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
+# (the ACME override publishes the same TRPG_TLS_ACME_CHALLENGE_PORT value,
+#  default 80; HTTP-01 verification fails if the port is only set, not published)
 # (TRPG_WEB_HOSTS alone needs no extra mapping as long as you use the main port.)
 
 # Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;

--- a/docker-compose.acme-challenge.yml
+++ b/docker-compose.acme-challenge.yml
@@ -1,0 +1,18 @@
+# 发布 Let's Encrypt http-01 验证端口（可选叠加文件）。
+#
+# ACME 的验证响应器会在**容器内**监听 TRPG_TLS_ACME_CHALLENGE_PORT（默认 80），
+# 校验方要从公网访问它，所以必须把同一个端口发布到宿主机：
+#
+#   1) 在 .env 里设置（不设则用默认 80）：
+#        TRPG_TLS_MODE=lets_encrypt
+#        TRPG_TLS_ACME_CHALLENGE_PORT=80
+#   2) docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
+#
+# 只把自定义端口透传进容器而不发布，验证一定失败 —— 因此这里发布的端口与
+# TRPG_TLS_ACME_CHALLENGE_PORT 保持同一个变量，不会出现"配置 8080、发布 80"。
+services:
+  web:
+    environment:
+      TRPG_TLS_ACME_CHALLENGE_PORT: "${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"
+    ports:
+      - "${TRPG_TLS_ACME_CHALLENGE_PORT:-80}:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,10 @@ services:
     container_name: diceframe-web
     ports:
       - "${DICEFRAME_HTTP_PORT:-9876}:9876"
-      # Let's Encrypt http-01 验证需要容器内监听 TRPG_TLS_ACME_CHALLENGE_PORT
-      # （默认 80）；启用 lets_encrypt 时取消下面这行的注释。
-      # - "80:80"
+      # 启用 lets_encrypt 时还要发布 ACME 验证端口（容器内监听
+      # TRPG_TLS_ACME_CHALLENGE_PORT，默认 80）。叠加文件会按同一个变量发布，
+      # 避免"容器监听 8080、宿主机只开 80"这种验证必失败的组合：
+      #   docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:

--- a/src/web_transport/listeners.py
+++ b/src/web_transport/listeners.py
@@ -42,17 +42,69 @@ class ListenerPlan:
         host = f"[{self.host}]" if ":" in self.host else self.host
         return f"{host}:{self.port}"
 
-    def display_host(self) -> str:
-        """启动日志里给人看的地址：通配地址按同族回环展示。"""
+    def connect_host(self) -> str:
+        """本机客户端（插件、健康检查）应连接的主机名。
 
-        if self.host in {"", "*", "0.0.0.0", "::"}:
-            return "::1" if ":" in self.host else "127.0.0.1"
+        通配地址按同族回环连接；具体地址（例如 10.0.0.9）就用它自己 —— 服务只监听
+        那个地址，连 127.0.0.1 会连不上。
+        """
+
+        if self.host in {"", "*", "0.0.0.0"}:
+            return "127.0.0.1"
+        if self.host == "::":
+            return "::1"
         return self.host
 
     def url(self, display_host: str | None = None) -> str:
-        host = str(display_host) if display_host else self.display_host()
+        host = str(display_host) if display_host else self.connect_host()
         host = f"[{host}]" if ":" in host else host
         return f"{self.scheme}://{host}:{self.port}"
+
+
+def internal_api_listener(plan: Sequence[ListenerPlan]) -> ListenerPlan | None:
+    """从监听计划里挑一个内部客户端能连上的监听器。
+
+    优先级：显式回环 > 通配（按同族回环连接）> 第一个具体地址。真正启用后还要用
+    :func:`resolve_internal_listener` 对照“实际成功启动”的列表复核。
+    """
+
+    loopbacks = {"127.0.0.1", "::1", "localhost"}
+    for item in plan:
+        if item.host in loopbacks:
+            return item
+    for item in plan:
+        if item.host in {"", "*", "0.0.0.0", "::"}:
+            return item
+    return plan[0] if plan else None
+
+
+def internal_api_base(listener: ListenerPlan) -> str:
+    """内部 API 基址：与 ``ServerEndpoint.url()`` 一样处理 IPv6 字面量。"""
+
+    return listener.url()
+
+
+def resolve_internal_listener(
+    plan: Sequence[ListenerPlan], started: Sequence[ListenerPlan],
+) -> tuple[ListenerPlan | None, str]:
+    """对照实际启动结果，确定内部 API 用哪个监听器。
+
+    返回 (监听器, 警告)。计划里选中的监听器没能成功启动时，退回第一个成功启动的
+    监听器并给出警告 —— 否则插件会一直去连一个不存在的地址。
+    """
+
+    wanted = internal_api_listener(plan)
+    if wanted is None:
+        return None, ""
+    if wanted in started:
+        return wanted, ""
+    if not started:
+        return None, f"内部 API 期望的监听器 {wanted.address} 未启动，且没有其它可用监听器"
+    fallback = started[0]
+    return fallback, (
+        f"内部 API 期望的监听器 {wanted.address} 未成功监听，"
+        f"已改用 {fallback.address}"
+    )
 
 
 def internal_loopback_host(hosts: Sequence[str]) -> str:

--- a/tests/test_docker_compose_env.py
+++ b/tests/test_docker_compose_env.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPOSE = ROOT / "docker-compose.yml"
 EXTRA_HTTP = ROOT / "docker-compose.extra-http-port.yml"
 EXTRA_HTTPS = ROOT / "docker-compose.extra-https-port.yml"
+ACME = ROOT / "docker-compose.acme-challenge.yml"
 
 # src/web_transport/config.py 里对外支持的 TLS 环境变量。
 SUPPORTED_TLS_ENV = (
@@ -107,6 +108,25 @@ def test_base_compose_publishes_only_the_main_port() -> None:
     """默认不额外占用宿主端口：附加端口必须由用户显式叠加文件。"""
 
     assert _published_ports(COMPOSE) == ['"${DICEFRAME_HTTP_PORT:-9876}:9876"']
+
+
+def test_acme_challenge_override_publishes_the_configured_port() -> None:
+    """ACME 验证端口必须"配多少发布多少"，否则 http-01 一定失败。"""
+
+    assert _compose_env_keys(ACME) == {"TRPG_TLS_ACME_CHALLENGE_PORT"}
+    assert _published_ports(ACME) == [
+        '"${TRPG_TLS_ACME_CHALLENGE_PORT:-80}:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"'
+    ]
+
+
+def test_documented_docker_overrides_exist() -> None:
+    """文档里点名的叠加文件必须真实存在，避免用户照抄命令却报找不到文件。"""
+
+    example = (ROOT / ".env.example").read_text(encoding="utf-8")
+    for name in ("extra-http-port", "extra-https-port", "acme-challenge"):
+        path = ROOT / f"docker-compose.{name}.yml"
+        assert path.is_file()
+        assert f"docker-compose.{name}.yml" in example
 
 
 def test_parser_ignores_comments() -> None:

--- a/tests/test_web_listener_plan.py
+++ b/tests/test_web_listener_plan.py
@@ -19,9 +19,12 @@ from src.web_transport.config import TLS_MODE_OFF, TLS_MODE_SELF_SIGNED, WebTran
 from src.web_transport.listeners import (
     ListenerPlan,
     build_listener_plan,
+    internal_api_base,
+    internal_api_listener,
     internal_loopback_host,
     normalize_hosts,
     parse_port,
+    resolve_internal_listener,
     split_hosts,
     start_listeners,
 )
@@ -183,6 +186,56 @@ def test_internal_loopback_follows_the_bound_family() -> None:
     assert internal_loopback_host(["::"]) == "::1"
     assert internal_loopback_host(["::", "::1"]) == "::1"
     assert internal_loopback_host([]) == "127.0.0.1"
+
+
+def test_internal_api_listener_prefers_a_reachable_listener() -> None:
+    """内部 API 必须挑一个本机真的连得上的监听器，而不是只看配置字符串。"""
+
+    plan, _warnings = build_listener_plan(
+        hosts=["10.0.0.9"], port=18000, transport=_http_transport(),
+    )
+    assert internal_api_listener(plan) is plan[0]
+    assert internal_api_base(plan[0]) == "http://10.0.0.9:18000"
+
+    wildcard, _warnings = build_listener_plan(
+        hosts=["0.0.0.0", "::"], port=18000, transport=_http_transport(),
+    )
+    chosen = internal_api_listener(wildcard)
+    assert chosen is wildcard[0]
+    assert internal_api_base(chosen) == "http://127.0.0.1:18000"
+
+    ipv6_only, _warnings = build_listener_plan(
+        hosts=["::"], port=18000, transport=_http_transport(),
+    )
+    assert internal_api_base(internal_api_listener(ipv6_only)) == "http://[::1]:18000"
+
+    explicit_loopback, _warnings = build_listener_plan(
+        hosts=["192.168.1.5", "127.0.0.1"], port=18000, transport=_http_transport(),
+    )
+    assert internal_api_base(internal_api_listener(explicit_loopback)) == "http://127.0.0.1:18000"
+
+    assert internal_api_listener([]) is None
+
+
+def test_internal_api_uses_an_extra_listener_when_the_primary_failed() -> None:
+    """主端口没起来、附加端口起来了：内部地址要跟着实际成功的那个走。"""
+
+    plan, _warnings = build_listener_plan(
+        hosts=["127.0.0.1"], port=18000, transport=_http_transport(),
+        http_port=18080,
+    )
+    primary, extra = plan
+
+    chosen, warning = resolve_internal_listener(plan, [primary])
+    assert chosen == primary and warning == ""
+
+    chosen, warning = resolve_internal_listener(plan, [extra])
+    assert chosen == extra
+    assert internal_api_base(chosen) == "http://127.0.0.1:18080"
+    assert "未成功监听" in warning and str(primary.port) in warning
+
+    chosen, warning = resolve_internal_listener(plan, [])
+    assert chosen is None and "没有其它可用监听器" in warning
 
 
 @pytest.mark.asyncio

--- a/web_server.py
+++ b/web_server.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from dataclasses import replace
 
 import asyncio
 import logging
@@ -43,7 +44,13 @@ from src.webui.bootstrap import (
 )
 from src.webui.access_control import WebAccessControl
 from src.web_transport.lifecycle import run_with_graceful_shutdown
-from src.web_transport.listeners import build_listener_plan, start_listeners
+from src.web_transport.listeners import (
+    build_listener_plan,
+    internal_api_base,
+    internal_api_listener,
+    resolve_internal_listener,
+    start_listeners,
+)
 from src.webui.config_controller import (
     ConfigController,
     ConfigControllerDependencies,
@@ -76,6 +83,26 @@ STATE = RUNTIME_CONFIG.state
 HOST = RUNTIME_CONFIG.host
 PORT = RUNTIME_CONFIG.port
 TRANSPORT = RUNTIME_CONFIG.transport
+# 监听计划在创建 app 之前就定好：插件/内部客户端用的 API 基址必须指向一个
+# 本机真的能连上的监听器（具体地址就用它自己，通配地址用同族回环）。
+LISTENER_PLAN, LISTENER_PLAN_WARNINGS = build_listener_plan(
+    hosts=RUNTIME_CONFIG.hosts,
+    port=PORT,
+    transport=TRANSPORT,
+    http_port=RUNTIME_CONFIG.http_port,
+    https_port=RUNTIME_CONFIG.https_port,
+)
+INTERNAL_LISTENER = internal_api_listener(LISTENER_PLAN)
+if INTERNAL_LISTENER is not None:
+    TRANSPORT = replace(
+        TRANSPORT,
+        endpoint=replace(
+            TRANSPORT.endpoint,
+            scheme=INTERNAL_LISTENER.scheme,
+            port=INTERNAL_LISTENER.port,
+            local_host=INTERNAL_LISTENER.connect_host(),
+        ),
+    )
 WEB_CORS_ENV_VALUE = RUNTIME_CONFIG.cors_env_value
 WEB_CORS_CONFIG_VALUE = RUNTIME_CONFIG.cors_config_value
 WEB_CORS_ORIGINS = RUNTIME_CONFIG.cors_origins
@@ -275,24 +302,18 @@ async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
     处理都在 web_transport.listeners 里，未启动任何监听器时按原语义抛错退出。
     """
 
-    plan, warnings = build_listener_plan(
-        hosts=RUNTIME_CONFIG.hosts,
-        port=PORT,
-        transport=TRANSPORT,
-        http_port=RUNTIME_CONFIG.http_port,
-        https_port=RUNTIME_CONFIG.https_port,
-    )
-    for message in warnings:
+    for message in LISTENER_PLAN_WARNINGS:
         logger.warning("%s", message)
 
     runner = web.AppRunner(app)
     await runner.setup()
     try:
-        started, failures = await start_listeners(runner, plan, TRANSPORT)
+        started, failures = await start_listeners(runner, LISTENER_PLAN, TRANSPORT)
         if not started:
             raise OSError(failures[0] if failures else "没有可用的监听地址")
         for item in started:
             print(f"DiceFrame WebUI: {item.url()}  (host={item.host})")
+        _align_internal_api(started)
         stop_event = asyncio.Event()
         try:
             loop.add_signal_handler(signal.SIGINT, stop_event.set)
@@ -305,6 +326,23 @@ async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
     finally:
         await runner.cleanup()
     return bool(app["runtime_control"]["restart_requested"])
+
+
+def _align_internal_api(started: list) -> None:
+    """监听器真正起来后复核内部 API 地址，必要时改到确实在监听的那个。"""
+
+    listener, warning = resolve_internal_listener(LISTENER_PLAN, started)
+    if warning:
+        logger.warning("%s", warning)
+    if listener is None:
+        return
+    plugin_host = app.get("plugin_host")
+    if plugin_host is None:
+        return
+    base = internal_api_base(listener)
+    if plugin_host.base_env.get("TRPG_API_BASE") != base:
+        plugin_host.base_env["TRPG_API_BASE"] = base
+        logger.info("插件 API 基址已调整为 %s", base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

#253/#255/#257 之后剩下的两处 P2：

### 1. Docker 的 ACME 验证端口只透传、不发布

`docker-compose.yml` 原本只有一行 `# - "80:80"` 注释，而 `TRPG_TLS_ACME_CHALLENGE_PORT` 在 #257 里被透传进容器：用户设 `8080` 时容器内监听 8080，宿主机只映射 9876 → http-01 验证必然失败。

新增 `docker-compose.acme-challenge.yml`，用**同一个变量**发布端口（不设则默认 80），并在基础 compose 与 `.env.example` 里指向它：

```
docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
```

### 2. 内部插件地址不一定对应实际成功启动的监听器

`internal_loopback_host()` 只按配置字符串推导回环地址，导致：

- `TRPG_WEB_HOST=10.0.0.9` → 服务只监听 10.0.0.9，插件却拿到 `http://127.0.0.1:<port>`；
- 主端口绑定失败、只有附加端口成功时，`endpoint` 仍指向失败的主端口；
- 具体 IPv6 地址也不一定是 `::1`。

改法：

- `ListenerPlan.connect_host()`：明确"本机可连"的主机（通配 → 同族回环；具体地址 → 它自己）；
- `web_server` 在创建 app **之前**就构建监听计划，用 `internal_api_listener()` 选出的监听器修正 `ServerTransport.endpoint`（插件的 `TRPG_API_BASE` 来自它）；
- 监听器真正启动后，`_align_internal_api()` 用 `resolve_internal_listener()` 对照"实际成功启动"的列表复核，必要时改到确实在监听的那个并写日志。

## 验证

`docker compose config`（docker CLI 29.1.2）：

| 场景 | published |
|---|---|
| 基础 compose | 9876 |
| `TRPG_TLS_ACME_CHALLENGE_PORT=8080` + ACME 叠加 | 9876 + **8080** |
| 不设该变量 + ACME 叠加 | 9876 + **80** |

真机（主端口被占用、附加端口成功）日志：

```
ERROR   http://127.0.0.1:18090 监听失败：... 只允许使用一次。
WARNING 内部 API 期望的监听器 127.0.0.1:18090 未成功监听，已改用 127.0.0.1:18091
INFO    插件 API 基址已调整为 http://127.0.0.1:18091
```

真机（`TRPG_WEB_HOST=192.168.19.1`）：`listener plan = [('192.168.19.1', 18088, 'http')]`，内部/插件 base 均为 `http://192.168.19.1:18088`（修复前是 127.0.0.1）。

```
python -m pytest tests -q                       # 2158 passed, 1 skipped
python -m ruff check src/ tests/ web_server.py  # All checks passed
python -m mypy                                  # Success；新模块单独 --no-incremental 亦通过
```

新增测试：
- `test_internal_api_listener_prefers_a_reachable_listener`（具体地址 / 通配 / 纯 IPv6 / 显式回环 / 空计划）
- `test_internal_api_uses_an_extra_listener_when_the_primary_failed`（失败回退 + 警告文案 + 无可用监听器）
- `test_acme_challenge_override_publishes_the_configured_port`、`test_documented_docker_overrides_exist`

## 兼容性

默认行为不变：不叠加 ACME 文件时仍只发布 9876；`TRPG_WEB_HOST` 为通配地址时内部 base 仍是 `127.0.0.1` / `[::1]`。内部 endpoint 现在跟随**计划中的**监听器，并在实际启动后复核纠正（插件若在纠正前已经启动，需要重启插件才能拿到新地址 —— 只发生在"选中的监听器绑定失败"这一异常路径）。
