### PR TITLE
fix(web): ACME 验证映射固定宿主 80，内部 API 优先明文 HTTP 并在改址后重启插件

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@ TRPG_WEB_HTTPS_PORT=
 
 # TLS settings. docker-compose.yml passes these into the container explicitly,
 # because Compose only uses .env for variable substitution.
-# lets_encrypt additionally needs the http-01 challenge port published
-# (container port TRPG_TLS_ACME_CHALLENGE_PORT, default 80).
+# lets_encrypt additionally needs the http-01 challenge port: the CA always
+# reaches public port 80, and the ACME override maps host 80 to the container
+# port TRPG_TLS_ACME_CHALLENGE_PORT (default 80).
 TRPG_TLS_MODE=
 TRPG_TLS_IDENTIFIER_TYPE=
 TRPG_TLS_IDENTIFIER=
@@ -29,8 +30,9 @@ TRPG_TLS_ACME_CHALLENGE_PORT=
 #   extra HTTP port:  docker compose -f docker-compose.yml -f docker-compose.extra-http-port.yml up -d
 #   extra HTTPS port: docker compose -f docker-compose.yml -f docker-compose.extra-https-port.yml up -d
 #   lets_encrypt:     docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
-# (the ACME override publishes the same TRPG_TLS_ACME_CHALLENGE_PORT value,
-#  default 80; HTTP-01 verification fails if the port is only set, not published)
+# (the ACME override maps host port 80 to the container's
+#  TRPG_TLS_ACME_CHALLENGE_PORT, default 80; the CA never visits other public
+#  ports, so "8080 on both sides" fails HTTP-01 verification)
 # (TRPG_WEB_HOSTS alone needs no extra mapping as long as you use the main port.)
 
 # Timezone used for runtime log timestamps. The image defaults to Asia/Shanghai;

--- a/docker-compose.acme-challenge.yml
+++ b/docker-compose.acme-challenge.yml
@@ -1,18 +1,25 @@
 # 发布 Let's Encrypt http-01 验证端口（可选叠加文件）。
 #
-# ACME 的验证响应器会在**容器内**监听 TRPG_TLS_ACME_CHALLENGE_PORT（默认 80），
-# 校验方要从公网访问它，所以必须把同一个端口发布到宿主机：
+# http-01 的校验方（Let's Encrypt）从公网访问的永远是 80 端口，这一点无法配置。
+# 验证响应器在**容器内**监听 TRPG_TLS_ACME_CHALLENGE_PORT（默认 80），所以映射
+# 固定为「宿主机 80 → 容器的 challenge 端口」：
 #
-#   1) 在 .env 里设置（不设则用默认 80）：
+#   公网 :80 → 宿主机 :80 → 容器 :TRPG_TLS_ACME_CHALLENGE_PORT
+#
+#   1) 在 .env 里设置（不设则容器内也监听 80）：
 #        TRPG_TLS_MODE=lets_encrypt
-#        TRPG_TLS_ACME_CHALLENGE_PORT=80
+#        TRPG_TLS_ACME_CHALLENGE_PORT=8080
 #   2) docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
 #
-# 只把自定义端口透传进容器而不发布，验证一定失败 —— 因此这里发布的端口与
-# TRPG_TLS_ACME_CHALLENGE_PORT 保持同一个变量，不会出现"配置 8080、发布 80"。
+# 注意两种都会让验证失败的写法：
+#   - 只透传端口不发布：公网 80 没人应答；
+#   - "配置 8080、发布 8080"：Let's Encrypt 不会去访问 8080。
+# 宿主机自己的 80 被其它服务占用时，compose 会绑定失败而显式报错 —— 此时应在
+# 宿主机外层做端口转发/反代把公网 80 引到本机，或改用 DNS-01 验证；如果公网 80
+# 由路由器转发到本机其它端口，请自行追加对应的 ports 映射。
 services:
   web:
     environment:
       TRPG_TLS_ACME_CHALLENGE_PORT: "${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"
     ports:
-      - "${TRPG_TLS_ACME_CHALLENGE_PORT:-80}:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"
+      - "80:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     container_name: diceframe-web
     ports:
       - "${DICEFRAME_HTTP_PORT:-9876}:9876"
-      # 启用 lets_encrypt 时还要发布 ACME 验证端口（容器内监听
-      # TRPG_TLS_ACME_CHALLENGE_PORT，默认 80）。叠加文件会按同一个变量发布，
-      # 避免"容器监听 8080、宿主机只开 80"这种验证必失败的组合：
+      # 启用 lets_encrypt 时还要发布 ACME 验证端口。http-01 校验方只访问公网 80，
+      # 叠加文件固定把宿主机 80 映射到容器内监听的 TRPG_TLS_ACME_CHALLENGE_PORT
+      # （默认 80）—— 若把宿主机侧也配成 8080，Let's Encrypt 不会来访问：
       #   docker compose -f docker-compose.yml -f docker-compose.acme-challenge.yml up -d
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/src/plugin_host/host.py
+++ b/src/plugin_host/host.py
@@ -910,6 +910,23 @@ class PluginHost:
             if "ai.providers" in permissions and uses_ai_provider and process_running:
                 await self.restart(plugin_id, require_enabled=False)
 
+    async def restart_api_consumers(self) -> int:
+        """重启正在运行且依赖 diceframe.http 的插件，返回重启数量。
+
+        插件进程在 spawn 时从 base_env 快照 TRPG_API_BASE，之后不再感知变化；
+        内部 API 基址在监听器启动后被修正（回退到实际成功的监听器）时，只有
+        重启进程才能拿到新地址。还没启动的插件下次 start 时自然读到新值。
+        """
+
+        restarted = 0
+        for plugin_id, runtime in self.plugins.items():
+            permissions = set(self._plugin_permissions(runtime))
+            process_running = bool(runtime.process and runtime.process.returncode is None)
+            if "diceframe.http" in permissions and process_running:
+                await self.restart(plugin_id, require_enabled=False)
+                restarted += 1
+        return restarted
+
     def _host_generation_path(self, plugin_id: str) -> Path:
         return (self.data_dir / plugin_id / "runtime" / ".host-generation").resolve()
 

--- a/src/web_transport/listeners.py
+++ b/src/web_transport/listeners.py
@@ -64,18 +64,27 @@ class ListenerPlan:
 def internal_api_listener(plan: Sequence[ListenerPlan]) -> ListenerPlan | None:
     """从监听计划里挑一个内部客户端能连上的监听器。
 
-    优先级：显式回环 > 通配（按同族回环连接）> 第一个具体地址。真正启用后还要用
-    :func:`resolve_internal_listener` 对照“实际成功启动”的列表复核。
+    内部客户端（插件）是普通 aiohttp 会话，不做任何 TLS 信任配置：主端口自签名、
+    或证书域名与本机回环/IP 地址不匹配时都会验证失败。因此存在明文 HTTP 监听器
+    时优先选它，外部继续走 HTTPS；同一 scheme 内再按 显式回环 > 通配（按同族回环
+    连接）> 第一个具体地址 选。真正启用后还要用 :func:`resolve_internal_listener`
+    对照“实际成功启动”的列表复核。
     """
 
     loopbacks = {"127.0.0.1", "::1", "localhost"}
-    for item in plan:
-        if item.host in loopbacks:
-            return item
-    for item in plan:
-        if item.host in {"", "*", "0.0.0.0", "::"}:
-            return item
-    return plan[0] if plan else None
+    wildcards = {"", "*", "0.0.0.0", "::"}
+
+    def pick(items: list[ListenerPlan]) -> ListenerPlan | None:
+        for item in items:
+            if item.host in loopbacks:
+                return item
+        for item in items:
+            if item.host in wildcards:
+                return item
+        return items[0] if items else None
+
+    plain = [item for item in plan if not item.tls]
+    return pick(plain) or pick([item for item in plan if item.tls])
 
 
 def internal_api_base(listener: ListenerPlan) -> str:
@@ -100,7 +109,8 @@ def resolve_internal_listener(
         return wanted, ""
     if not started:
         return None, f"内部 API 期望的监听器 {wanted.address} 未启动，且没有其它可用监听器"
-    fallback = started[0]
+    # 回退也按同样规则在"实际启动"里挑最适合内部的那个，而不是简单取第一个。
+    fallback = internal_api_listener(started) or started[0]
     return fallback, (
         f"内部 API 期望的监听器 {wanted.address} 未成功监听，"
         f"已改用 {fallback.address}"

--- a/tests/test_docker_compose_env.py
+++ b/tests/test_docker_compose_env.py
@@ -110,13 +110,15 @@ def test_base_compose_publishes_only_the_main_port() -> None:
     assert _published_ports(COMPOSE) == ['"${DICEFRAME_HTTP_PORT:-9876}:9876"']
 
 
-def test_acme_challenge_override_publishes_the_configured_port() -> None:
-    """ACME 验证端口必须"配多少发布多少"，否则 http-01 一定失败。"""
+def test_acme_challenge_override_maps_host_80_to_the_container_port() -> None:
+    """http-01 校验方只访问公网 80：映射必须是 宿主机 80 → 容器 challenge 端口。
+
+    "配置 8080、发布 8080" 对 Let's Encrypt 无效 —— 它不会去访问 8080；容器内
+    改监听 8080 时，宿主机侧仍要固定 80。
+    """
 
     assert _compose_env_keys(ACME) == {"TRPG_TLS_ACME_CHALLENGE_PORT"}
-    assert _published_ports(ACME) == [
-        '"${TRPG_TLS_ACME_CHALLENGE_PORT:-80}:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"'
-    ]
+    assert _published_ports(ACME) == ['"80:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"']
 
 
 def test_documented_docker_overrides_exist() -> None:

--- a/tests/test_plugin_host.py
+++ b/tests/test_plugin_host.py
@@ -411,3 +411,39 @@ def test_version_below_semantics():
     assert version_below("2.0.0", "1.9.12") is True
 
 
+@pytest.mark.asyncio
+async def test_restart_api_consumers_only_restarts_running_http_plugins(tmp_path, monkeypatch):
+    """内部 API 基址被修正后，只有"在运行 + 依赖 diceframe.http"的插件需要重启。
+
+    插件进程在 spawn 时快照 TRPG_API_BASE；基址回退到实际成功的监听器后，
+    未启动的插件下次 start 自然读到新值，只有运行中的必须重启进程。
+    """
+
+    host = PluginHost(tmp_path / "plugins", tmp_path / "data")
+
+    def runtime_with(permissions, process):
+        return SimpleNamespace(
+            manifest={"permissions": permissions},
+            schema={},
+            config={},
+            process=process,
+        )
+
+    host.plugins = {
+        "http-running": runtime_with(["diceframe.http"], SimpleNamespace(returncode=None)),
+        "http-exited": runtime_with(["diceframe.http"], SimpleNamespace(returncode=0)),
+        "http-no-process": runtime_with(["diceframe.http"], None),
+        "other-running": runtime_with(["plugin.config"], SimpleNamespace(returncode=None)),
+    }
+    restarted: list[str] = []
+
+    async def fake_restart(plugin_id, *, require_enabled=True):
+        restarted.append(plugin_id)
+
+    monkeypatch.setattr(host, "restart", fake_restart)
+    count = await host.restart_api_consumers()
+
+    assert restarted == ["http-running"]
+    assert count == 1
+
+

--- a/tests/test_web_listener_plan.py
+++ b/tests/test_web_listener_plan.py
@@ -238,6 +238,66 @@ def test_internal_api_uses_an_extra_listener_when_the_primary_failed() -> None:
     assert chosen is None and "没有其它可用监听器" in warning
 
 
+def test_internal_api_listener_prefers_plain_http_over_tls(tmp_path: Path) -> None:
+    """插件客户端不做 TLS 信任配置：有明文 HTTP 监听器时必须优先于 HTTPS 主端口。"""
+
+    transport = _tls_transport(tmp_path)
+    plan, _warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=transport, http_port=18080,
+    )
+    assert [(item.port, item.scheme) for item in plan] == [(18000, "https"), (18080, "http")]
+
+    chosen = internal_api_listener(plan)
+    assert chosen is plan[1]
+    assert internal_api_base(chosen) == "http://127.0.0.1:18080"
+
+
+def test_internal_api_listener_scheme_outranks_reachability() -> None:
+    """明文 HTTP 优先于任何 HTTPS 监听器：验证必败的回环 HTTPS 不如可直连的明文。"""
+
+    plan = [
+        ListenerPlan(host="127.0.0.1", port=18000, tls=True),
+        ListenerPlan(host="10.0.0.9", port=18080, tls=False),
+    ]
+    assert internal_api_listener(plan) is plan[1]
+
+
+def test_internal_api_listener_keeps_https_when_no_plain_listener(tmp_path: Path) -> None:
+    """只有 HTTPS 时行为不变：仍按 回环 > 通配 > 具体地址 挑。"""
+
+    transport = _tls_transport(tmp_path)
+    plan, _warnings = build_listener_plan(
+        hosts=["0.0.0.0"], port=18000, transport=transport,
+    )
+    assert internal_api_base(internal_api_listener(plan)) == "https://127.0.0.1:18000"
+
+
+def test_internal_api_fallback_applies_the_same_preference() -> None:
+    """期望的监听器没起来时，回退也要按同样规则挑 started 里最适合内部的那个。"""
+
+    # 期望的明文 18080 失败：实际起了 HTTPS 主端口与明文具体地址，
+    # 回退必须仍选明文，而不是 started 里的第一个 HTTPS。
+    plan = [
+        ListenerPlan(host="127.0.0.1", port=18000, tls=True),
+        ListenerPlan(host="127.0.0.1", port=18080, tls=False),
+        ListenerPlan(host="10.0.0.9", port=19000, tls=False),
+    ]
+    chosen, warning = resolve_internal_listener(plan, [plan[0], plan[2]])
+    assert chosen == plan[2]
+    assert internal_api_base(chosen) == "http://10.0.0.9:19000"
+    assert "未成功监听" in warning
+
+    # 回退同样优先"按同族回环连接"的通配地址，而不是 started 里的第一个具体地址。
+    plan = [
+        ListenerPlan(host="127.0.0.1", port=18000, tls=False),
+        ListenerPlan(host="10.0.0.9", port=19000, tls=False),
+        ListenerPlan(host="0.0.0.0", port=18080, tls=False),
+    ]
+    chosen, warning = resolve_internal_listener(plan, [plan[1], plan[2]])
+    assert chosen == plan[2]
+    assert internal_api_base(chosen) == "http://127.0.0.1:18080"
+
+
 @pytest.mark.asyncio
 async def test_dual_listeners_actually_serve_http_and_https(tmp_path: Path) -> None:
     """真实起两个监听器：HTTPS 主端口 + HTTP 附加端口，两边都要能连上。"""

--- a/web_server.py
+++ b/web_server.py
@@ -313,7 +313,7 @@ async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
             raise OSError(failures[0] if failures else "没有可用的监听地址")
         for item in started:
             print(f"DiceFrame WebUI: {item.url()}  (host={item.host})")
-        _align_internal_api(started)
+        await _align_internal_api(started)
         stop_event = asyncio.Event()
         try:
             loop.add_signal_handler(signal.SIGINT, stop_event.set)
@@ -328,7 +328,7 @@ async def _serve(loop: asyncio.AbstractEventLoop) -> bool:
     return bool(app["runtime_control"]["restart_requested"])
 
 
-def _align_internal_api(started: list) -> None:
+async def _align_internal_api(started: list) -> None:
     """监听器真正起来后复核内部 API 地址，必要时改到确实在监听的那个。"""
 
     listener, warning = resolve_internal_listener(LISTENER_PLAN, started)
@@ -336,6 +336,13 @@ def _align_internal_api(started: list) -> None:
         logger.warning("%s", warning)
     if listener is None:
         return
+    if listener.tls:
+        logger.warning(
+            "内部 API 使用 HTTPS 监听器 %s：插件客户端不做 TLS 信任配置，"
+            "自签名或证书与地址不匹配时插件将无法连接；建议设置 TRPG_WEB_HTTP_PORT "
+            "提供一个明文内部端口",
+            listener.address,
+        )
     plugin_host = app.get("plugin_host")
     if plugin_host is None:
         return
@@ -343,6 +350,10 @@ def _align_internal_api(started: list) -> None:
     if plugin_host.base_env.get("TRPG_API_BASE") != base:
         plugin_host.base_env["TRPG_API_BASE"] = base
         logger.info("插件 API 基址已调整为 %s", base)
+        # 已启动的插件在 spawn 时就快照了旧地址，只有重启进程才能拿到新基址。
+        restarted = await plugin_host.restart_api_consumers()
+        if restarted:
+            logger.info("已重启 %d 个使用内部 API 的插件以应用新基址", restarted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#258 follow-up。代码审阅确认 #258 方向正确、不需要回滚，但有三处需要补，本 PR 按优先级全部修复。

## 1. 🔴 ACME 验证端口映射写反（真 bug）

`docker-compose.acme-challenge.yml` 原来按同一个变量发布两端：`${PORT}:${PORT}`。设置 `TRPG_TLS_ACME_CHALLENGE_PORT=8080` 时得到 宿主 8080 → 容器 8080，但 Let's Encrypt 的 http-01 校验方只会访问公网 **80** 端口 —— #258 描述里「配置 8080、发布 8080」恰恰会被 LE 拒绝。默认 80 → 80 不受影响，坏的只有自定义端口。

**修复**：映射固定为 `"80:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"`（公网 :80 → 容器 challenge 端口）。同步更正 compose 注释与 `.env.example` 的错误指引；宿主 80 被占用时 compose 会显式绑定失败（此时应外层转发或改 DNS-01）。

## 2. 🟠 内部 API 在 TLS 模式下仍不可用（#258 未解决）

`internal_api_listener()` 原来只按 回环 > 通配 > 具体地址 选，不看 scheme：典型配置（`self_signed` 主端口 9876 + 附加 HTTP 18080 + `host=0.0.0.0`）下插件仍拿到 `https://127.0.0.1:9876`。而 `DiceFrameClient` 是不带任何 TLS 信任配置的普通 `aiohttp.ClientSession`：self-signed 不受信任，LE 证书又与 127.0.0.1 不匹配，必然验证失败。

**修复**：存在明文 HTTP 监听器时优先选它（scheme 优先于可达性），外部继续走 HTTPS，插件内部走明文，不绕 TLS 信任链；同 scheme 内排序不变，纯 HTTPS 行为不变。`resolve_internal_listener()` 的回退也改为按同样规则在「实际启动」列表里挑（不再简单取 `started[0]`）。内部 API 只能落在 HTTPS 时输出启动警告，提示配置 `TRPG_WEB_HTTP_PORT`。

## 3. 🟡 基址回退后已运行插件拿不到新地址（#258 自己承认的限制）

`AppRunner.setup()` 先触发 `on_startup()` → `start_enabled()`，之后才 `start_listeners()` → `_align_internal_api()` 改 `base_env`。插件进程在 spawn 时就从 `base_env` 快照了 `TRPG_API_BASE`（`host.py` 的 `_build_process_env`），改址只影响之后启动的插件。

**修复**：新增 `PluginHost.restart_api_consumers()`（照 `restart_ai_provider_consumers()` 先例，仅重启「运行中 + 依赖 `diceframe.http`」的插件），基址实际变化时重启并记日志。

## 测试

- 守卫测试钉住新映射 `"80:${TRPG_TLS_ACME_CHALLENGE_PORT:-80}"`；
- 新增 4 个 listener 用例：明文优先于 HTTPS 主端口 / scheme 优先于可达性（http 具体地址 > https 回环）/ 纯 HTTPS 行为不变 / 回退按同样规则挑选；
- 新增 `restart_api_consumers` 选择逻辑用例（只重启运行中且依赖 `diceframe.http` 的插件）；
- 本地通过：`test_docker_compose_env` + `test_web_listener_plan` + `test_plugin_host` 全量 54 个；`test_web_server_bot_auth` 等 5 个涉及 `TRPG_API_BASE` 的测试文件共 102 个。

## Changed files

仅 9 个相关文件（compose 三个、`.env.example`、`web_server.py`、`listeners.py`、`plugin_host/host.py`、三个测试文件），未包含工作区中其它任务的未提交改动。