### PR TITLE
fix(startup): detect peewee runtime dependency

### DIFF
--- a/scripts/ensure_runtime_deps.py
+++ b/scripts/ensure_runtime_deps.py
@@ -18,6 +18,7 @@ REQUIREMENTS = ROOT / "requirements.txt"
 RUNTIME_IMPORTS = {
     "aiohttp": "aiohttp",
     "Pillow": "PIL",
+    "peewee": "peewee",
 }
 
 

--- a/tests/test_ensure_runtime_deps.py
+++ b/tests/test_ensure_runtime_deps.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from scripts import ensure_runtime_deps
+
+
+def test_runtime_dependency_check_includes_peewee(monkeypatch) -> None:
+    def fake_find_spec(name: str):
+        return None if name == "peewee" else object()
+
+    monkeypatch.setattr(ensure_runtime_deps.importlib.util, "find_spec", fake_find_spec)
+
+    assert ensure_runtime_deps.missing_imports() == ["peewee"]


### PR DESCRIPTION
修复 Windows 启动脚本在运行环境缺少 peewee 时的依赖检测与提示，避免启动阶段直接导入失败。

验证：Python 源码编译通过；相关迁移/权限回归测试通过。