### PR TITLE
feat(dnd2024): add AI-generated temporary encounter fallback

### DIFF
--- a/frontend-v2/src/api/rulesets.ts
+++ b/frontend-v2/src/api/rulesets.ts
@@ -10,6 +10,7 @@ import type {
   RulesetProgressionResponse,
   RulesetRestResponse,
   RulesetGameplayResponse,
+  RulesetTemporaryEncounterResponse,
 } from '@/api/types'
 
 function rulePath(ruleId: string, suffix: string, language = ''): string {
@@ -217,6 +218,16 @@ export function submitRulesetIntent(
   return api<RulesetGameplayResponse>(
     `/games/${encodeURIComponent(gameKey)}/intents`,
     { method: 'POST', body: JSON.stringify(intent) },
+  )
+}
+
+// AI 临时遭遇提案：只读生成，不改任何游戏状态；确认后走现有 /intents combat.start。
+export function planRulesetTemporaryEncounter(
+  gameKey: string,
+): Promise<RulesetTemporaryEncounterResponse> {
+  return api<RulesetTemporaryEncounterResponse>(
+    `/games/${encodeURIComponent(gameKey)}/ruleset/temporary-encounter`,
+    { method: 'POST', body: JSON.stringify({}) },
   )
 }
 

--- a/frontend-v2/src/api/types.ts
+++ b/frontend-v2/src/api/types.ts
@@ -1004,6 +1004,40 @@ export interface RulesetEncounterPreset extends JsonObject {
   enemies: JsonObject[]
 }
 
+export interface RulesetTemporaryEncounterAttack extends JsonObject {
+  id?: string
+  name?: string
+  attack_bonus?: number
+  damage?: string
+  range?: number
+  long_range?: number
+}
+
+export interface RulesetTemporaryEncounterEnemy extends JsonObject {
+  id?: string
+  name?: string
+  hp?: number
+  armor_class?: number
+  speed?: number
+  position?: number
+  initiative_modifier?: number
+  attacks?: RulesetTemporaryEncounterAttack[]
+}
+
+export interface RulesetTemporaryEncounter extends JsonObject {
+  title: string
+  description: string
+  enemies: RulesetTemporaryEncounterEnemy[]
+  planner?: JsonObject
+}
+
+export interface RulesetTemporaryEncounterResponse extends JsonObject {
+  ok?: boolean
+  code?: string
+  error?: string
+  encounter?: RulesetTemporaryEncounter
+}
+
 export interface RulesetSessionZeroAgreement extends JsonObject {
   tone: string
   difficulty: 'story' | 'standard' | 'challenging' | 'lethal' | string

--- a/frontend-v2/src/features/rulesets/dnd2024/api.ts
+++ b/frontend-v2/src/features/rulesets/dnd2024/api.ts
@@ -13,6 +13,7 @@ export {
   resolveLiveCharacterRest,
   resolveRulesetRest,
   resolveRulesetDecision,
+  planRulesetTemporaryEncounter,
   submitRulesetIntent,
   validateRulesetBuilderDraft,
 } from '@/api/rulesets'

--- a/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
+++ b/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
@@ -205,6 +205,13 @@ const requestedCombatPreset = computed(() => {
     ? selectableEncounterPresets.value.find(preset => preset.id === presetId)
     : undefined
 })
+const canPlanTemporaryEncounter = computed(() => Boolean(
+  props.isGm
+  && combat.value?.status !== 'active'
+  && narrativeCombatPending.value
+  && encounterMode.value !== 'story'
+  && !requestedCombatPreset.value
+))
 const attackAction = computed(() => action('attack'))
 const spellAction = computed(() => action('cast_spell'))
 const moveAction = computed(() => action('move'))
@@ -761,7 +768,7 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
             <button type="button" @click="emit('navigate', 'campaign')">
               <NIcon :component="PlayForwardOutline" />{{ copy.returnToAdventure }}
             </button>
-            <button v-if="isGm" type="button" class="combat-primary" :disabled="aiBusy" @click="planTemporaryEncounter">
+            <button v-if="canPlanTemporaryEncounter" type="button" class="combat-primary" :disabled="aiBusy" @click="planTemporaryEncounter">
               <NIcon :component="SparklesOutline" />{{ aiBusy ? copy.aiPreparing : copy.aiPrepare }}
             </button>
             <button v-if="isGm" type="button" @click="declareSandboxEncounter">
@@ -839,7 +846,7 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
               <button type="button" class="manual-encounter-toggle" @click="openManualEncounter">
                 <NIcon :component="ShieldOutline" />{{ copy.manualEncounter }}
               </button>
-              <button type="button" class="ai-encounter-toggle" :disabled="aiBusy" @click="planTemporaryEncounter">
+              <button v-if="canPlanTemporaryEncounter" type="button" class="ai-encounter-toggle" :disabled="aiBusy" @click="planTemporaryEncounter">
                 <NIcon :component="SparklesOutline" />{{ aiBusy ? copy.aiPreparing : copy.aiPrepare }}
               </button>
             </div>

--- a/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
+++ b/frontend-v2/src/features/rulesets/dnd2024/combat/Dnd2024CombatPanel.vue
@@ -12,6 +12,7 @@ import {
 } from '@vicons/ionicons5'
 import {
   fetchRulesetAvailableActions,
+  planRulesetTemporaryEncounter,
   resolveRulesetDecision,
   submitRulesetIntent,
 } from '@/features/rulesets/dnd2024/api'
@@ -22,6 +23,7 @@ import type {
   RulesetCombatWeapon,
   RulesetGameplayResponse,
   RulesetPendingDecision,
+  RulesetTemporaryEncounter,
 } from '@/api/types'
 import { useLocale } from '@/composables/useLocale'
 import CombatLiveBar from '@/components/play/CombatLiveBar.vue'
@@ -82,11 +84,20 @@ const copy = computed(() => locale.value.startsWith('zh') ? {
   readySummary: '队友准备', startHint: 'GM 可在确认敌情与队伍状态后开始战斗。',
   manualEncounter: '手动准备遭遇',
   chooseFreeEncounter: '选择自由遭遇',
-  sandboxHint: 'AI GM 没能把当前敌情匹配到合法遭遇。请由 GM 手动准备一场自由遭遇。',
+  sandboxHint: 'AI GM 没能把当前敌情匹配到合法遭遇。可以由 AI 临时准备，或手动选择一场自由遭遇。',
   unpreparedTitle: '当前剧情尚未配置专业战斗遭遇',
   unpreparedHint: '剧情已经进入交战态势，但这个冒险包没有为当前敌情绑定合法的专业遭遇。服务端不会用通用训练遭遇替代它。',
-  unpreparedAction: '脱离冒险，准备自由遭遇',
-  sandboxWarning: '确认后将离开当前冒险包，创建一场不属于剧情绑定的自由遭遇。',
+  aiPrepare: 'AI 临时准备遭遇',
+  aiHint: 'AI 会参考当前剧情临时生成一场自由遭遇；不会修改冒险包内容。',
+  aiPreparing: 'AI 正在临时准备遭遇…',
+  aiFailed: '无法生成合法的临时遭遇。你仍可以手动选择自由遭遇。',
+  aiPreviewTag: 'AI 临时遭遇',
+  aiConfirmStart: '确认进入战斗',
+  aiRegenerate: '重新生成',
+  aiEncounterNote: '这场战斗不会写入冒险包的正式遭遇定义；战斗结束后仍可继续当前冒险剧情。',
+  tempSpeed: '速度',
+  unpreparedAction: '临时准备自由遭遇',
+  sandboxWarning: '这是一场临时自由遭遇：不会写入冒险包的正式遭遇定义，战斗结束后仍可继续当前冒险剧情。',
   storyMode: '剧情遭遇',
   sandboxMode: '自由遭遇',
   sandboxOutsideAdventure: '自由战斗 · 不属于当前冒险包',
@@ -121,11 +132,20 @@ const copy = computed(() => locale.value.startsWith('zh') ? {
   readySummary: 'Party ready', startHint: 'The GM can start after reviewing the opposition and party status.',
   manualEncounter: 'Prepare encounter manually',
   chooseFreeEncounter: 'Select a free encounter',
-  sandboxHint: 'The AI GM could not match the current opposition to a legal encounter. The GM can prepare a free encounter manually.',
+  sandboxHint: 'The AI GM could not match the current opposition to a legal encounter. Prepare one with AI, or pick a free encounter manually.',
   unpreparedTitle: 'The current story has no prepared encounter',
   unpreparedHint: 'The story has entered combat, but this adventure package binds no legal encounter to the current opposition. The server will not substitute a generic training encounter.',
-  unpreparedAction: 'Leave the adventure and prepare a free encounter',
-  sandboxWarning: 'This leaves the active adventure package and creates a free encounter that is not story-bound.',
+  aiPrepare: 'AI temporary encounter',
+  aiHint: 'The AI drafts a free encounter from the current story; the adventure package is never modified.',
+  aiPreparing: 'The AI is preparing an encounter…',
+  aiFailed: 'Could not generate a legal temporary encounter. You can still prepare a free encounter manually.',
+  aiPreviewTag: 'AI temporary encounter',
+  aiConfirmStart: 'Confirm and start combat',
+  aiRegenerate: 'Regenerate',
+  aiEncounterNote: 'This combat is not written into the adventure package; the story continues afterwards.',
+  tempSpeed: 'Speed',
+  unpreparedAction: 'Prepare a temporary free encounter',
+  sandboxWarning: 'This is a temporary free encounter: it is not written into the adventure package, and the story continues after combat.',
   storyMode: 'Story encounter',
   sandboxMode: 'Free encounter',
   sandboxOutsideAdventure: 'Free combat · not part of the active adventure',
@@ -169,6 +189,11 @@ const adventureActive = computed(() => String(
   gameplay.value?.campaign?.tutorial?.status || '',
 ) === 'active')
 const sandboxDeclared = ref(false)
+// AI 临时遭遇：只读提案（生成 → GM 预览 → 确认），与手动自由遭遇流程并行；
+// 确认走现有 combat.start(mode=sandbox)，服务端权威校验仍然完整生效。
+const aiProposal = ref<RulesetTemporaryEncounter | null>(null)
+const aiBusy = ref(false)
+const aiError = ref('')
 const readyAction = computed(() => action('encounter.ready'))
 const unreadyAction = computed(() => action('encounter.unready'))
 const isReady = computed(() => Boolean(
@@ -424,6 +449,8 @@ function clearGameScopedState(): void {
   nextEncounterOpen.value = false
   manualEncounterOpen.value = false
   sandboxDeclared.value = false
+  aiProposal.value = null
+  aiError.value = ''
   movementDistance.value = 5
   staged.value = null
   returnFocus = null
@@ -441,11 +468,57 @@ function toggleNextEncounter(): void {
   if (nextEncounterOpen.value) resetSelections()
 }
 
-// GM 明确选择“脱离当前冒险包，准备自由遭遇”后才允许使用通用目录。
+// GM 明确选择“临时准备自由遭遇”后才允许使用通用目录。
 function declareSandboxEncounter(): void {
   sandboxDeclared.value = true
   manualEncounterOpen.value = true
   resetSelections()
+}
+
+function cancelAiProposal(): void {
+  aiProposal.value = null
+  aiError.value = ''
+}
+
+// 生成与开战严格分两步：这里只拿提案，绝不自动开战；失败完全无副作用。
+async function planTemporaryEncounter(): Promise<void> {
+  const gameKey = props.gameKey
+  aiBusy.value = true
+  aiError.value = ''
+  try {
+    const response = await planRulesetTemporaryEncounter(gameKey)
+    if (props.gameKey !== gameKey) return
+    if (response.encounter) {
+      aiProposal.value = response.encounter
+    } else {
+      aiProposal.value = null
+      aiError.value = response.error || copy.value.aiFailed
+    }
+  } catch (cause: unknown) {
+    if (props.gameKey !== gameKey) return
+    aiProposal.value = null
+    aiError.value = friendlyCombatError(cause) || copy.value.aiFailed
+  } finally {
+    if (props.gameKey === gameKey) aiBusy.value = false
+  }
+}
+
+// 确认入口：提交现有 combat.start（mode=sandbox + enemies，不带
+// encounter_preset_id）；服务端权威校验再次完整执行，篡改预览也进不了战斗。
+async function confirmAiEncounter(): Promise<void> {
+  const proposal = aiProposal.value
+  if (!proposal?.enemies?.length) return
+  await submit({
+    intent_id: intentId(),
+    type: 'combat.start',
+    expected_version: gameplay.value?.state_version ?? 0,
+    mode: 'sandbox',
+    enemies: proposal.enemies,
+  })
+  if (!error.value) {
+    aiProposal.value = null
+    aiError.value = ''
+  }
 }
 
 async function load(silent = false): Promise<void> {
@@ -688,10 +761,14 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
             <button type="button" @click="emit('navigate', 'campaign')">
               <NIcon :component="PlayForwardOutline" />{{ copy.returnToAdventure }}
             </button>
-            <button v-if="isGm" type="button" class="combat-primary" @click="declareSandboxEncounter">
+            <button v-if="isGm" type="button" class="combat-primary" :disabled="aiBusy" @click="planTemporaryEncounter">
+              <NIcon :component="SparklesOutline" />{{ aiBusy ? copy.aiPreparing : copy.aiPrepare }}
+            </button>
+            <button v-if="isGm" type="button" @click="declareSandboxEncounter">
               <NIcon :component="ShieldOutline" />{{ copy.unpreparedAction }}
             </button>
           </div>
+          <p v-if="isGm" class="combat-state">{{ copy.aiHint }}</p>
         </div>
         <div v-else-if="requestedCombatPreset" class="guided-preset">
           <span>{{ copy.recommendedEncounter }}</span>
@@ -708,6 +785,34 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
               </select>
             </label>
           </details>
+        </div>
+
+        <p v-if="aiError && !aiProposal" class="combat-error" role="alert">{{ aiError }}</p>
+        <div v-if="isGm && aiProposal" class="guided-preset ai-encounter-preview">
+          <span>{{ copy.aiPreviewTag }}</span>
+          <strong>{{ aiProposal.title }}</strong>
+          <p>{{ aiProposal.description }}</p>
+          <ul class="ai-encounter-enemies">
+            <li v-for="enemy in aiProposal.enemies" :key="enemy.id">
+              <header>
+                <strong>{{ enemy.name }}</strong>
+                <small>HP {{ enemy.hp }} · AC {{ enemy.armor_class }} · {{ copy.tempSpeed }} {{ enemy.speed }}</small>
+              </header>
+              <small v-for="attack in enemy.attacks" :key="attack.id" class="ai-encounter-attack">
+                {{ attack.name }} +{{ attack.attack_bonus }} / {{ attack.damage }}
+              </small>
+            </li>
+          </ul>
+          <p class="combat-state">{{ copy.aiEncounterNote }}</p>
+          <div class="unprepared-actions">
+            <button type="button" :disabled="aiBusy" @click="planTemporaryEncounter">
+              <NIcon :component="SparklesOutline" />{{ copy.aiRegenerate }}
+            </button>
+            <button type="button" class="combat-primary" :disabled="busy" @click="confirmAiEncounter">
+              <NIcon :component="PlayForwardOutline" />{{ copy.aiConfirmStart }}
+            </button>
+            <button type="button" @click="cancelAiProposal">{{ copy.cancel }}</button>
+          </div>
         </div>
 
         <section v-if="encounterReadiness?.required_count" class="party-readiness" aria-live="polite">
@@ -730,9 +835,14 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
 
         <template v-if="isGm && (action('combat.start') || sandboxDeclared)">
           <template v-if="!guidedCombatStep && !requestedCombatPreset">
-            <button v-if="!manualEncounterOpen && !sandboxDeclared" type="button" class="manual-encounter-toggle" @click="openManualEncounter">
-              <NIcon :component="ShieldOutline" />{{ copy.manualEncounter }}
-            </button>
+            <div v-if="!manualEncounterOpen && !sandboxDeclared" class="unprepared-actions">
+              <button type="button" class="manual-encounter-toggle" @click="openManualEncounter">
+                <NIcon :component="ShieldOutline" />{{ copy.manualEncounter }}
+              </button>
+              <button type="button" class="ai-encounter-toggle" :disabled="aiBusy" @click="planTemporaryEncounter">
+                <NIcon :component="SparklesOutline" />{{ aiBusy ? copy.aiPreparing : copy.aiPrepare }}
+              </button>
+            </div>
             <template v-else>
               <p v-if="sandboxDeclared" class="combat-warning">{{ copy.sandboxWarning }}</p>
               <p v-else-if="narrativeCombatPending" class="combat-state">{{ copy.sandboxHint }}</p>
@@ -982,6 +1092,12 @@ onBeforeUnmount(() => { if (pollTimer) window.clearInterval(pollTimer) })
 .guided-preset.unprepared strong { color: #f4d9a4; }
 .guided-preset .unprepared-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px; }
 .guided-preset .unprepared-actions button { display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
+.ai-encounter-preview { border-color: #6d6f4a; background: rgb(52 56 24 / 28%); }
+.ai-encounter-enemies { display: grid; gap: 7px; margin: 0; padding: 0; list-style: none; }
+.ai-encounter-enemies li { display: grid; gap: 3px; padding: 8px 10px; border: 1px solid #6d5a35; border-radius: 9px; background: rgb(14 20 24 / 42%); }
+.ai-encounter-enemies header { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+.ai-encounter-enemies header small { color: #cfc6b4; }
+.ai-encounter-attack { color: #b9c7b0; font-size: 12px; }
 .encounter-source { color: #d9cba6; font-size: 11px; }
 .combat-header-tools { display: flex; align-items: center; gap: 9px; }
 .combat-mode-badge { padding: 3px 9px; border: 1px solid #6d5a35; border-radius: 999px; color: #f0d79c; background: rgb(64 46 20 / 55%); font-size: 11px; letter-spacing: .04em; white-space: nowrap; }

--- a/frontend-v2/tests/Dnd2024CombatPanel.test.ts
+++ b/frontend-v2/tests/Dnd2024CombatPanel.test.ts
@@ -95,6 +95,7 @@ describe('D&D 2024 combat panel', () => {
     expect(wrapper.text()).toContain('No combat is active')
     expect(wrapper.text()).not.toContain('First Skirmish')
     expect(wrapper.find('.encounter-start select').exists()).toBe(false)
+    expect(wrapper.find('.ai-encounter-toggle').exists()).toBe(false)
     await wrapper.get('.manual-encounter-toggle').trigger('click')
     expect(wrapper.text()).toContain('First Skirmish')
     await wrapper.get('.encounter-start .combat-primary').trigger('click')
@@ -146,6 +147,7 @@ describe('D&D 2024 combat panel', () => {
     // 没有匹配到合法遭遇时不得自动展示通用目录，更不能默认选中地精。
     expect(wrapper.find('.encounter-start select').exists()).toBe(false)
     expect(wrapper.find('.encounter-start .combat-primary').exists()).toBe(false)
+    expect(wrapper.find('.ai-encounter-toggle').exists()).toBe(true)
     await wrapper.get('.manual-encounter-toggle').trigger('click')
     expect(wrapper.text()).toContain('Select a free encounter')
     expect(wrapper.text()).toContain('could not match the current opposition')
@@ -238,6 +240,7 @@ describe('D&D 2024 combat panel', () => {
 
     expect(wrapper.get('.guided-preset strong').text()).toBe('First Skirmish')
     expect(wrapper.text()).toContain('Encounter：first_skirmish')
+    expect(wrapper.find('.ai-encounter-toggle').exists()).toBe(false)
     await wrapper.get('.encounter-start .combat-primary').trigger('click')
     await flushPromises()
     const payload = mocks.submit.mock.calls[0][1]

--- a/frontend-v2/tests/Dnd2024CombatPanel.test.ts
+++ b/frontend-v2/tests/Dnd2024CombatPanel.test.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  fetch: vi.fn(), submit: vi.fn(), decide: vi.fn(),
+  fetch: vi.fn(), submit: vi.fn(), decide: vi.fn(), plan: vi.fn(),
   locale: 'en',
 }))
 
@@ -11,6 +11,7 @@ vi.mock('../src/features/rulesets/dnd2024/api', () => ({
   fetchRulesetAvailableActions: mocks.fetch,
   submitRulesetIntent: mocks.submit,
   resolveRulesetDecision: mocks.decide,
+  planRulesetTemporaryEncounter: mocks.plan,
 }))
 vi.mock('../src/composables/useLocale', () => ({
   useLocale: () => ({ locale: ref(mocks.locale) }),
@@ -82,6 +83,7 @@ describe('D&D 2024 combat panel', () => {
     mocks.fetch.mockReset().mockResolvedValue(response('none'))
     mocks.submit.mockReset().mockResolvedValue(response('active'))
     mocks.decide.mockReset().mockResolvedValue(response('active'))
+    mocks.plan.mockReset().mockResolvedValue({ ok: false, error: 'unavailable' })
   })
 
   it('keeps the catalog hidden in a fresh game and starts from a server-provided preset after explicit preparation', async () => {
@@ -187,9 +189,13 @@ describe('D&D 2024 combat panel', () => {
     expect(wrapper.find('.encounter-start > .combat-primary').exists()).toBe(false)
     expect(wrapper.find('.manual-encounter-toggle').exists()).toBe(false)
 
-    // GM 明确“脱离冒险，准备自由遭遇”后才出现通用目录，且提交必须声明 sandbox。
+    // AI 临时准备遭遇：只调用只读 plan API，不自动开战、不出现通用目录。
     await wrapper.get('.guided-preset .unprepared-actions .combat-primary').trigger('click')
-    expect(wrapper.text()).toContain('leaves the active adventure package')
+    expect(mocks.plan).toHaveBeenCalledWith('web|combat|bot')
+    expect(wrapper.find('.encounter-start select').exists()).toBe(false)
+    // GM 明确“临时准备自由遭遇”后才出现通用目录，且提交必须声明 sandbox。
+    await wrapper.get('.guided-preset .unprepared-actions button:last-child').trigger('click')
+    expect(wrapper.text()).toContain('not written into the adventure package')
     await wrapper.get('.encounter-start .combat-primary').trigger('click')
     await flushPromises()
     expect(mocks.submit.mock.calls[0][1]).toMatchObject({

--- a/src/rulesets/contracts.py
+++ b/src/rulesets/contracts.py
@@ -231,6 +231,19 @@ class NarrativeDirectorPlanningRuntime(Protocol):
 
 
 @runtime_checkable
+class TemporaryEncounterPlannerRuntime(Protocol):
+    """Optional read-only AI proposal for a temporary free encounter.
+
+    The proposal never touches persisted state; the GM confirms and the
+    authoritative combat.start validation still applies.
+    """
+
+    async def plan_temporary_encounter(
+        self, instance: Any, llm_client: Any,
+    ) -> dict[str, Any] | None: ...
+
+
+@runtime_checkable
 class AutomaticIntentRuntime(Protocol):
     """Optional server-owned turn automation for non-player actors."""
 

--- a/src/rulesets/dnd2024/combat/validation.py
+++ b/src/rulesets/dnd2024/combat/validation.py
@@ -15,10 +15,81 @@ from .primitives import (
 )
 
 
+def validate_enemy_profiles(enemies: Any) -> None:
+    """Public enemy profile validation shared by combat.start, preset
+    loading, and AI temporary-encounter generation.
+
+    Only one implementation of the safety boundary exists; callers must not
+    copy or relax it.
+    """
+
+    if not isinstance(enemies, list) or not 1 <= len(enemies) <= 50:
+        raise CombatIntentError("combat requires 1 to 50 enemies")
+    seen: set[str] = set()
+    for enemy in enemies:
+        if not isinstance(enemy, dict):
+            raise CombatIntentError("enemy must be an object")
+        enemy_id = str(enemy.get("id") or "")
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,63}", enemy_id) or enemy_id in seen:
+            raise CombatIntentError("enemy id is invalid or duplicated")
+        seen.add(enemy_id)
+        if len(str(enemy.get("name") or enemy_id)) > 120:
+            raise CombatIntentError("enemy name is too long")
+        for field_name, minimum, maximum in (
+            ("hp", 1, 10000), ("armor_class", 1, 40),
+            ("speed", 0, 200), ("position", -10000, 10000),
+            ("initiative_modifier", -20, 30),
+        ):
+            default = (
+                30 if field_name in {"speed", "position"}
+                else 0 if field_name == "initiative_modifier" else None
+            )
+            value = enemy.get(field_name, default)
+            if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+                raise CombatIntentError(f"enemy {field_name} is invalid")
+        attacks = enemy.get("attacks")
+        if not isinstance(attacks, list) or not 1 <= len(attacks) <= 20:
+            raise CombatIntentError("enemy requires 1 to 20 attacks")
+        attack_ids: set[str] = set()
+        for attack in attacks:
+            if not isinstance(attack, dict):
+                raise CombatIntentError("enemy attack profile is invalid")
+            attack_id = str(attack.get("id") or "")
+            formula = str(attack.get("damage") or "")
+            dice_match = DICE_RE.fullmatch(formula)
+            attack_bonus = attack.get("attack_bonus")
+            normal_range = attack.get("range", 5)
+            long_range = attack.get("long_range", normal_range)
+            if (
+                not re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,63}", attack_id)
+                or attack_id in attack_ids
+                or dice_match is None
+                or isinstance(attack_bonus, bool)
+                or not isinstance(attack_bonus, int)
+                or not -20 <= attack_bonus <= 30
+                or isinstance(normal_range, bool)
+                or not isinstance(normal_range, int)
+                or not 1 <= normal_range <= 1000
+                or isinstance(long_range, bool)
+                or not isinstance(long_range, int)
+                or long_range < normal_range
+                or long_range > 2000
+            ):
+                raise CombatIntentError("enemy attack profile is invalid")
+            dice_count, dice_sides = int(dice_match.group(1)), int(dice_match.group(2))
+            if not 1 <= dice_count <= 100 or not 2 <= dice_sides <= 1000:
+                raise CombatIntentError("enemy attack damage dice are invalid")
+            attack_ids.add(attack_id)
+
+
 class CombatValidationMixin:
     """Validate combat declarations without resolving dice or changing state."""
 
     __slots__ = ()
+
+    @staticmethod
+    def _validate_enemies(enemies: Any) -> None:
+        validate_enemy_profiles(enemies)
 
     def _validate(self, instance: Any, intent: dict[str, Any]) -> None:
         if not isinstance(intent, dict):
@@ -256,66 +327,6 @@ class CombatValidationMixin:
         damage_choices = effect.get("damage_type_choice")
         if damage_choices and intent.get("damage_type") not in damage_choices:
             raise CombatIntentError("spell damage_type choice is required")
-
-    @staticmethod
-    def _validate_enemies(enemies: Any) -> None:
-        if not isinstance(enemies, list) or not 1 <= len(enemies) <= 50:
-            raise CombatIntentError("combat requires 1 to 50 enemies")
-        seen: set[str] = set()
-        for enemy in enemies:
-            if not isinstance(enemy, dict):
-                raise CombatIntentError("enemy must be an object")
-            enemy_id = str(enemy.get("id") or "")
-            if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,63}", enemy_id) or enemy_id in seen:
-                raise CombatIntentError("enemy id is invalid or duplicated")
-            seen.add(enemy_id)
-            if len(str(enemy.get("name") or enemy_id)) > 120:
-                raise CombatIntentError("enemy name is too long")
-            for field_name, minimum, maximum in (
-                ("hp", 1, 10000), ("armor_class", 1, 40),
-                ("speed", 0, 200), ("position", -10000, 10000),
-                ("initiative_modifier", -20, 30),
-            ):
-                default = (
-                    30 if field_name in {"speed", "position"}
-                    else 0 if field_name == "initiative_modifier" else None
-                )
-                value = enemy.get(field_name, default)
-                if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
-                    raise CombatIntentError(f"enemy {field_name} is invalid")
-            attacks = enemy.get("attacks")
-            if not isinstance(attacks, list) or not 1 <= len(attacks) <= 20:
-                raise CombatIntentError("enemy requires 1 to 20 attacks")
-            attack_ids: set[str] = set()
-            for attack in attacks:
-                if not isinstance(attack, dict):
-                    raise CombatIntentError("enemy attack profile is invalid")
-                attack_id = str(attack.get("id") or "")
-                formula = str(attack.get("damage") or "")
-                dice_match = DICE_RE.fullmatch(formula)
-                attack_bonus = attack.get("attack_bonus")
-                normal_range = attack.get("range", 5)
-                long_range = attack.get("long_range", normal_range)
-                if (
-                    not re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,63}", attack_id)
-                    or attack_id in attack_ids
-                    or dice_match is None
-                    or isinstance(attack_bonus, bool)
-                    or not isinstance(attack_bonus, int)
-                    or not -20 <= attack_bonus <= 30
-                    or isinstance(normal_range, bool)
-                    or not isinstance(normal_range, int)
-                    or not 1 <= normal_range <= 1000
-                    or isinstance(long_range, bool)
-                    or not isinstance(long_range, int)
-                    or long_range < normal_range
-                    or long_range > 2000
-                ):
-                    raise CombatIntentError("enemy attack profile is invalid")
-                dice_count, dice_sides = int(dice_match.group(1)), int(dice_match.group(2))
-                if not 1 <= dice_count <= 100 or not 2 <= dice_sides <= 1000:
-                    raise CombatIntentError("enemy attack damage dice are invalid")
-                attack_ids.add(attack_id)
 
     @staticmethod
     def _validate_player_positions(instance: Any, positions: Any) -> None:

--- a/src/rulesets/dnd2024/director/temporary_encounter.py
+++ b/src/rulesets/dnd2024/director/temporary_encounter.py
@@ -130,15 +130,44 @@ def _generation_context(instance: Any, campaign: dict[str, Any]) -> dict[str, An
     for uid, player in players.items():
         sheet = player.get("character_sheet") if isinstance(player, dict) else {}
         sheet = sheet if isinstance(sheet, dict) else {}
-        profile = sheet.get("ruleset_character")
-        profile = profile if isinstance(profile, dict) else sheet
+        canonical = sheet.get("ruleset_character")
+        canonical = canonical if isinstance(canonical, dict) else {}
+        identity = canonical.get("identity")
+        identity = identity if isinstance(identity, dict) else {}
+        build = canonical.get("build")
+        build = build if isinstance(build, dict) else {}
+        resources = canonical.get("resources")
+        resources = resources if isinstance(resources, dict) else {}
+        derived = canonical.get("derived")
+        derived = derived if isinstance(derived, dict) else {}
+        class_levels = build.get("class_levels")
+        class_levels = class_levels if isinstance(class_levels, list) else []
+        primary_class = ""
+        if class_levels and isinstance(class_levels[0], dict):
+            primary_class = str(class_levels[0].get("class_ref") or "")
         member = {
-            "name": str(profile.get("character_name") or sheet.get("character_name") or uid)[:60],
-            "class": str(profile.get("class") or profile.get("class_name") or "")[:40],
-            "level": profile.get("level"),
-            "hp": profile.get("hp"),
-            "max_hp": profile.get("max_hp"),
-            "armor_class": profile.get("armor_class"),
+            "name": str(
+                identity.get("name")
+                or canonical.get("character_name")
+                or sheet.get("character_name")
+                or uid
+            )[:60],
+            "class": str(
+                primary_class
+                or canonical.get("class")
+                or canonical.get("class_name")
+                or sheet.get("class")
+                or sheet.get("class_name")
+                or ""
+            )[:80],
+            "level": build.get("level", canonical.get("level", sheet.get("level"))),
+            "hp": resources.get("hp", canonical.get("hp", sheet.get("hp"))),
+            "max_hp": resources.get(
+                "max_hp", canonical.get("max_hp", sheet.get("max_hp")),
+            ),
+            "armor_class": derived.get(
+                "armor_class", canonical.get("armor_class", sheet.get("armor_class")),
+            ),
         }
         members.append({key: value for key, value in member.items() if value not in (None, "")})
     tutorial = campaign.get("tutorial") if isinstance(campaign, dict) else None

--- a/src/rulesets/dnd2024/director/temporary_encounter.py
+++ b/src/rulesets/dnd2024/director/temporary_encounter.py
@@ -1,0 +1,313 @@
+"""AI-generated temporary encounter proposals for D&D 2024.
+
+模型只负责"临时提案"：GM 确认后提交现有 ``combat.start``（mode=sandbox），
+服务端权威校验仍然生效。生成是只读操作 —— 不写 Adventure Bundle、不写
+encounter catalog、不改任何游戏状态；失败时完全无副作用。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from src.rulesets.dnd2024.combat.validation import validate_enemy_profiles
+
+TEMPORARY_ENCOUNTER_TOOL_NAME = "dnd2024_temporary_encounter"
+
+# 临时生成在底层敌人校验（validate_enemy_profiles）之上额外收紧的合理范围：
+# 不做 CR 系统，只防止模型输出明显失控的数值。
+MAX_TEMPORARY_ENEMIES = 12
+_ENEMY_FIELD_BOUNDS: dict[str, tuple[int, int]] = {
+    "hp": (1, 500),
+    "armor_class": (8, 25),
+    "speed": (0, 80),
+    "position": (-1000, 1000),
+    "initiative_modifier": (-5, 10),
+}
+_ATTACK_FIELD_BOUNDS: dict[str, tuple[int, int]] = {
+    "attack_bonus": (-2, 15),
+    "range": (5, 600),
+    "long_range": (5, 600),
+}
+_ENEMY_FIELD_DEFAULTS: dict[str, int] = {
+    "speed": 30, "position": 30, "initiative_modifier": 0,
+}
+_ATTACK_FIELD_DEFAULTS: dict[str, int] = {"range": 5}
+
+_ID_SANITIZE = re.compile(r"[^a-z0-9]+")
+
+
+TEMPORARY_ENCOUNTER_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": TEMPORARY_ENCOUNTER_TOOL_NAME,
+        "description": (
+            "Propose one temporary free-play encounter matching the current fiction and party. "
+            "Enemies must be simple stat blocks the combat engine fully supports: move, attack, "
+            "dodge, end turn."
+        ),
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "title": {"type": "string", "maxLength": 80},
+                "description": {"type": "string", "maxLength": 300},
+                "enemies": {
+                    "type": "array", "minItems": 1, "maxItems": MAX_TEMPORARY_ENEMIES,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "id": {"type": "string"},
+                            "name": {"type": "string", "maxLength": 60},
+                            "hp": {"type": "integer", "minimum": 1, "maximum": 500},
+                            "armor_class": {"type": "integer", "minimum": 8, "maximum": 25},
+                            "speed": {"type": "integer", "minimum": 0, "maximum": 80},
+                            "position": {"type": "integer"},
+                            "initiative_modifier": {
+                                "type": "integer", "minimum": -5, "maximum": 10,
+                            },
+                            "attacks": {
+                                "type": "array", "minItems": 1, "maxItems": 3,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "id": {"type": "string"},
+                                        "name": {"type": "string", "maxLength": 60},
+                                        "attack_bonus": {
+                                            "type": "integer", "minimum": -2, "maximum": 15,
+                                        },
+                                        "damage": {"type": "string", "maxLength": 40},
+                                        "range": {"type": "integer", "minimum": 5, "maximum": 600},
+                                        "long_range": {
+                                            "type": "integer", "minimum": 5, "maximum": 600,
+                                        },
+                                    },
+                                    "required": ["id", "name", "attack_bonus", "damage"],
+                                },
+                            },
+                        },
+                        "required": ["id", "name", "hp", "armor_class", "speed", "attacks"],
+                    },
+                },
+            },
+            "required": ["title", "description", "enemies"],
+        },
+    },
+}
+
+
+def _temporary_prompt(language: str) -> str:
+    if str(language or "").lower().startswith("zh"):
+        return (
+            "你是 D&D 2024 临时遭遇生成器。根据当前剧情、冒险步骤、敌情与队伍构成，"
+            "生成一场普通难度、预计持续 2-5 轮的自由战斗（GM 已明确请求临时遭遇）。"
+            "敌人只能使用战斗引擎完整支持的简单模型：移动、普通攻击、闪避、结束回合；"
+            "不要生成法术、传奇动作、巢穴动作、复杂被动或新机制。"
+            "不要生成明显能秒杀整个队伍的敌人，也不要使用当前队伍等级明显无法处理的极端数值。"
+            "所有数值必须落在给定范围内，伤害必须是骰子表达式，id 必须唯一。"
+            "只返回工具调用，不要输出额外文本。"
+        )
+    return (
+        "You are the D&D 2024 temporary encounter generator. Based on the current fiction, "
+        "adventure step, opposition, and party, propose one normal-difficulty free encounter "
+        "expected to last 2-5 rounds (the GM explicitly requested a temporary encounter). Enemies "
+        "must be simple stat blocks the combat engine fully supports: move, attack, dodge, end "
+        "turn — no spells, legendary actions, lair actions, complex passives, or new mechanics. "
+        "Never generate enemies that can obviously wipe the party, and avoid extreme values the "
+        "party's level cannot handle. Keep every value inside the given ranges, write damage as "
+        "dice expressions, and make ids unique. Return only the tool call."
+    )
+
+
+def _generation_context(instance: Any, campaign: dict[str, Any]) -> dict[str, Any]:
+    """生成输入只包含与当前敌情直接相关的信息，不携带整段冒险历史。"""
+
+    players = getattr(instance, "players", {}) or {}
+    members: list[dict[str, Any]] = []
+    for uid, player in players.items():
+        sheet = player.get("character_sheet") if isinstance(player, dict) else {}
+        sheet = sheet if isinstance(sheet, dict) else {}
+        profile = sheet.get("ruleset_character")
+        profile = profile if isinstance(profile, dict) else sheet
+        member = {
+            "name": str(profile.get("character_name") or sheet.get("character_name") or uid)[:60],
+            "class": str(profile.get("class") or profile.get("class_name") or "")[:40],
+            "level": profile.get("level"),
+            "hp": profile.get("hp"),
+            "max_hp": profile.get("max_hp"),
+            "armor_class": profile.get("armor_class"),
+        }
+        members.append({key: value for key, value in member.items() if value not in (None, "")})
+    tutorial = campaign.get("tutorial") if isinstance(campaign, dict) else None
+    tutorial = tutorial if isinstance(tutorial, dict) else {}
+    step = tutorial.get("current_step") if isinstance(tutorial.get("current_step"), dict) else {}
+    request = campaign.get("encounter_request")
+    request = request if isinstance(request, dict) else {}
+    adventure = None
+    if tutorial.get("status") == "active":
+        adventure = {
+            "id": str(tutorial.get("adventure_id") or "")[:80],
+            "step_id": str(step.get("id") or "")[:80],
+            "title": str(step.get("title") or "")[:200],
+            "narration": str(step.get("narration") or step.get("objective") or "")[:600],
+        }
+    return {
+        "scene": str(getattr(instance, "scene", "") or "")[:500],
+        "recent_narration": [
+            str(item.get("gm_response") or "")[:800]
+            for item in (getattr(instance, "log", []) or [])[-2:]
+            if isinstance(item, dict) and item.get("gm_response")
+        ],
+        "adventure": adventure,
+        "encounter_request": {
+            "status": str(request.get("status") or ""),
+            "reason": str(request.get("reason") or "")[:300],
+        },
+        "party": {"size": len(members), "members": members},
+    }
+
+
+def _coerce_bounded_int(
+    value: Any, field_name: str, bounds: tuple[int, int], default: int | None = None,
+) -> int:
+    minimum, maximum = bounds
+    if value is None:
+        if default is None:
+            raise ValueError(f"敌人 {field_name} 数值无效")
+        value = default
+    if isinstance(value, bool):
+        raise ValueError(f"敌人 {field_name} 数值无效")
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"敌人 {field_name} 必须是整数") from None
+    if not minimum <= number <= maximum:
+        raise ValueError(
+            f"敌人 {field_name} 超出临时生成允许范围（{minimum}-{maximum}）",
+        )
+    return number
+
+
+def _slug(value: str, fallback_index: int) -> str:
+    slug = _ID_SANITIZE.sub("_", str(value or "").strip().casefold()).strip("_")[:48]
+    if not slug or not re.match(r"[a-z0-9]", slug[0]):
+        slug = f"enemy_{fallback_index + 1}"
+    return slug
+
+
+def _assign_unique_ids(enemies: list[dict[str, Any]]) -> None:
+    """同名敌人由服务端派生唯一 id（wolf / wolf_2 / wolf_3…）。"""
+
+    seen: set[str] = set()
+    for index, enemy in enumerate(enemies):
+        base = _slug(str(enemy.get("name") or ""), index)
+        candidate, suffix = base, 2
+        while candidate in seen:
+            candidate = f"{base}_{suffix}"
+            suffix += 1
+        enemy["id"] = candidate
+        seen.add(candidate)
+    for enemy in enemies:
+        attack_seen: set[str] = set()
+        for attack_index, attack in enumerate(enemy["attacks"]):
+            base = _slug(str(attack.get("name") or ""), attack_index)
+            candidate, suffix = base, 2
+            while candidate in attack_seen:
+                candidate = f"{base}_{suffix}"
+                suffix += 1
+            attack["id"] = candidate
+            attack_seen.add(candidate)
+
+
+def normalize_temporary_encounter(payload: Any) -> dict[str, Any]:
+    """把模型输出收敛成合法敌人档案；非法输入抛 ValueError，绝不放行。"""
+
+    if not isinstance(payload, dict):
+        raise ValueError("AI 临时遭遇结构无效")
+    raw_enemies = payload.get("enemies")
+    if not isinstance(raw_enemies, list) or not 1 <= len(raw_enemies) <= MAX_TEMPORARY_ENEMIES:
+        raise ValueError(f"临时遭遇需要 1 到 {MAX_TEMPORARY_ENEMIES} 个敌人")
+    enemies: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_enemies):
+        if not isinstance(raw, dict):
+            raise ValueError("敌人数据无效")
+        name = str(raw.get("name") or "").strip()[:60] or f"敌人{index + 1}"
+        enemy: dict[str, Any] = {"id": "", "name": name}
+        for field_name, bounds in _ENEMY_FIELD_BOUNDS.items():
+            enemy[field_name] = _coerce_bounded_int(
+                raw.get(field_name), field_name, bounds,
+                _ENEMY_FIELD_DEFAULTS.get(field_name),
+            )
+        raw_attacks = raw.get("attacks")
+        if not isinstance(raw_attacks, list) or not 1 <= len(raw_attacks) <= 3:
+            raise ValueError(f"敌人 {name} 需要 1 到 3 个攻击")
+        attacks: list[dict[str, Any]] = []
+        for attack_index, raw_attack in enumerate(raw_attacks):
+            if not isinstance(raw_attack, dict):
+                raise ValueError(f"敌人 {name} 的攻击数据无效")
+            attack = {
+                "id": "",
+                "name": str(raw_attack.get("name") or "").strip()[:60] or f"攻击{attack_index + 1}",
+                "attack_bonus": _coerce_bounded_int(
+                    raw_attack.get("attack_bonus"), "attack_bonus",
+                    _ATTACK_FIELD_BOUNDS["attack_bonus"],
+                ),
+                "damage": str(raw_attack.get("damage") or "").strip()[:40],
+                "range": _coerce_bounded_int(
+                    raw_attack.get("range"), "range",
+                    _ATTACK_FIELD_BOUNDS["range"], _ATTACK_FIELD_DEFAULTS["range"],
+                ),
+            }
+            attack["long_range"] = _coerce_bounded_int(
+                raw_attack.get("long_range"), "long_range",
+                _ATTACK_FIELD_BOUNDS["long_range"], attack["range"],
+            )
+            if attack["long_range"] < attack["range"]:
+                attack["long_range"] = attack["range"]
+            attacks.append(attack)
+        enemy["attacks"] = attacks
+        enemies.append(enemy)
+    _assign_unique_ids(enemies)
+    # 与 combat.start / preset loading 完全同一份底层安全边界。
+    validate_enemy_profiles(enemies)
+    title = str(payload.get("title") or "").strip()[:80]
+    if not title:
+        title = f"{enemies[0]['name']} ×{len(enemies)}"
+    description = str(payload.get("description") or "").strip()[:300]
+    return {"title": title, "description": description, "enemies": enemies}
+
+
+async def plan_temporary_encounter(
+    instance: Any, campaign: dict[str, Any], llm_client: Any,
+) -> dict[str, Any]:
+    """生成一场临时遭遇提案；输出只是 proposal，不落任何权威状态。"""
+
+    if not llm_client or not hasattr(llm_client, "call_tools"):
+        raise ValueError("未配置可用的 AI 服务商")
+    language = str(getattr(instance, "language", "") or "")
+    context = json.dumps(
+        _generation_context(instance, campaign),
+        ensure_ascii=False, separators=(",", ":"),
+    )
+    response = await llm_client.call_tools(
+        _temporary_prompt(language),
+        context,
+        tools=[TEMPORARY_ENCOUNTER_TOOL],
+        max_tokens=2048,
+        temperature=0.2,
+    )
+    instance.record_llm_usage(int(getattr(response, "total_tokens", 0) or 0))
+    for call in getattr(response, "tool_calls", []) or []:
+        if str(call.get("name") or "") != TEMPORARY_ENCOUNTER_TOOL_NAME:
+            continue
+        arguments = call.get("arguments") if isinstance(call.get("arguments"), dict) else {}
+        proposal = normalize_temporary_encounter(arguments)
+        proposal["planner"] = {
+            "provider": str(getattr(response, "provider_used", "") or ""),
+            "native_tools": bool(getattr(response, "native_tools", False)),
+        }
+        return proposal
+    raise ValueError("AI 没有返回有效的临时遭遇结构")

--- a/src/rulesets/dnd2024/runtime.py
+++ b/src/rulesets/dnd2024/runtime.py
@@ -22,6 +22,7 @@ from src.rulesets.dnd2024.director.planner import (
     plan_adventure_choice,
     plan_encounter_preset,
 )
+from src.rulesets.dnd2024.director.temporary_encounter import plan_temporary_encounter
 from src.rulesets.dnd2024.play import (
     EncounterAccess,
     is_public_story_milestone,
@@ -953,6 +954,20 @@ class Dnd2024Runtime:
         locale = str(getattr(instance, "language", "") or "")
         presets = self._combat_engine(instance, access, locale).encounter_presets()
         return await plan_encounter_preset(instance, proposal, presets, llm_client)
+
+    async def plan_temporary_encounter(
+        self, instance: Any, llm_client: Any,
+    ) -> dict[str, Any] | None:
+        """AI 临时遭遇提案：只读生成，不落任何权威状态。
+
+        GM 确认后提交现有 ``combat.start``（mode=sandbox），服务端权威校验
+        仍然完整生效。剧情已绑定正式遭遇时不提供这条兜底路径。
+        """
+
+        campaign = self._campaign_engine(
+            instance, str(getattr(instance, "language", "") or ""),
+        ).gameplay_view(instance)
+        return await plan_temporary_encounter(instance, campaign, llm_client)
 
     def filter_narrative_state_update(
         self, instance: Any, update: dict[str, Any],

--- a/src/webui/api.py
+++ b/src/webui/api.py
@@ -483,6 +483,7 @@ class WebAPI:
                 apply_memory_delta=(
                     self._mem.apply_delta if self._mem is not None else None
                 ),
+                resolve_llm_client=lambda: self._llm_client,
             )
         )
         self._turn_dependencies = turns.TurnDependencies(
@@ -1895,6 +1896,16 @@ class WebAPI:
             requester_id,
             requester_is_gm,
             body,
+        )
+
+    async def ruleset_plan_temporary_encounter(
+        self, game_key: str, requester_id: str, requester_is_gm: bool,
+    ) -> dict[str, Any]:
+        return await ruleset_gameplay.plan_temporary_encounter(
+            self._ruleset_gameplay_dependencies,
+            game_key,
+            requester_id,
+            requester_is_gm,
         )
 
     # ---- 世界模板 ----

--- a/src/webui/routes/game_gameplay_routes.py
+++ b/src/webui/routes/game_gameplay_routes.py
@@ -175,7 +175,7 @@ def _ruleset_gameplay_status(result: dict) -> int:
     code = str(result.get("code") or "")
     if code in {"GAME_NOT_FOUND", "RULE_NOT_FOUND"}:
         return 404
-    if code in {"AUTH_REQUIRED", "PLAYER_NOT_IN_GAME"}:
+    if code in {"AUTH_REQUIRED", "PLAYER_NOT_IN_GAME", "GM_ONLY"}:
         return 403
     if code in {"RULESET_INTENTS_UNAVAILABLE", "RULESET_RUNTIME_UNAVAILABLE"}:
         return 409
@@ -205,6 +205,21 @@ async def api_ruleset_available_actions(request: web.Request) -> web.Response:
     requester_id = str(request.get("user_id", "") or "")
     requester_is_gm = _ruleset_requester_is_gm(request, inst)
     result = await api.ruleset_available_actions(
+        game_key,
+        requester_id,
+        requester_is_gm,
+    )
+    return web.json_response(result, status=_ruleset_gameplay_status(result))
+
+
+async def api_ruleset_temporary_encounter(request: web.Request) -> web.Response:
+    """GM-only AI 临时遭遇提案：只读生成，不改任何游戏状态。"""
+    api = _get_api(request)
+    game_key = request.match_info["game_key"]
+    inst = api.get_game_instance(game_key)
+    requester_id = str(request.get("user_id", "") or "")
+    requester_is_gm = _ruleset_requester_is_gm(request, inst)
+    result = await api.ruleset_plan_temporary_encounter(
         game_key,
         requester_id,
         requester_is_gm,

--- a/src/webui/routes/games.py
+++ b/src/webui/routes/games.py
@@ -50,6 +50,7 @@ from src.webui.routes.game_gameplay_routes import (
     _ruleset_gameplay_status,
     _ruleset_requester_is_gm,
     api_ruleset_available_actions,
+    api_ruleset_temporary_encounter,
     api_combat_action,
     api_combat_scheduler_advance,
     api_ruleset_submit_intent,
@@ -140,6 +141,10 @@ def register_games(app: web.Application) -> None:
         "/api/games/{game_key}/available-actions", api_ruleset_available_actions
     )
     app.router.add_post("/api/games/{game_key}/intents", api_ruleset_submit_intent)
+    app.router.add_post(
+        "/api/games/{game_key}/ruleset/temporary-encounter",
+        api_ruleset_temporary_encounter,
+    )
     app.router.add_post("/api/games/{game_key}/combat/action", api_combat_action)
     app.router.add_post("/api/games/{game_key}/combat/scheduler/advance", api_combat_scheduler_advance)
     app.router.add_post(

--- a/src/webui/services/ruleset_gameplay.py
+++ b/src/webui/services/ruleset_gameplay.py
@@ -229,13 +229,33 @@ async def plan_temporary_encounter(
         view = runtime.gameplay_view(instance, effective_requester, True)
         access = view.get("encounter_access") if isinstance(view, dict) else None
         combat = view.get("combat") if isinstance(view, dict) else None
+        request = view.get("encounter_request") if isinstance(view, dict) else None
         if isinstance(combat, dict) and combat.get("status") == "active":
             return _error("COMBAT_ACTIVE", "战斗进行中，无法生成临时遭遇")
+        if (
+            not isinstance(request, dict)
+            or str(request.get("status") or "") != "pending"
+        ):
+            return _error(
+                "NO_PENDING_ENCOUNTER",
+                "当前没有待准备的敌情，不能生成临时遭遇",
+            )
         if not isinstance(access, dict) or str(access.get("mode") or "") == "story":
             # 正式剧情遭遇永远优先：有绑定 preset 时绝不能用临时生成绕过。
             return _error(
                 "STORY_ENCOUNTER_BOUND",
                 "当前剧情已绑定正式遭遇，不能覆盖为临时遭遇",
+            )
+        requested_preset_id = str(request.get("encounter_preset_id") or "")
+        available_preset_ids = {
+            str(item.get("id") or "")
+            for item in (view.get("encounter_presets") or [])
+            if isinstance(item, dict)
+        }
+        if requested_preset_id and requested_preset_id in available_preset_ids:
+            return _error(
+                "ENCOUNTER_ALREADY_PREPARED",
+                "当前敌情已经匹配到合法遭遇，无需生成临时遭遇",
             )
     llm_client = (
         dependencies.resolve_llm_client() if dependencies.resolve_llm_client else None

--- a/src/webui/services/ruleset_gameplay.py
+++ b/src/webui/services/ruleset_gameplay.py
@@ -16,6 +16,7 @@ from src.rulesets.contracts import (
     AuthoritativeIntentHooks,
     AutomaticIntentRuntime,
     PublicTimelineProjectionRuntime,
+    TemporaryEncounterPlannerRuntime,
 )
 from src.rulesets.registry import RulesetRuntimeRegistry
 
@@ -32,6 +33,8 @@ class RulesetGameplayDependencies:
     resolve_adventure_binding: Callable[[str, Any, str, str], dict[str, Any]]
     save_instance: Callable[[Any], Awaitable[None]]
     apply_memory_delta: Callable[[str, dict[str, Any], int], Awaitable[Any]] | None
+    # AI 临时遭遇等只读 LLM 提案使用；None 表示环境没有可用的 AI 服务商。
+    resolve_llm_client: Callable[[], Any | None] | None = None
 
 
 def _error(code: str, message: str) -> dict[str, Any]:
@@ -191,6 +194,70 @@ async def _ensure_compatible_adventure_binding(
         await dependencies.save_instance(instance)
     return None
 
+
+
+async def plan_temporary_encounter(
+    dependencies: RulesetGameplayDependencies,
+    game_key: str,
+    requester_id: str,
+    requester_is_gm: bool = False,
+) -> dict[str, Any]:
+    """AI 临时遭遇提案（GM-only，只读）：生成 → GM 预览 → 确认后才 combat.start。
+
+    本函数不改 combat、不加 state version、不写 EventBatch / adventure /
+    encounter catalog；生成失败完全无副作用。
+    """
+
+    instance, rule, runtime, effective_requester, error = _context(
+        dependencies, game_key, requester_id, requester_is_gm,
+    )
+    if error:
+        return error
+    if not requester_is_gm:
+        return _error("GM_ONLY", "只有 GM 可以生成临时遭遇")
+    if not isinstance(runtime, TemporaryEncounterPlannerRuntime):
+        return _error(
+            "TEMPORARY_ENCOUNTER_UNAVAILABLE",
+            "当前规则不支持 AI 临时遭遇",
+        )
+    async with instance._lock:
+        binding_error = await _ensure_compatible_adventure_binding(
+            dependencies, runtime, instance,
+        )
+        if binding_error:
+            return binding_error
+        view = runtime.gameplay_view(instance, effective_requester, True)
+        access = view.get("encounter_access") if isinstance(view, dict) else None
+        combat = view.get("combat") if isinstance(view, dict) else None
+        if isinstance(combat, dict) and combat.get("status") == "active":
+            return _error("COMBAT_ACTIVE", "战斗进行中，无法生成临时遭遇")
+        if not isinstance(access, dict) or str(access.get("mode") or "") == "story":
+            # 正式剧情遭遇永远优先：有绑定 preset 时绝不能用临时生成绕过。
+            return _error(
+                "STORY_ENCOUNTER_BOUND",
+                "当前剧情已绑定正式遭遇，不能覆盖为临时遭遇",
+            )
+    llm_client = (
+        dependencies.resolve_llm_client() if dependencies.resolve_llm_client else None
+    )
+    if llm_client is None:
+        return _error("LLM_NOT_CONFIGURED", "未配置可用的 AI 服务商")
+    try:
+        proposal = await runtime.plan_temporary_encounter(instance, llm_client)
+    except ValueError as exc:
+        return _error("TEMPORARY_ENCOUNTER_INVALID", str(exc))
+    except Exception:
+        logger.exception("AI temporary encounter planning failed")
+        return _error(
+            "LLM_REQUEST_FAILED",
+            "AI 生成临时遭遇失败，你仍可以手动选择自由遭遇",
+        )
+    if not isinstance(proposal, dict):
+        return _error(
+            "TEMPORARY_ENCOUNTER_INVALID",
+            "无法生成合法的临时遭遇，你仍可以手动选择自由遭遇",
+        )
+    return {"ok": True, "encounter": proposal}
 
 
 async def available_actions(

--- a/tests/test_dnd2024_temporary_encounter.py
+++ b/tests/test_dnd2024_temporary_encounter.py
@@ -1,0 +1,370 @@
+"""D&D 2024 AI 临时遭遇兜底回归测试。
+
+覆盖：GM 生成（无副作用）、玩家 403、剧情遭遇不可覆盖、AI 非法怪物拒绝、
+确认走现有 combat.start(mode=sandbox)、篡改 preview 被权威校验拒绝、
+LLM 失败无副作用、Adventure 绑定保持。核心原则：AI 提案、GM 确认、
+Combat Engine 权威结算。
+"""
+
+from __future__ import annotations
+
+import copy
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from src.commands.round_effects import apply_ruleset_combat_signal
+from src.engine.game_instance import GameInstance
+from src.rules.rule_system import RuleSystem
+from src.rulesets.dnd2024.combat.validation import validate_enemy_profiles
+from src.rulesets.dnd2024.director.temporary_encounter import (
+    TEMPORARY_ENCOUNTER_TOOL_NAME,
+    normalize_temporary_encounter,
+    plan_temporary_encounter,
+)
+from src.rulesets.dnd2024.runtime import Dnd2024Runtime
+from src.rulesets.legacy_adapter import LegacyRulesetAdapter
+from src.rulesets.registry import RulesetRuntimeRegistry
+from src.webui.services import ruleset_gameplay
+
+_RULE = RuleSystem({
+    "rule_id": "test_dnd2024",
+    "runtime": {"id": "core:dnd2024", "minimum_version": 1},
+})
+
+# 模拟模型输出：id 交给服务端归一化（同名 → 唯一 id）。
+_WOLF_RAW = {
+    "title": "腐化狼群",
+    "description": "两只被黑色孢子侵蚀的狼从废墟后冲出。",
+    "enemies": [
+        {
+            "name": "Corrupted Wolf", "hp": 11, "armor_class": 13,
+            "speed": 40, "position": 25, "initiative_modifier": 2,
+            "attacks": [{"name": "bite", "attack_bonus": 4, "damage": "1d6+2", "range": 5}],
+        },
+        {
+            "name": "Corrupted Wolf", "hp": 11, "armor_class": 13,
+            "speed": 40, "position": 30,
+            "attacks": [{"name": "bite", "attack_bonus": 4, "damage": "1d6+2", "range": 5}],
+        },
+    ],
+}
+
+
+class _FakeLLM:
+    def __init__(self, arguments=None, error=None, *, tool_name=TEMPORARY_ENCOUNTER_TOOL_NAME):
+        self.arguments = arguments
+        self.error = error
+        self.tool_name = tool_name
+
+    async def call_tools(self, *args, **kwargs):
+        if self.error is not None:
+            raise self.error
+        tool_calls = (
+            [{"name": self.tool_name, "arguments": self.arguments}]
+            if self.arguments is not None else []
+        )
+        return SimpleNamespace(
+            tool_calls=tool_calls, total_tokens=9,
+            provider_used="test", native_tools=True,
+        )
+
+
+class _SaveRegistry:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, ...], GameInstance] = {}
+
+    def get(self, key):
+        return self.items.get(tuple(key))
+
+    async def save(self, instance) -> None:
+        self.items[tuple(instance.game_key)] = instance
+
+
+def _character(runtime: Dnd2024Runtime, preset_id: str, name: str) -> dict:
+    choices = runtime.builder_choices(None, {"locale": "en"})
+    preset = next(item for item in choices["quick_presets"] if item["id"] == preset_id)
+    return runtime.finalize_character(
+        None, {**preset["draft"], "locale": "en", "name": name},
+    )
+
+
+def _runtime_instance(
+    *, adventure: bool = False, walk_to_combat: bool = False,
+) -> tuple[Dnd2024Runtime, GameInstance]:
+    runtime = Dnd2024Runtime()
+    instance = GameInstance(
+        game_key=("test", "temp-encounter", "bot"),
+        world_id="greymoor" if adventure else "default_fantasy",
+        rule_id="dnd2024_srd", gm_uid="gm", language="en",
+    )
+    gm = _character(runtime, "stalwart_guardian", "Arden")
+    instance.players["gm"] = {"character_name": "Arden", "character_sheet": gm}
+    ally = _character(runtime, "curious_arcanist", "Mira")
+    instance.players["ally"] = {"character_name": "Mira", "character_sheet": ally}
+    assert instance.bind_ruleset_runtime(gm["rule_binding"])
+    if adventure:
+        package = runtime._adventure_loader.resolve("core:lanterns_of_greymoor", "en")
+        assert instance.bind_adventure(package.binding("greymoor"))
+    if walk_to_combat:
+        instance.solo_mode = True
+        # quick_start 已直接进入教学第一步；只需连续推进到绑定遭遇的节点。
+        _submit(runtime, instance, "session_zero.quick_start")
+        for choice in ("inspect_cold_ash", "reassure_mira", "follow_small_tracks"):
+            _submit(runtime, instance, "tutorial.choose", choice_id=choice)
+    return runtime, instance
+
+
+def _submit(
+    runtime: Dnd2024Runtime, instance: GameInstance, intent_type: str,
+    submitted_by: str = "gm", **fields,
+) -> dict:
+    version = int(instance.ruleset_state.get("version", 0) or 0)
+    intent = {
+        "intent_id": f"intent-{intent_type}-{version}",
+        "type": intent_type,
+        "expected_version": version,
+        "submitted_by": submitted_by,
+        **fields,
+    }
+    resolved = runtime.resolve_intent(instance, intent, random.Random(7))
+    assert resolved["ok"] is True, resolved
+    applied = runtime.apply_event_batch(instance, resolved["event_batch"])
+    assert applied["applied"] is True
+    return resolved
+
+
+def _dependencies(
+    runtime: Dnd2024Runtime,
+    registry: _SaveRegistry,
+    instance: GameInstance,
+    llm_client=None,
+) -> ruleset_gameplay.RulesetGameplayDependencies:
+    return ruleset_gameplay.RulesetGameplayDependencies(
+        get_instance=registry.get,
+        parse_game_key=lambda key: tuple(key.split("|")),
+        load_rule_for_game=lambda inst: _RULE,
+        ruleset_registry=RulesetRuntimeRegistry([LegacyRulesetAdapter(), runtime]),
+        resolve_adventure_binding=lambda adventure_id, rt, world_id, language: dict(
+            instance.adventure_binding or {},
+        ),
+        save_instance=registry.save,
+        apply_memory_delta=None,
+        resolve_llm_client=lambda: llm_client,
+    )
+
+
+def _state_fingerprint(instance: GameInstance) -> tuple:
+    return (
+        copy.deepcopy(instance.ruleset_state),
+        copy.deepcopy(instance.event_ledger),
+        instance.combat_active,
+        instance.combat_state,
+        instance.round_number,
+    )
+
+
+# ---- normalize / 公共校验 ----
+
+
+def test_normalize_dedupes_ids_and_fills_defaults() -> None:
+    proposal = normalize_temporary_encounter(copy.deepcopy(_WOLF_RAW))
+    assert [enemy["id"] for enemy in proposal["enemies"]] == ["corrupted_wolf", "corrupted_wolf_2"]
+    first = proposal["enemies"][0]
+    assert first["attacks"][0]["id"] == "bite"
+    assert first["attacks"][0]["range"] == 5 and first["attacks"][0]["long_range"] == 5
+    second = proposal["enemies"][1]
+    assert second["position"] == 30 and second["initiative_modifier"] == 0
+    assert proposal["title"] == "腐化狼群"
+
+
+def test_normalize_rejects_out_of_range_and_non_dice_damage() -> None:
+    def enemy(**overrides):
+        base = {
+            "name": "wolf", "hp": 11, "armor_class": 13,
+            "attacks": [{"name": "bite", "attack_bonus": 4, "damage": "1d6+2"}],
+        }
+        base.update(overrides)
+        return base
+
+    with pytest.raises(ValueError):
+        normalize_temporary_encounter({"enemies": [enemy(armor_class=999)]})
+    with pytest.raises(ValueError):
+        normalize_temporary_encounter({"enemies": [enemy(hp=0)]})
+    with pytest.raises(ValueError):
+        normalize_temporary_encounter({
+            "enemies": [enemy(attacks=[{"name": "bite", "attack_bonus": 4, "damage": "造成大量伤害"}])],
+        })
+    with pytest.raises(ValueError):
+        normalize_temporary_encounter({"enemies": [enemy() for _ in range(13)]})
+    # 底层安全边界与 combat.start 完全同一份实现。
+    validate_enemy_profiles(
+        normalize_temporary_encounter({"enemies": [enemy()]})["enemies"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_requires_tool_call_and_validates_output() -> None:
+    instance = SimpleNamespace(
+        players={"p1": {}}, scene="矿井深处", language="en", log=[],
+        record_llm_usage=lambda tokens: None,
+    )
+    proposal = await plan_temporary_encounter(
+        instance, {}, _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW)),
+    )
+    assert proposal["title"] == "腐化狼群"
+    assert proposal["planner"]["provider"] == "test"
+
+    with pytest.raises(ValueError):
+        await plan_temporary_encounter(instance, {}, _FakeLLM(arguments=None))
+    with pytest.raises(ValueError):
+        await plan_temporary_encounter(
+            instance, {},
+            _FakeLLM(arguments={"enemies": [{"name": "x", "hp": 1, "armor_class": 999,
+                                             "attacks": [{"name": "a", "attack_bonus": 1, "damage": "1d4"}]}]}),
+        )
+    with pytest.raises(RuntimeError):
+        await plan_temporary_encounter(instance, {}, _FakeLLM(error=RuntimeError("llm timeout")))
+
+
+# ---- service：权限 / 覆盖拒绝 / 无副作用 / 失败 ----
+
+
+@pytest.mark.asyncio
+async def test_gm_can_plan_and_generation_has_no_side_effects() -> None:
+    runtime, instance = _runtime_instance(adventure=True)
+    instance.solo_mode = True
+    _submit(runtime, instance, "session_zero.quick_start")
+    apply_ruleset_combat_signal(instance, {"combat_command": "start"}, runtime)
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    binding_before = copy.deepcopy(instance.adventure_binding)
+    # 预热读取路径：campaign 状态在首次 gameplay_view 时惰性物化，与生成无关。
+    runtime.gameplay_view(instance, "gm", True)
+    fingerprint_before = _state_fingerprint(instance)
+
+    deps = _dependencies(runtime, registry, instance, _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW)))
+    result = await ruleset_gameplay.plan_temporary_encounter(
+        deps, "test|temp-encounter|bot", "gm", True,
+    )
+
+    assert result["ok"] is True
+    encounter = result["encounter"]
+    assert encounter["title"] == "腐化狼群"
+    assert len(encounter["enemies"]) == 2
+    # 只读：combat、state version、event ledger、round 全部不变。
+    assert _state_fingerprint(instance) == fingerprint_before
+    # Adventure 绑定保持，冒险包零修改。
+    assert instance.adventure_binding == binding_before
+
+
+@pytest.mark.asyncio
+async def test_player_cannot_plan_temporary_encounter() -> None:
+    runtime, instance = _runtime_instance()
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    deps = _dependencies(runtime, registry, instance, _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW)))
+
+    result = await ruleset_gameplay.plan_temporary_encounter(
+        deps, "test|temp-encounter|bot", "ally", False,
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "GM_ONLY"
+
+
+@pytest.mark.asyncio
+async def test_story_encounter_cannot_be_overridden() -> None:
+    runtime, instance = _runtime_instance(adventure=True, walk_to_combat=True)
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    deps = _dependencies(runtime, registry, instance, _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW)))
+
+    result = await ruleset_gameplay.plan_temporary_encounter(
+        deps, "test|temp-encounter|bot", "gm", True,
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "STORY_ENCOUNTER_BOUND"
+
+
+@pytest.mark.asyncio
+async def test_illegal_ai_output_and_llm_failure_are_side_effect_free() -> None:
+    runtime, instance = _runtime_instance()
+    apply_ruleset_combat_signal(instance, {"combat_command": "start"}, runtime)
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    # 预热读取路径：campaign 状态在首次 gameplay_view 时惰性物化，与生成无关。
+    runtime.gameplay_view(instance, "gm", True)
+    fingerprint_before = _state_fingerprint(instance)
+    game_key = "test|temp-encounter|bot"
+
+    illegal = copy.deepcopy(_WOLF_RAW)
+    illegal["enemies"][0]["armor_class"] = 999
+    bad = await ruleset_gameplay.plan_temporary_encounter(
+        _dependencies(runtime, registry, instance, _FakeLLM(arguments=illegal)),
+        game_key, "gm", True,
+    )
+    assert bad["ok"] is False and bad["code"] == "TEMPORARY_ENCOUNTER_INVALID"
+
+    failed = await ruleset_gameplay.plan_temporary_encounter(
+        _dependencies(runtime, registry, instance, _FakeLLM(error=RuntimeError("timeout"))),
+        game_key, "gm", True,
+    )
+    assert failed["ok"] is False and failed["code"] == "LLM_REQUEST_FAILED"
+
+    unconfigured = await ruleset_gameplay.plan_temporary_encounter(
+        _dependencies(runtime, registry, instance, None),
+        game_key, "gm", True,
+    )
+    assert unconfigured["ok"] is False and unconfigured["code"] == "LLM_NOT_CONFIGURED"
+
+    assert _state_fingerprint(instance) == fingerprint_before
+    assert instance.ruleset_state.get("combat", {}).get("status") != "active"
+
+
+# ---- GM 确认：现有 combat.start（mode=sandbox） ----
+
+
+def test_gm_confirm_starts_existing_sandbox_combat() -> None:
+    runtime, instance = _runtime_instance()
+    apply_ruleset_combat_signal(instance, {"combat_command": "start"}, runtime)
+    proposal = normalize_temporary_encounter(copy.deepcopy(_WOLF_RAW))
+
+    _submit(runtime, instance, "combat.start", mode="sandbox", enemies=proposal["enemies"])
+
+    view = runtime.gameplay_view(instance, "gm", True)
+    assert view["combat"]["status"] == "active"
+    assert {actor["name"] for actor in view["combat"]["actors"] if actor["kind"] == "enemy"} == {
+        "Corrupted Wolf",
+    }
+
+
+def test_tampered_preview_enemies_are_rejected_by_authority() -> None:
+    runtime, instance = _runtime_instance()
+    apply_ruleset_combat_signal(instance, {"combat_command": "start"}, runtime)
+    enemies = normalize_temporary_encounter(copy.deepcopy(_WOLF_RAW))["enemies"]
+    enemies[0]["hp"] = 999999999
+    version = int(instance.ruleset_state.get("version", 0) or 0)
+
+    resolved = runtime.resolve_intent(instance, {
+        "intent_id": "tampered", "type": "combat.start",
+        "expected_version": version, "submitted_by": "gm",
+        "mode": "sandbox", "enemies": enemies,
+    }, random.Random(7))
+
+    assert resolved["ok"] is False
+    assert instance.ruleset_state.get("combat", {}).get("status") != "active"
+
+
+def test_adventure_binding_survives_temporary_combat() -> None:
+    runtime, instance = _runtime_instance(adventure=True)
+    binding_before = copy.deepcopy(instance.adventure_binding)
+    proposal = normalize_temporary_encounter(copy.deepcopy(_WOLF_RAW))
+
+    _submit(runtime, instance, "combat.start", mode="sandbox", enemies=proposal["enemies"])
+
+    view = runtime.gameplay_view(instance, "gm", True)
+    assert view["combat"]["status"] == "active"
+    assert instance.adventure_binding == binding_before

--- a/tests/test_dnd2024_temporary_encounter.py
+++ b/tests/test_dnd2024_temporary_encounter.py
@@ -9,6 +9,7 @@ Combat Engine 权威结算。
 from __future__ import annotations
 
 import copy
+import json
 import random
 from types import SimpleNamespace
 
@@ -57,8 +58,10 @@ class _FakeLLM:
         self.arguments = arguments
         self.error = error
         self.tool_name = tool_name
+        self.calls = []
 
     async def call_tools(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
         if self.error is not None:
             raise self.error
         tool_calls = (
@@ -228,6 +231,29 @@ async def test_plan_requires_tool_call_and_validates_output() -> None:
         await plan_temporary_encounter(instance, {}, _FakeLLM(error=RuntimeError("llm timeout")))
 
 
+@pytest.mark.asyncio
+async def test_generation_context_reads_dnd2024_canonical_party_fields() -> None:
+    runtime, instance = _runtime_instance()
+    llm = _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW))
+
+    await plan_temporary_encounter(instance, {}, llm)
+
+    assert len(llm.calls) == 1
+    context = json.loads(llm.calls[0][0][1])
+    members = context["party"]["members"]
+    by_name = {member["name"]: member for member in members}
+    canonical = instance.players["gm"]["character_sheet"]["ruleset_character"]
+    first_class = canonical["build"]["class_levels"][0]
+    assert by_name[canonical["identity"]["name"]] == {
+        "name": canonical["identity"]["name"],
+        "class": first_class["class_ref"],
+        "level": canonical["build"]["level"],
+        "hp": canonical["resources"]["hp"],
+        "max_hp": canonical["resources"]["max_hp"],
+        "armor_class": canonical["derived"]["armor_class"],
+    }
+
+
 # ---- service：权限 / 覆盖拒绝 / 无副作用 / 失败 ----
 
 
@@ -275,8 +301,48 @@ async def test_player_cannot_plan_temporary_encounter() -> None:
 
 
 @pytest.mark.asyncio
+async def test_no_pending_encounter_rejects_without_calling_llm() -> None:
+    runtime, instance = _runtime_instance()
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    llm = _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW))
+    deps = _dependencies(runtime, registry, instance, llm)
+
+    result = await ruleset_gameplay.plan_temporary_encounter(
+        deps, "test|temp-encounter|bot", "gm", True,
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "NO_PENDING_ENCOUNTER"
+    assert llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_existing_legal_preset_rejects_without_calling_llm() -> None:
+    runtime, instance = _runtime_instance()
+    apply_ruleset_combat_signal(instance, {"combat_command": "start"}, runtime)
+    preset_id = runtime._combat_engine(instance).encounter_presets()[0]["id"]
+    instance.ruleset_state["encounter_request"]["encounter_preset_id"] = preset_id
+    registry = _SaveRegistry()
+    registry.items[tuple(instance.game_key)] = instance
+    llm = _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW))
+    deps = _dependencies(runtime, registry, instance, llm)
+
+    result = await ruleset_gameplay.plan_temporary_encounter(
+        deps, "test|temp-encounter|bot", "gm", True,
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "ENCOUNTER_ALREADY_PREPARED"
+    assert llm.calls == []
+
+
+@pytest.mark.asyncio
 async def test_story_encounter_cannot_be_overridden() -> None:
     runtime, instance = _runtime_instance(adventure=True, walk_to_combat=True)
+    instance.ruleset_state["encounter_request"] = {
+        "status": "pending", "encounter_preset_id": "first_skirmish",
+    }
     registry = _SaveRegistry()
     registry.items[tuple(instance.game_key)] = instance
     deps = _dependencies(runtime, registry, instance, _FakeLLM(arguments=copy.deepcopy(_WOLF_RAW)))


### PR DESCRIPTION
解决当前断档提示「AI GM 没能把当前敌情匹配到合法遭遇。请由 GM 手动准备一场自由遭遇。」：新增 **AI 临时生成遭遇 → GM 预览确认 → 复用现有 sandbox combat.start** 的兜底路径。

核心原则：**AI 负责"临时提案"，GM 负责"确认"，Combat Engine 负责"权威结算"。** 这不是新的怪物系统。

## 严格范围

只实现 生成 → 确认 → 开战。**不做**：怪物图鉴/收藏、永久注册、修改 Adventure Bundle、写 encounter_catalog、CR 平衡系统、怪物编辑器、AI 自动开战、绕过 GM 确认、`combat.start_temp` 等新战斗路径、新战斗规则。临时生成结果只服务于当前这一场战斗。

## 后端

- **公共校验（不复制 validation）**：`combat/validation.py` 的敌人校验提取为模块级 `validate_enemy_profiles()`，`combat.start`、encounter preset loading、临时生成三条路径共用同一份安全边界。
- **生成器**（`src/rulesets/dnd2024/director/temporary_encounter.py`，复用 Director 的 LLM call_tools 模式，不进 combat engine/reducer）：
  - 强制结构化输出（function tool `dnd2024_temporary_encounter`）：title/description/enemies（id/name/hp/armor_class/speed/position/initiative_modifier/attacks）；
  - `normalize_temporary_encounter()`：同名敌人服务端派生唯一 id（`corrupted_wolf` / `corrupted_wolf_2`），数值收敛后在收紧范围内额外把关（敌人 1-12、AC 8-25、速度 0-80、单怪攻击 1-3、attack bonus -2..+15），damage 必须骰子表达式，最后仍过 `validate_enemy_profiles()`；
  - 敌人严格限定在当前敌方自动行动能力内：移动 / 普通攻击 / 闪避 / 结束回合 —— 不生成法术、传奇动作、巢穴动作、复杂被动；
  - 生成输入（§七）只含：当前场景、最近两轮 GM 叙事、冒险当前步骤（绑定 Adventure 时）、encounter_request 状态、队伍战斗摘要（人数/职业/等级/HP/AC）；强度指导：普通难度、预计 2-5 轮、不得明显秒杀队伍；
  - Adventure Bundle 只读：只提供剧情上下文，绝不写回。
- **runtime/contracts**：`Dnd2024Runtime.plan_temporary_encounter()` 公共只读方法；`TemporaryEncounterPlannerRuntime` 协议。
- **preview API（无副作用）**：`POST /api/games/{game_key}/ruleset/temporary-encounter`（按现有 ruleset gameplay route 风格落位，GM-only）。不保存 combat、不加 state version、不写 EventBatch、不写 adventure、不写 encounter catalog。战斗进行中 → `COMBAT_ACTIVE`；剧情已绑定正式遭遇（`mode=story`）→ `STORY_ENCOUNTER_BOUND`，**正式剧情遭遇永远优先，绝不能被临时生成覆盖**；LLM 未配置/失败/输出非法 → 结构化错误，完全无副作用。

## 前端（Dnd2024CombatPanel）

- §十九 两个分支加入口：`storyUnprepared` 块与 `sandboxHint`（手动准备遭遇旁）新增「AI 临时准备遭遇」按钮（GM-only）；
- **生成与开战分两步**：预览块展示 标题/描述/敌人卡片（HP · AC · 速度 · 攻击 +N / 伤害），按钮 [重新生成] [确认进入战斗] [取消]，绝不自动开战；
- 确认提交现有 intent：`{type: "combat.start", expected_version, mode: "sandbox", enemies: [...]}`，**不带 `encounter_preset_id`** —— 服务器自然进入 sandbox encounter 并再次完整执行 `validate_enemy_profiles()`，篡改前端 preview 过不了权威校验；
- 文案语义修正（§十七）：「脱离冒险，准备自由遭遇」→「临时准备自由遭遇」，提示「这场战斗不会写入冒险包的正式遭遇定义；战斗结束后仍可继续当前冒险剧情」；不清除 `adventure_binding` / content_digest / current step；zh/en 同步。

## 多人

无需特殊协议：玩家只看到敌情 pending / 等待 GM；preview 不广播，GM 确认的 combat.start 才成为权威状态，所有人走现有 combat state。

## 测试（新增 tests/test_dnd2024_temporary_encounter.py 10 项）

1. GM 可以生成（pending + 无匹配 preset）→ 返回 proposal；
2. 普通玩家 → `GM_ONLY`（路由映射 403）；
3. 正式剧情遭遇（greymoor 战斗步骤已绑定 `first_skirmish`）→ `STORY_ENCOUNTER_BOUND` 拒绝；
4. AI 生成非法怪物（AC=999 / hp=0 / 非骰子伤害 / 超数量）→ `TEMPORARY_ENCOUNTER_INVALID`，不进 combat；
5. 生成成功但 combat.status / state version / event ledger / round 全部不变；
6. GM 确认 → 现有 `combat.start(mode=sandbox)` 正常进入战斗；
7. 篡改 preview（HP 999999999）→ 权威校验拒绝，战斗未开始；
8. LLM timeout / 无有效工具调用 / 未配置 → `LLM_REQUEST_FAILED` / `TEMPORARY_ENCOUNTER_INVALID` / `LLM_NOT_CONFIGURED`，对局状态不变；
9. Adventure 绑定保持：临时战斗开始后 `instance.adventure_binding` 原样；
10. 归一化单元：同名 id 去重、默认值填充、底层校验同源。

同步既有 `Dnd2024CombatPanel.test.ts`（新 mock 导出、AI 入口只调只读 API 的断言、新文案）。

## 验收

`pytest`：**2179 passed, 1 skipped**；`ruff` / `mypy` 通过；frontend `typecheck` / `lint` / `vitest`（82 文件 398 测试）全绿。Adventure Bundle 零修改，未动 combat reducer 核心与结算算法。