### PR TITLE
feat(web): /api/config 公开下发 server_version 与 min_client_version

### DIFF
--- a/frontend-v2/src/api/types.ts
+++ b/frontend-v2/src/api/types.ts
@@ -1839,6 +1839,10 @@ export interface BotTokenResponse {
 }
 
 export interface AppConfig {
+  /** 服务器版本（/api/config 公开下发，供客户端做版本兼容提示） */
+  server_version?: string
+  /** 服务器仍能正确服务的最低客户端版本；客户端版本低于它应提示升级 App */
+  min_client_version?: string
   model?: string
   ai_providers?: AiProvider[]
   llm_provider_ref?: string

--- a/src/version.py
+++ b/src/version.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 APP_NAME = "DiceFrame"
 __version__ = "2.5.7-beta.1"
 DEFAULT_UPDATE_REPOSITORY = "diceframe/diceframe"
+# 服务器仍能正确服务的最低客户端（移动端 App）版本；出现不兼容契约变更时上调，
+# 经 /api/config 的 min_client_version 下发，客户端据此提示升级 App。宽松初值。
+MIN_CLIENT_VERSION = "0.5.0"
 
 
 def version_below(minimum: str, current: str) -> bool:

--- a/tests/test_public_config_version.py
+++ b/tests/test_public_config_version.py
@@ -1,0 +1,27 @@
+"""验证 /api/config 公开视图携带服务器版本元数据。
+
+移动端客户端在登录前只能匿名探测 /api/config，靠其中的 server_version 与
+min_client_version 做“App 过旧 / 服务器过旧”双向兼容提示；字段缺失时
+客户端按版本未知放行（兼容旧服务器），因此这里只保证字段存在且取自
+src.version，不约束具体数值。
+"""
+
+from __future__ import annotations
+
+import web_server
+from src.version import MIN_CLIENT_VERSION, __version__
+
+
+def test_public_config_exposes_server_version_metadata():
+    public = web_server._public_config()
+
+    assert public["server_version"] == __version__
+    assert public["min_client_version"] == MIN_CLIENT_VERSION
+
+
+def test_min_client_version_is_semver_like():
+    # 客户端按点分数字段比较（对齐 version_below 语义），非空且可解析才有效
+    parts = str(MIN_CLIENT_VERSION).strip().lstrip("vV").split(".")
+    assert len(parts) >= 2
+    for chunk in parts:
+        assert chunk.split("-")[0].isdigit()

--- a/web_server.py
+++ b/web_server.py
@@ -55,6 +55,7 @@ from src.webui.config_controller import (
     ConfigController,
     ConfigControllerDependencies,
 )
+from src.version import MIN_CLIENT_VERSION, __version__
 
 logger = logging.getLogger("trpg")
 logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
@@ -125,7 +126,13 @@ def _mask_secret(value: str) -> dict:
 
 
 def _public_config() -> dict:
-    return CONFIG_STORE.public_view(RUNTIME_CONFIG)
+    # 版本元数据是组合层事实而非配置状态，在这里注入而不是写进 ConfigStore：
+    # 公开的 /api/config 是客户端（移动端）登录前唯一可匿名探测的端点，
+    # 客户端据此做双向版本兼容提示（App 过旧 / 服务器过旧）。
+    public = CONFIG_STORE.public_view(RUNTIME_CONFIG)
+    public["server_version"] = __version__
+    public["min_client_version"] = MIN_CLIENT_VERSION
+    return public
 
 
 def save_config():


### PR DESCRIPTION
## 概述

公开端点 `/api/config` 增加服务器版本元数据下发，让移动端客户端在登录前即可做"App 过旧 / 服务器过旧"双向版本兼容提示。

## 变更

- `src/version.py` 新增 `MIN_CLIENT_VERSION`：服务器仍能正确服务的最低客户端（移动端 App）版本；出现不兼容契约变更时上调，当前为宽松初值 `0.5.0`。
- `web_server._public_config` 在组合层注入 `server_version` 与 `min_client_version`，而不是写进 ConfigStore：版本元数据是组合层事实而非配置状态，且公开 `/api/config` 是客户端登录前唯一可匿名探测的端点。
- `frontend-v2/src/api/types.ts` 的 `AppConfig` 同步两个可选字段（旧服务器不下发时客户端按版本未知放行）。
- 新增 `tests/test_public_config_version.py`，锁定字段存在且取自 `src.version`，并约束 `MIN_CLIENT_VERSION` 可被点分数字段比较（对齐 `version_below` 语义）。

## 测试

- `tests/test_public_config_version.py` 2 项通过。
