### PR TITLE
fix(build): 助手知识索引可离线构建，测试不再依赖外网

### DIFF
--- a/scripts/build_assistant_knowledge.py
+++ b/scripts/build_assistant_knowledge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import urllib.request
 from pathlib import Path
@@ -34,24 +35,49 @@ sys.modules[_spec.name] = ak  # 注册后 exec，dataclass 才能解析模块
 _spec.loader.exec_module(ak)
 
 _CONTENT_REPO_CHECKOUT = ROOT.parent / "diceframe-content"
+# 与运行时一致：DICEFRAME_DOCS_BASE_URL 优先，其次 GitHub raw。此前这里写死
+# GITHUB_DOCS_BASE_URL，用户配了镜像也没用，离线/受限网络下每个文档都要等超时。
+_FETCH_TIMEOUT_SECONDS = 8
 
 
-def _read_content_doc(lang_key: str, path: str) -> str | None:
-    """从相邻 diceframe-content 检出读文档；没有检出时退回 GitHub raw。"""
+def _local_only_requested(explicit: bool | None = None) -> bool:
+    """是否只使用本地 diceframe-content 检出（不发网络请求）。
+
+    显式参数优先；否则读 DICEFRAME_DOCS_LOCAL_ONLY，便于离线打包与测试。
+    """
+
+    if explicit is not None:
+        return explicit
+    return str(os.getenv("DICEFRAME_DOCS_LOCAL_ONLY", "")).strip().lower() in {
+        "1", "true", "yes",
+    }
+
+
+def _read_content_doc(lang_key: str, path: str, *, allow_remote: bool = True) -> str | None:
+    """从相邻 diceframe-content 检出读文档；没有检出时退回配置的文档源。"""
+
     local = _CONTENT_REPO_CHECKOUT / "docs" / lang_key / path
     if local.exists():
         return local.read_text(encoding="utf-8")
-    url = f"{ak.GITHUB_DOCS_BASE_URL}/{lang_key}/{path}"
-    try:
-        with urllib.request.urlopen(url, timeout=15) as resp:
-            return resp.read().decode("utf-8")
-    except Exception:
-        print(f"  ! 跳过（本地无检出且拉取失败）: docs/{lang_key}/{path}")
+    if not allow_remote:
         return None
+    bases = tuple(getattr(ak, "_DOCS_BASE_URLS", ()) or (ak.GITHUB_DOCS_BASE_URL,))
+    for base in bases:
+        url = f"{base}/{lang_key}/{path}"
+        try:
+            with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT_SECONDS) as resp:
+                return resp.read().decode("utf-8")
+        except Exception:
+            continue
+    print(f"  ! 跳过（本地无检出且拉取失败）: docs/{lang_key}/{path}")
+    return None
 
 
-def build(output: Path | None = None) -> Path:
+def build(output: Path | None = None, *, local_only: bool | None = None) -> Path:
     target = output or ak.INDEX_FILE
+    allow_remote = not _local_only_requested(local_only)
+    if not allow_remote:
+        print("  · 仅使用本地 diceframe-content 检出（跳过远程文档）")
     index: dict[str, list[dict]] = {}
     for lang_key in ("zh", "en"):
         chunks: list[dict] = []
@@ -63,7 +89,7 @@ def build(output: Path | None = None) -> Path:
             for chunk in ak._parse_markdown(relative, text):
                 chunks.append(_chunk_payload(chunk))
         for doc_path in ak._CONTENT_DOC_PATHS[lang_key]:
-            text = _read_content_doc(lang_key, doc_path)
+            text = _read_content_doc(lang_key, doc_path, allow_remote=allow_remote)
             if text is None:
                 continue
             source = f"docs/{lang_key}/{doc_path}"
@@ -94,8 +120,13 @@ def _chunk_payload(chunk) -> dict:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Build the AI assistant local knowledge index.")
     parser.add_argument("--output", type=Path, default=None, help="Output index file path")
+    parser.add_argument(
+        "--local-only",
+        action="store_true",
+        help="只使用本地 diceframe-content 检出，不访问网络（也可用 DICEFRAME_DOCS_LOCAL_ONLY=1）",
+    )
     args = parser.parse_args()
-    build(args.output)
+    build(args.output, local_only=args.local_only or None)
     return 0
 
 

--- a/tests/test_assistant_knowledge_build.py
+++ b/tests/test_assistant_knowledge_build.py
@@ -1,0 +1,119 @@
+"""助手知识索引构建：文档源必须可配置，且能完全离线构建。
+
+历史问题：scripts/build_assistant_knowledge.py 写死 GitHub raw，用户在
+DICEFRAME_DOCS_BASE_URL 里配的镜像不生效；受限网络下打包会为每个文档等一次
+超时（本地全套测试因此多花 220s）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import build_assistant_knowledge as bak
+
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self._text = text.encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._text
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        return None
+
+
+def test_read_content_doc_prefers_the_local_checkout(monkeypatch, tmp_path: Path) -> None:
+    checkout = tmp_path / "diceframe-content"
+    doc = checkout / "docs" / "zh" / "guide.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# 本地文档", encoding="utf-8")
+    monkeypatch.setattr(bak, "_CONTENT_REPO_CHECKOUT", checkout)
+    monkeypatch.setattr(
+        bak.urllib.request, "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("本地有检出时不应发网络请求"),
+    )
+
+    assert bak._read_content_doc("zh", "guide.md") == "# 本地文档"
+
+
+def test_read_content_doc_uses_the_configured_docs_base_url(monkeypatch, tmp_path: Path) -> None:
+    """DICEFRAME_DOCS_BASE_URL 类配置必须优先生效（与运行时一致）。"""
+
+    monkeypatch.setattr(bak, "_CONTENT_REPO_CHECKOUT", tmp_path / "missing")
+    monkeypatch.setattr(bak.ak, "_DOCS_BASE_URLS", ("https://mirror.example/docs",))
+    requested: list[str] = []
+
+    def fake_urlopen(url, timeout=None):  # noqa: ANN001, ANN202
+        requested.append(url)
+        return _FakeResponse("# 镜像文档")
+
+    monkeypatch.setattr(bak.urllib.request, "urlopen", fake_urlopen)
+
+    assert bak._read_content_doc("en", "deploy.md") == "# 镜像文档"
+    assert requested == ["https://mirror.example/docs/en/deploy.md"]
+
+
+def test_read_content_doc_falls_through_bases_then_gives_up(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(bak, "_CONTENT_REPO_CHECKOUT", tmp_path / "missing")
+    monkeypatch.setattr(
+        bak.ak, "_DOCS_BASE_URLS",
+        ("https://mirror.example/docs", "https://raw.example/docs"),
+    )
+    requested: list[str] = []
+
+    def failing_urlopen(url, timeout=None):  # noqa: ANN001, ANN202
+        requested.append(url)
+        raise OSError("refused")
+
+    monkeypatch.setattr(bak.urllib.request, "urlopen", failing_urlopen)
+
+    assert bak._read_content_doc("zh", "guide.md") is None
+    assert requested == [
+        "https://mirror.example/docs/zh/guide.md",
+        "https://raw.example/docs/zh/guide.md",
+    ]
+
+
+def test_local_only_skips_remote_fetch(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(bak, "_CONTENT_REPO_CHECKOUT", tmp_path / "missing")
+    monkeypatch.setattr(
+        bak.urllib.request, "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("local_only 不应发网络请求"),
+    )
+
+    assert bak._read_content_doc("zh", "guide.md", allow_remote=False) is None
+
+
+def test_local_only_switch_reads_the_environment(monkeypatch) -> None:
+    monkeypatch.delenv("DICEFRAME_DOCS_LOCAL_ONLY", raising=False)
+    assert bak._local_only_requested() is False
+    assert bak._local_only_requested(True) is True
+
+    for value in ("1", "true", "YES"):
+        monkeypatch.setenv("DICEFRAME_DOCS_LOCAL_ONLY", value)
+        assert bak._local_only_requested() is True
+
+    monkeypatch.setenv("DICEFRAME_DOCS_LOCAL_ONLY", "0")
+    assert bak._local_only_requested() is False
+
+
+def test_build_writes_an_index_without_touching_the_network(monkeypatch, tmp_path: Path) -> None:
+    """离线构建也要产出可用索引（内容文档缺失时降级，不报错）。"""
+
+    monkeypatch.setattr(bak, "_CONTENT_REPO_CHECKOUT", tmp_path / "missing")
+    monkeypatch.setattr(
+        bak.urllib.request, "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("离线构建不应发网络请求"),
+    )
+    output = tmp_path / "assistant_knowledge_index.json"
+
+    target = bak.build(output, local_only=True)
+
+    assert target == output and output.is_file()
+    assert output.read_text(encoding="utf-8").startswith("{")

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -47,6 +47,9 @@ def test_prepare_package_tree_excludes_non_server_projects(monkeypatch, tmp_path
     (root / "mobile" / "package.json").write_text("{}", encoding="utf-8")
     package = tmp_path / "package"
     monkeypatch.setattr(build_release, "ROOT", root)
+    # 打包会重建助手知识索引，而索引默认会去 diceframe-content 拉文档。测试必须
+    # 离线：否则受限网络下每个文档都要等一次超时（曾让这个用例跑 220s）。
+    monkeypatch.setenv("DICEFRAME_DOCS_LOCAL_ONLY", "1")
 
     build_release.prepare_package_tree(package)
 


### PR DESCRIPTION
## 背景

`python -m pytest tests -q` 在本机要 436s，其中 **220s 是单独一个用例**：

```
220.4s  tests/test_release_build.py::test_prepare_package_tree_excludes_non_server_projects
```

它在打包时会重建助手知识索引，而 `scripts/build_assistant_knowledge.py` 会去
`https://raw.githubusercontent.com/diceframe/diceframe-content/...` 抓文档，**每个文档一次
`urlopen(timeout=15)`**。本机 urllib 在这条路径上会卡在 Windows 代理解析
（`proxy_bypass_registry` → `socket.getfqdn`），于是一篇篇等到超时；CI（ubuntu、有直连外网）
跑同一条命令只要 1m20s，所以这个问题一直在 CI 上看不出来。

顺带还有一个真实的不一致：运行时会读 `DICEFRAME_DOCS_BASE_URL` 覆盖，构建脚本却写死
GitHub raw —— 用户配了镜像，打包出来的离线快照仍来自 raw。

## 改动

- `_read_content_doc` 改为按 `ak._DOCS_BASE_URLS` 依次尝试（与运行时一致：env 覆盖优先、
  其次 GitHub raw），超时从 15s 降到 8s，与运行时 `_REMOTE_FETCH_TIMEOUT` 对齐；
- 新增离线开关：`build(..., local_only=True)` / CLI `--local-only` /
  `DICEFRAME_DOCS_LOCAL_ONLY=1`，只读本地 `diceframe-content` 检出、不发网络请求；
- `tests/test_release_build.py` 的该用例设置 `DICEFRAME_DOCS_LOCAL_ONLY=1`，彻底离线。

**发布流程默认行为不变**（不设开关时仍会抓取，保证包里带离线快照）；只有明确选择离线时才跳过。

## 验证

| | 修改前 | 修改后 |
|---|---|---|
| 该用例 | 220.4s | **0.02s** |
| `tests/test_release_build.py` 整个文件 | 221s | **0.49s** |
| `python -m pytest tests -q` | 436s | **216s** |

```
2164 passed, 1 skipped in 216.31s
python -m ruff check src/ tests/ scripts/ web_server.py   # All checks passed
python -m mypy                                            # Success
```

新增 `tests/test_assistant_knowledge_build.py`（6 例）：本地检出优先（且断言不发网络）、
配置的镜像 base 优先生效、多个 base 依次回退、`local_only` 不发请求、环境变量取值
（`1`/`true`/`YES`/`0`）、离线构建仍能产出索引。

## 兼容性

纯构建/测试侧改动，运行时行为不变；`scripts/build_assistant_knowledge.py` 的 CLI 兼容（新增可选参数），
`build_release` 的调用点无需修改。
